### PR TITLE
Broadcast order book updates over web-sockets

### DIFF
--- a/backend/src/main/kotlin/co/chainring/core/model/db/Trade.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/Trade.kt
@@ -9,7 +9,6 @@ import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 import org.jetbrains.exposed.dao.EntityClass
 import org.jetbrains.exposed.dao.id.EntityID
-import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -52,9 +51,7 @@ object TradeTable : GUIDTable<TradeId>("trade", ::TradeId) {
 }
 
 class TradeEntity(guid: EntityID<TradeId>) : GUIDEntity<TradeId>(guid) {
-
     companion object : EntityClass<TradeId, TradeEntity>(TradeTable) {
-
         fun create(
             timestamp: Instant,
             market: MarketEntity,
@@ -68,14 +65,6 @@ class TradeEntity(guid: EntityID<TradeId>) : GUIDEntity<TradeId>(guid) {
             this.amount = amount
             this.price = price
             this.settlementStatus = SettlementStatus.Pending
-        }
-
-        fun listTrades(beforeTimestamp: Instant, limit: Int): List<TradeEntity> {
-            return TradeEntity
-                .find { OrderExecutionTable.createdAt.lessEq(beforeTimestamp) }
-                .orderBy(OrderExecutionTable.createdAt to SortOrder.DESC)
-                .limit(limit)
-                .toList()
         }
     }
 

--- a/backend/src/main/kotlin/co/chainring/core/model/db/migrations/V22_BroadcasterJob.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/migrations/V22_BroadcasterJob.kt
@@ -2,8 +2,8 @@ package co.chainring.core.model.db.migrations
 
 import co.chainring.core.db.Migration
 import co.chainring.core.model.db.BroadcasterJobId
+import co.chainring.core.model.db.BroadcasterNotification
 import co.chainring.core.model.db.GUIDTable
-import co.chainring.core.model.db.PrincipalNotifications
 import org.http4k.format.KotlinxSerialization
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.json.jsonb
@@ -19,7 +19,7 @@ class V22_BroadcasterJob : Migration() {
     ) {
         val createdAt = timestamp("created_at")
         val createdBy = varchar("created_by", 10485760)
-        val notificationData = jsonb<List<PrincipalNotifications>>("notification_data", KotlinxSerialization.json)
+        val notificationData = jsonb<List<BroadcasterNotification>>("notification_data", KotlinxSerialization.json)
     }
 
     override fun run() {

--- a/backend/src/main/kotlin/co/chainring/core/utils/Units.kt
+++ b/backend/src/main/kotlin/co/chainring/core/utils/Units.kt
@@ -14,3 +14,7 @@ fun BigDecimal.toFundamentalUnits(decimals: UByte): BigInteger {
 fun BigInteger.fromFundamentalUnits(decimals: Int): BigDecimal {
     return BigDecimal(this).movePointLeft(decimals)
 }
+
+fun BigInteger.fromFundamentalUnits(decimals: UByte): BigDecimal {
+    return BigDecimal(this).movePointLeft(decimals.toInt())
+}

--- a/backend/src/test/kotlin/co/chainring/core/model/db/OrderBookTest.kt
+++ b/backend/src/test/kotlin/co/chainring/core/model/db/OrderBookTest.kt
@@ -1,0 +1,1043 @@
+package co.chainring.core.model.db
+
+import co.chainring.apps.api.model.websocket.LastTrade
+import co.chainring.apps.api.model.websocket.LastTradeDirection
+import co.chainring.apps.api.model.websocket.OrderBook
+import co.chainring.apps.api.model.websocket.OrderBookEntry
+import co.chainring.core.model.SequencerOrderId
+import co.chainring.core.model.Symbol
+import co.chainring.core.utils.toFundamentalUnits
+import co.chainring.testutils.TestWithDb
+import kotlinx.datetime.Clock
+import org.jetbrains.exposed.sql.transactions.TransactionManager
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class OrderBookTest : TestWithDb() {
+    private val btcEthMarket = MarketId("BTC/ETH")
+    private val ethUsdcMarket = MarketId("ETH/USDC")
+    private lateinit var wallets: List<WalletEntity>
+
+    @BeforeEach
+    fun setup() {
+        transaction {
+            val chain = createChain(ChainId(123UL), "test-chain")
+            val btc = createNativeSymbol("BTC", chain.id.value, decimals = 18U)
+            val eth = createSymbol("ETH", chain.id.value, decimals = 18U)
+            val usdc = createSymbol("USDC", chain.id.value, decimals = 18U)
+            createMarket(btc, eth, tickSize = "0.05".toBigDecimal()).id.value
+            createMarket(eth, usdc, tickSize = "0.01".toBigDecimal()).id.value
+            wallets = (1..5).map { createWallet() }
+        }
+    }
+
+    @Test
+    fun empty() {
+        verifyOrderBook(
+            btcEthMarket,
+            ordersInDb = emptyList(),
+            tradesInDb = emptyList(),
+            expected = OrderBook(
+                marketId = btcEthMarket,
+                buy = emptyList(),
+                sell = emptyList(),
+                last = LastTrade(
+                    price = "0.00",
+                    direction = LastTradeDirection.Up,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `buy orders only`() {
+        verifyOrderBook(
+            btcEthMarket,
+            ordersInDb = listOf(
+                Order(
+                    OrderId("order_1"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.55".toBigDecimal(),
+                    amount = "1.2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_2"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.55".toBigDecimal(),
+                    amount = "1.3".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_3"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.50".toBigDecimal(),
+                    amount = "1.5".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_4"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.40".toBigDecimal(),
+                    amount = "5".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_5"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Partial,
+                    price = "17.40".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+            ),
+            tradesInDb = emptyList(),
+            expected = OrderBook(
+                marketId = btcEthMarket,
+                buy = listOf(
+                    OrderBookEntry(price = "17.40", size = "7".toBigDecimal()),
+                    OrderBookEntry(price = "17.50", size = "1.5".toBigDecimal()),
+                    OrderBookEntry(price = "17.55", size = "2.5".toBigDecimal()),
+                ),
+                sell = emptyList(),
+                last = LastTrade(
+                    price = "0.00",
+                    direction = LastTradeDirection.Up,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `sell orders only`() {
+        verifyOrderBook(
+            btcEthMarket,
+            ordersInDb = listOf(
+                Order(
+                    OrderId("order_1"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.35".toBigDecimal(),
+                    amount = "1.2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_2"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Limit,
+                    OrderStatus.Partial,
+                    price = "17.35".toBigDecimal(),
+                    amount = "1.3".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_3"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.30".toBigDecimal(),
+                    amount = "5".toBigDecimal(),
+                ),
+            ),
+            tradesInDb = emptyList(),
+            expected = OrderBook(
+                marketId = btcEthMarket,
+                buy = emptyList(),
+                sell = listOf(
+                    OrderBookEntry(price = "17.35", size = "2.5".toBigDecimal()),
+                    OrderBookEntry(price = "17.30", size = "5".toBigDecimal()),
+                ),
+                last = LastTrade(
+                    price = "0.00",
+                    direction = LastTradeDirection.Up,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `buy and sell orders`() {
+        verifyOrderBook(
+            btcEthMarket,
+            ordersInDb = listOf(
+                Order(
+                    OrderId("order_1"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.55".toBigDecimal(),
+                    amount = "1.2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_2"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.55".toBigDecimal(),
+                    amount = "1.3".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_3"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.50".toBigDecimal(),
+                    amount = "1.5".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_4"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.40".toBigDecimal(),
+                    amount = "5".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_5"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Partial,
+                    price = "17.40".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_6"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.35".toBigDecimal(),
+                    amount = "1.2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_7"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Limit,
+                    OrderStatus.Partial,
+                    price = "17.35".toBigDecimal(),
+                    amount = "1.3".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_8"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.30".toBigDecimal(),
+                    amount = "5".toBigDecimal(),
+                ),
+            ),
+            tradesInDb = emptyList(),
+            expected = OrderBook(
+                marketId = btcEthMarket,
+                buy = listOf(
+                    OrderBookEntry(price = "17.40", size = "7".toBigDecimal()),
+                    OrderBookEntry(price = "17.50", size = "1.5".toBigDecimal()),
+                    OrderBookEntry(price = "17.55", size = "2.5".toBigDecimal()),
+                ),
+                sell = listOf(
+                    OrderBookEntry(price = "17.35", size = "2.5".toBigDecimal()),
+                    OrderBookEntry(price = "17.30", size = "5".toBigDecimal()),
+                ),
+                last = LastTrade(
+                    price = "0.00",
+                    direction = LastTradeDirection.Up,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `only open and partially filled limit orders are considered`() {
+        verifyOrderBook(
+            btcEthMarket,
+            ordersInDb = listOf(
+                Order(
+                    OrderId("order_1"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.55".toBigDecimal(),
+                    amount = "1.2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_2"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.55".toBigDecimal(),
+                    amount = "1.3".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_3"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.50".toBigDecimal(),
+                    amount = "1.5".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_4"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.40".toBigDecimal(),
+                    amount = "5".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_5"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Partial,
+                    price = "17.40".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_6"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Market,
+                    OrderStatus.Open,
+                    price = "17.35".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_7"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Filled,
+                    price = "17.35".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_8"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Cancelled,
+                    price = "17.35".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_9"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Expired,
+                    price = "17.35".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_10"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.CrossesMarket,
+                    price = "17.35".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_11"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Rejected,
+                    price = "17.35".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_12"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.35".toBigDecimal(),
+                    amount = "1.2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_13"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Limit,
+                    OrderStatus.Partial,
+                    price = "17.35".toBigDecimal(),
+                    amount = "1.3".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_14"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.30".toBigDecimal(),
+                    amount = "5".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_15"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Market,
+                    OrderStatus.Open,
+                    price = "17.40".toBigDecimal(),
+                    amount = "5".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_16"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Market,
+                    OrderStatus.Filled,
+                    price = "17.35".toBigDecimal(),
+                    amount = "5".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_17"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Market,
+                    OrderStatus.Cancelled,
+                    price = "17.35".toBigDecimal(),
+                    amount = "5".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_18"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Market,
+                    OrderStatus.Expired,
+                    price = "17.35".toBigDecimal(),
+                    amount = "5".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_19"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Market,
+                    OrderStatus.Rejected,
+                    price = "17.35".toBigDecimal(),
+                    amount = "5".toBigDecimal(),
+                ),
+            ),
+            tradesInDb = emptyList(),
+            expected = OrderBook(
+                marketId = btcEthMarket,
+                buy = listOf(
+                    OrderBookEntry(price = "17.40", size = "7".toBigDecimal()),
+                    OrderBookEntry(price = "17.50", size = "1.5".toBigDecimal()),
+                    OrderBookEntry(price = "17.55", size = "2.5".toBigDecimal()),
+                ),
+                sell = listOf(
+                    OrderBookEntry(price = "17.35", size = "2.5".toBigDecimal()),
+                    OrderBookEntry(price = "17.30", size = "5".toBigDecimal()),
+                ),
+                last = LastTrade(
+                    price = "0.00",
+                    direction = LastTradeDirection.Up,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `last trade when only one trade present`() {
+        verifyOrderBook(
+            btcEthMarket,
+            ordersInDb = listOf(
+                Order(
+                    OrderId("order_1"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.50".toBigDecimal(),
+                    amount = "1".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_2"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Limit,
+                    OrderStatus.Partial,
+                    price = "17.55".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_3"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Filled,
+                    price = "17.40".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_4"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Market,
+                    OrderStatus.Filled,
+                    price = null,
+                    amount = "2".toBigDecimal(),
+                ),
+            ),
+            tradesInDb = listOf(
+                Trade(
+                    btcEthMarket,
+                    timeSinceHappened = 1.seconds,
+                    buyOrder = OrderId("order_3"),
+                    sellOrder = OrderId("order_4"),
+                    amount = "2".toBigDecimal(),
+                    price = "17.40".toBigDecimal(),
+                ),
+            ),
+            expected = OrderBook(
+                marketId = btcEthMarket,
+                buy = listOf(
+                    OrderBookEntry(price = "17.50", size = "1".toBigDecimal()),
+                ),
+                sell = listOf(
+                    OrderBookEntry(price = "17.55", size = "2".toBigDecimal()),
+                ),
+                last = LastTrade(
+                    price = "17.40",
+                    direction = LastTradeDirection.Up,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `last trade up`() {
+        verifyOrderBook(
+            btcEthMarket,
+            ordersInDb = listOf(
+                Order(
+                    OrderId("order_1"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.50".toBigDecimal(),
+                    amount = "1".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_2"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Limit,
+                    OrderStatus.Partial,
+                    price = "17.55".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_3"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Filled,
+                    price = "17.45".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_4"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Market,
+                    OrderStatus.Filled,
+                    price = null,
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_5"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Filled,
+                    price = "17.40".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_6"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Market,
+                    OrderStatus.Filled,
+                    price = null,
+                    amount = "2".toBigDecimal(),
+                ),
+            ),
+            tradesInDb = listOf(
+                Trade(
+                    btcEthMarket,
+                    timeSinceHappened = 2.seconds,
+                    buyOrder = OrderId("order_3"),
+                    sellOrder = OrderId("order_4"),
+                    amount = "2".toBigDecimal(),
+                    price = "17.45".toBigDecimal(),
+                ),
+                Trade(
+                    btcEthMarket,
+                    timeSinceHappened = 1.seconds,
+                    buyOrder = OrderId("order_5"),
+                    sellOrder = OrderId("order_6"),
+                    amount = "2".toBigDecimal(),
+                    price = "17.40".toBigDecimal(),
+                ),
+            ),
+            expected = OrderBook(
+                marketId = btcEthMarket,
+                buy = listOf(
+                    OrderBookEntry(price = "17.50", size = "1".toBigDecimal()),
+                ),
+                sell = listOf(
+                    OrderBookEntry(price = "17.55", size = "2".toBigDecimal()),
+                ),
+                last = LastTrade(
+                    price = "17.40",
+                    direction = LastTradeDirection.Down,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `last trade down`() {
+        verifyOrderBook(
+            btcEthMarket,
+            ordersInDb = listOf(
+                Order(
+                    OrderId("order_1"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.50".toBigDecimal(),
+                    amount = "1".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_2"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Limit,
+                    OrderStatus.Partial,
+                    price = "17.55".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_3"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Filled,
+                    price = "17.45".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_4"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Market,
+                    OrderStatus.Filled,
+                    price = null,
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_5"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Filled,
+                    price = "17.40".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_6"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Market,
+                    OrderStatus.Filled,
+                    price = null,
+                    amount = "2".toBigDecimal(),
+                ),
+            ),
+            tradesInDb = listOf(
+                Trade(
+                    btcEthMarket,
+                    timeSinceHappened = 2.seconds,
+                    buyOrder = OrderId("order_5"),
+                    sellOrder = OrderId("order_6"),
+                    amount = "2".toBigDecimal(),
+                    price = "17.40".toBigDecimal(),
+                ),
+                Trade(
+                    btcEthMarket,
+                    timeSinceHappened = 1.seconds,
+                    buyOrder = OrderId("order_3"),
+                    sellOrder = OrderId("order_4"),
+                    amount = "2".toBigDecimal(),
+                    price = "17.45".toBigDecimal(),
+                ),
+            ),
+            expected = OrderBook(
+                marketId = btcEthMarket,
+                buy = listOf(
+                    OrderBookEntry(price = "17.50", size = "1".toBigDecimal()),
+                ),
+                sell = listOf(
+                    OrderBookEntry(price = "17.55", size = "2".toBigDecimal()),
+                ),
+                last = LastTrade(
+                    price = "17.45",
+                    direction = LastTradeDirection.Up,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `last trade's price is a weighted average for all executions in latest match`() {
+        verifyOrderBook(
+            btcEthMarket,
+            ordersInDb = listOf(
+                Order(
+                    OrderId("order_1"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.50".toBigDecimal(),
+                    amount = "1".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_2"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Limit,
+                    OrderStatus.Partial,
+                    price = "17.55".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_3"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Filled,
+                    price = "17.45".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_4"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Filled,
+                    price = "17.40".toBigDecimal(),
+                    amount = "3".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_5"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Market,
+                    OrderStatus.Filled,
+                    price = null,
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_6"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Filled,
+                    price = "17.35".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_7"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Market,
+                    OrderStatus.Filled,
+                    price = null,
+                    amount = "2".toBigDecimal(),
+                ),
+            ),
+            tradesInDb = listOf(
+                Trade(
+                    btcEthMarket,
+                    timeSinceHappened = 1.seconds,
+                    buyOrder = OrderId("order_3"),
+                    sellOrder = OrderId("order_5"),
+                    amount = "2".toBigDecimal(),
+                    price = "17.45".toBigDecimal(),
+                ),
+                Trade(
+                    btcEthMarket,
+                    timeSinceHappened = 1.seconds,
+                    buyOrder = OrderId("order_4"),
+                    sellOrder = OrderId("order_5"),
+                    amount = "3".toBigDecimal(),
+                    price = "17.40".toBigDecimal(),
+                ),
+                Trade(
+                    btcEthMarket,
+                    timeSinceHappened = 2.seconds,
+                    buyOrder = OrderId("order_6"),
+                    sellOrder = OrderId("order_7"),
+                    amount = "2".toBigDecimal(),
+                    price = "17.35".toBigDecimal(),
+                ),
+            ),
+            expected = OrderBook(
+                marketId = btcEthMarket,
+                buy = listOf(
+                    OrderBookEntry(price = "17.50", size = "1".toBigDecimal()),
+                ),
+                sell = listOf(
+                    OrderBookEntry(price = "17.55", size = "2".toBigDecimal()),
+                ),
+                last = LastTrade(
+                    price = "17.42",
+                    direction = LastTradeDirection.Up,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `orders and trades from other markets are not considered`() {
+        verifyOrderBook(
+            btcEthMarket,
+            ordersInDb = listOf(
+                Order(
+                    OrderId("order_1"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "17.50".toBigDecimal(),
+                    amount = "1".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_2"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Limit,
+                    OrderStatus.Partial,
+                    price = "17.55".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_3"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Filled,
+                    price = "17.45".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_4"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Market,
+                    OrderStatus.Filled,
+                    price = null,
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_5"),
+                    btcEthMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Filled,
+                    price = "17.40".toBigDecimal(),
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_6"),
+                    btcEthMarket,
+                    OrderSide.Sell,
+                    OrderType.Market,
+                    OrderStatus.Filled,
+                    price = null,
+                    amount = "2".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_7"),
+                    ethUsdcMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "3000".toBigDecimal(),
+                    amount = "1".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_8"),
+                    ethUsdcMarket,
+                    OrderSide.Sell,
+                    OrderType.Limit,
+                    OrderStatus.Open,
+                    price = "3001".toBigDecimal(),
+                    amount = "1".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_9"),
+                    ethUsdcMarket,
+                    OrderSide.Buy,
+                    OrderType.Limit,
+                    OrderStatus.Filled,
+                    price = "3000".toBigDecimal(),
+                    amount = "1".toBigDecimal(),
+                ),
+                Order(
+                    OrderId("order_10"),
+                    ethUsdcMarket,
+                    OrderSide.Sell,
+                    OrderType.Market,
+                    OrderStatus.Filled,
+                    price = null,
+                    amount = "1".toBigDecimal(),
+                ),
+            ),
+            tradesInDb = listOf(
+                Trade(
+                    btcEthMarket,
+                    timeSinceHappened = 3.seconds,
+                    buyOrder = OrderId("order_5"),
+                    sellOrder = OrderId("order_6"),
+                    amount = "2".toBigDecimal(),
+                    price = "17.40".toBigDecimal(),
+                ),
+                Trade(
+                    btcEthMarket,
+                    timeSinceHappened = 2.seconds,
+                    buyOrder = OrderId("order_3"),
+                    sellOrder = OrderId("order_4"),
+                    amount = "2".toBigDecimal(),
+                    price = "17.45".toBigDecimal(),
+                ),
+                Trade(
+                    ethUsdcMarket,
+                    timeSinceHappened = 1.seconds,
+                    buyOrder = OrderId("order_9"),
+                    sellOrder = OrderId("order_10"),
+                    amount = "1".toBigDecimal(),
+                    price = "3000".toBigDecimal(),
+                ),
+            ),
+            expected = OrderBook(
+                marketId = btcEthMarket,
+                buy = listOf(
+                    OrderBookEntry(price = "17.50", size = "1".toBigDecimal()),
+                ),
+                sell = listOf(
+                    OrderBookEntry(price = "17.55", size = "2".toBigDecimal()),
+                ),
+                last = LastTrade(
+                    price = "17.45",
+                    direction = LastTradeDirection.Up,
+                ),
+            ),
+        )
+    }
+
+    data class Order(
+        val id: OrderId,
+        val market: MarketId,
+        val side: OrderSide,
+        val type: OrderType,
+        val status: OrderStatus,
+        val price: BigDecimal?,
+        val amount: BigDecimal,
+    )
+
+    data class Trade(
+        val market: MarketId,
+        val timeSinceHappened: Duration,
+        val buyOrder: OrderId,
+        val sellOrder: OrderId,
+        val amount: BigDecimal,
+        val price: BigDecimal,
+    )
+
+    private fun verifyOrderBook(marketId: MarketId, ordersInDb: List<Order>, tradesInDb: List<Trade>, expected: OrderBook) {
+        transaction {
+            val market = MarketEntity[marketId]
+
+            ordersInDb.forEachIndexed { i, order ->
+                createOrder(
+                    MarketEntity[order.market], wallets.random(),
+                    order.side, order.type, order.amount, order.price, order.status,
+                    SequencerOrderId(i.toLong()),
+                    order.id,
+                )
+            }
+
+            TransactionManager.current().commit()
+
+            val now = Clock.System.now()
+            tradesInDb.forEach { trade ->
+                val tradeMarket = MarketEntity[trade.market]
+
+                val tradeEntity = TradeEntity.create(
+                    now.minus(trade.timeSinceHappened),
+                    tradeMarket,
+                    amount = trade.amount.toFundamentalUnits(tradeMarket.baseSymbol.decimals),
+                    price = trade.price,
+                )
+
+                listOf(trade.buyOrder, trade.sellOrder).forEach { orderId ->
+                    val order = OrderEntity[orderId]
+                    assertTrue(
+                        order.status == OrderStatus.Filled || order.status == OrderStatus.Partial,
+                        "Order must be filled or partially filled",
+                    )
+                    OrderExecutionEntity.create(
+                        timestamp = tradeEntity.timestamp,
+                        orderEntity = order,
+                        tradeEntity = tradeEntity,
+                        role = if (order.type == OrderType.Market) ExecutionRole.Taker else ExecutionRole.Maker,
+                        feeAmount = BigInteger.ZERO,
+                        feeSymbol = Symbol(order.market.quoteSymbol.name),
+                    )
+                }
+            }
+
+            TransactionManager.current().commit()
+
+            assertEquals(expected, OrderEntity.getOrderBook(market))
+        }
+    }
+}

--- a/backend/src/test/kotlin/co/chainring/core/model/db/OrderBookTest.kt
+++ b/backend/src/test/kotlin/co/chainring/core/model/db/OrderBookTest.kt
@@ -49,7 +49,7 @@ class OrderBookTest : TestWithDb() {
                 buy = emptyList(),
                 sell = emptyList(),
                 last = LastTrade(
-                    price = "0.00",
+                    price = "0.000",
                     direction = LastTradeDirection.Up,
                 ),
             ),
@@ -111,13 +111,13 @@ class OrderBookTest : TestWithDb() {
             expected = OrderBook(
                 marketId = btcEthMarket,
                 buy = listOf(
-                    OrderBookEntry(price = "17.40", size = "7".toBigDecimal()),
-                    OrderBookEntry(price = "17.50", size = "1.5".toBigDecimal()),
-                    OrderBookEntry(price = "17.55", size = "2.5".toBigDecimal()),
+                    OrderBookEntry(price = "17.400", size = "7".toBigDecimal()),
+                    OrderBookEntry(price = "17.500", size = "1.5".toBigDecimal()),
+                    OrderBookEntry(price = "17.550", size = "2.5".toBigDecimal()),
                 ),
                 sell = emptyList(),
                 last = LastTrade(
-                    price = "0.00",
+                    price = "0.000",
                     direction = LastTradeDirection.Up,
                 ),
             ),
@@ -162,11 +162,11 @@ class OrderBookTest : TestWithDb() {
                 marketId = btcEthMarket,
                 buy = emptyList(),
                 sell = listOf(
-                    OrderBookEntry(price = "17.35", size = "2.5".toBigDecimal()),
-                    OrderBookEntry(price = "17.30", size = "5".toBigDecimal()),
+                    OrderBookEntry(price = "17.350", size = "2.5".toBigDecimal()),
+                    OrderBookEntry(price = "17.300", size = "5".toBigDecimal()),
                 ),
                 last = LastTrade(
-                    price = "0.00",
+                    price = "0.000",
                     direction = LastTradeDirection.Up,
                 ),
             ),
@@ -255,16 +255,16 @@ class OrderBookTest : TestWithDb() {
             expected = OrderBook(
                 marketId = btcEthMarket,
                 buy = listOf(
-                    OrderBookEntry(price = "17.40", size = "7".toBigDecimal()),
-                    OrderBookEntry(price = "17.50", size = "1.5".toBigDecimal()),
-                    OrderBookEntry(price = "17.55", size = "2.5".toBigDecimal()),
+                    OrderBookEntry(price = "17.400", size = "7".toBigDecimal()),
+                    OrderBookEntry(price = "17.500", size = "1.5".toBigDecimal()),
+                    OrderBookEntry(price = "17.550", size = "2.5".toBigDecimal()),
                 ),
                 sell = listOf(
-                    OrderBookEntry(price = "17.35", size = "2.5".toBigDecimal()),
-                    OrderBookEntry(price = "17.30", size = "5".toBigDecimal()),
+                    OrderBookEntry(price = "17.350", size = "2.5".toBigDecimal()),
+                    OrderBookEntry(price = "17.300", size = "5".toBigDecimal()),
                 ),
                 last = LastTrade(
-                    price = "0.00",
+                    price = "0.000",
                     direction = LastTradeDirection.Up,
                 ),
             ),
@@ -452,16 +452,16 @@ class OrderBookTest : TestWithDb() {
             expected = OrderBook(
                 marketId = btcEthMarket,
                 buy = listOf(
-                    OrderBookEntry(price = "17.40", size = "7".toBigDecimal()),
-                    OrderBookEntry(price = "17.50", size = "1.5".toBigDecimal()),
-                    OrderBookEntry(price = "17.55", size = "2.5".toBigDecimal()),
+                    OrderBookEntry(price = "17.400", size = "7".toBigDecimal()),
+                    OrderBookEntry(price = "17.500", size = "1.5".toBigDecimal()),
+                    OrderBookEntry(price = "17.550", size = "2.5".toBigDecimal()),
                 ),
                 sell = listOf(
-                    OrderBookEntry(price = "17.35", size = "2.5".toBigDecimal()),
-                    OrderBookEntry(price = "17.30", size = "5".toBigDecimal()),
+                    OrderBookEntry(price = "17.350", size = "2.5".toBigDecimal()),
+                    OrderBookEntry(price = "17.300", size = "5".toBigDecimal()),
                 ),
                 last = LastTrade(
-                    price = "0.00",
+                    price = "0.000",
                     direction = LastTradeDirection.Up,
                 ),
             ),
@@ -523,13 +523,13 @@ class OrderBookTest : TestWithDb() {
             expected = OrderBook(
                 marketId = btcEthMarket,
                 buy = listOf(
-                    OrderBookEntry(price = "17.50", size = "1".toBigDecimal()),
+                    OrderBookEntry(price = "17.500", size = "1".toBigDecimal()),
                 ),
                 sell = listOf(
-                    OrderBookEntry(price = "17.55", size = "2".toBigDecimal()),
+                    OrderBookEntry(price = "17.550", size = "2".toBigDecimal()),
                 ),
                 last = LastTrade(
-                    price = "17.40",
+                    price = "17.400",
                     direction = LastTradeDirection.Up,
                 ),
             ),
@@ -617,13 +617,13 @@ class OrderBookTest : TestWithDb() {
             expected = OrderBook(
                 marketId = btcEthMarket,
                 buy = listOf(
-                    OrderBookEntry(price = "17.50", size = "1".toBigDecimal()),
+                    OrderBookEntry(price = "17.500", size = "1".toBigDecimal()),
                 ),
                 sell = listOf(
-                    OrderBookEntry(price = "17.55", size = "2".toBigDecimal()),
+                    OrderBookEntry(price = "17.550", size = "2".toBigDecimal()),
                 ),
                 last = LastTrade(
-                    price = "17.40",
+                    price = "17.400",
                     direction = LastTradeDirection.Down,
                 ),
             ),
@@ -711,13 +711,13 @@ class OrderBookTest : TestWithDb() {
             expected = OrderBook(
                 marketId = btcEthMarket,
                 buy = listOf(
-                    OrderBookEntry(price = "17.50", size = "1".toBigDecimal()),
+                    OrderBookEntry(price = "17.500", size = "1".toBigDecimal()),
                 ),
                 sell = listOf(
-                    OrderBookEntry(price = "17.55", size = "2".toBigDecimal()),
+                    OrderBookEntry(price = "17.550", size = "2".toBigDecimal()),
                 ),
                 last = LastTrade(
-                    price = "17.45",
+                    price = "17.450",
                     direction = LastTradeDirection.Up,
                 ),
             ),
@@ -822,13 +822,13 @@ class OrderBookTest : TestWithDb() {
             expected = OrderBook(
                 marketId = btcEthMarket,
                 buy = listOf(
-                    OrderBookEntry(price = "17.50", size = "1".toBigDecimal()),
+                    OrderBookEntry(price = "17.500", size = "1".toBigDecimal()),
                 ),
                 sell = listOf(
-                    OrderBookEntry(price = "17.55", size = "2".toBigDecimal()),
+                    OrderBookEntry(price = "17.550", size = "2".toBigDecimal()),
                 ),
                 last = LastTrade(
-                    price = "17.42",
+                    price = "17.420",
                     direction = LastTradeDirection.Up,
                 ),
             ),
@@ -960,13 +960,13 @@ class OrderBookTest : TestWithDb() {
             expected = OrderBook(
                 marketId = btcEthMarket,
                 buy = listOf(
-                    OrderBookEntry(price = "17.50", size = "1".toBigDecimal()),
+                    OrderBookEntry(price = "17.500", size = "1".toBigDecimal()),
                 ),
                 sell = listOf(
-                    OrderBookEntry(price = "17.55", size = "2".toBigDecimal()),
+                    OrderBookEntry(price = "17.550", size = "2".toBigDecimal()),
                 ),
                 last = LastTrade(
-                    price = "17.45",
+                    price = "17.450",
                     direction = LastTradeDirection.Up,
                 ),
             ),

--- a/docker-compose-ci.yaml
+++ b/docker-compose-ci.yaml
@@ -19,6 +19,16 @@ services:
       PGUSER: chainring # is used by psql inside container
     ports:
       - "5432:5432"
+  ut_db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: chainring
+      POSTGRES_PASSWORD: chainring
+      POSTGRES_DB: chainring
+      PGUSER: chainring # is used by psql inside container
+    ports:
+      - "5433:5432"
 
 volumes:
   anvil-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,16 @@ services:
       PGUSER: chainring # is used by psql inside container
     ports:
       - "5432:5432"
+  ut_db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: chainring
+      POSTGRES_PASSWORD: chainring
+      POSTGRES_DB: chainring
+      PGUSER: chainring # is used by psql inside container
+    ports:
+      - "5433:5432"
 
 volumes:
   anvil-data:

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/OrderRoutesApiTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/OrderRoutesApiTest.kt
@@ -81,11 +81,8 @@ class OrderRoutesApiTest {
         wsClient.subscribeToOrders()
         val initialOrdersOverWs = wsClient.assertOrdersMessageReceived().orders
 
-        wsClient.subscribe(SubscriptionTopic.Balances)
-        wsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Balances, message.topic)
-            assertIs<Balances>(message.data)
-        }
+        wsClient.subscribeToBalances()
+        wsClient.assertBalancesMessageReceived()
 
         Faucet.fund(wallet.address)
         wallet.mintERC20("DAI", wallet.formatAmount("14", "DAI"))
@@ -175,11 +172,8 @@ class OrderRoutesApiTest {
         wsClient.subscribeToOrders()
         wsClient.assertOrdersMessageReceived()
 
-        wsClient.subscribe(SubscriptionTopic.Balances)
-        wsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Balances, message.topic)
-            assertIs<Balances>(message.data)
-        }
+        wsClient.subscribeToBalances()
+        wsClient.assertBalancesMessageReceived()
 
         Faucet.fund(wallet.address)
         val amountToDeposit = wallet.formatAmount("20", "DAI")
@@ -314,11 +308,8 @@ class OrderRoutesApiTest {
         wsClient.subscribeToOrders()
         val initialOrdersOverWs = wsClient.assertOrdersMessageReceived().orders
 
-        wsClient.subscribe(SubscriptionTopic.Balances)
-        wsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Balances, message.topic)
-            assertIs<Balances>(message.data)
-        }
+        wsClient.subscribeToBalances()
+        wsClient.assertBalancesMessageReceived()
 
         Faucet.fund(wallet.address)
         val amountToDeposit = wallet.formatAmount("30", "DAI")
@@ -399,10 +390,10 @@ class OrderRoutesApiTest {
                 OrderBook(
                     marketId = btcEthMarketId,
                     buy = listOf(
-                        OrderBookEntry(price = "17.45", size = "0.00013345".toBigDecimal()),
+                        OrderBookEntry(price = "17.450", size = "0.00013345".toBigDecimal()),
                     ),
                     sell = emptyList(),
-                    last = LastTrade("0.00", LastTradeDirection.Up),
+                    last = LastTrade("0.000", LastTradeDirection.Up),
                 ),
             )
         }
@@ -425,10 +416,10 @@ class OrderRoutesApiTest {
                 OrderBook(
                     marketId = btcEthMarketId,
                     buy = listOf(
-                        OrderBookEntry(price = "17.50", size = "0.00012345".toBigDecimal()),
+                        OrderBookEntry(price = "17.500", size = "0.00012345".toBigDecimal()),
                     ),
                     sell = emptyList(),
-                    last = LastTrade("0.00", LastTradeDirection.Up),
+                    last = LastTrade("0.000", LastTradeDirection.Up),
                 ),
             )
         }
@@ -458,12 +449,12 @@ class OrderRoutesApiTest {
                 OrderBook(
                     marketId = btcEthMarketId,
                     buy = listOf(
-                        OrderBookEntry(price = "17.50", size = "0.00012345".toBigDecimal()),
+                        OrderBookEntry(price = "17.500", size = "0.00012345".toBigDecimal()),
                     ),
                     sell = listOf(
-                        OrderBookEntry(price = "17.60", size = "0.00154321".toBigDecimal()),
+                        OrderBookEntry(price = "17.600", size = "0.00154321".toBigDecimal()),
                     ),
-                    last = LastTrade("0.00", LastTradeDirection.Up),
+                    last = LastTrade("0.000", LastTradeDirection.Up),
                 ),
             )
         }
@@ -488,12 +479,12 @@ class OrderRoutesApiTest {
                 OrderBook(
                     marketId = btcEthMarketId,
                     buy = listOf(
-                        OrderBookEntry(price = "17.50", size = "0.00012345".toBigDecimal()),
+                        OrderBookEntry(price = "17.500", size = "0.00012345".toBigDecimal()),
                     ),
                     sell = listOf(
-                        OrderBookEntry(price = "17.55", size = "0.00054321".toBigDecimal()),
+                        OrderBookEntry(price = "17.550", size = "0.00054321".toBigDecimal()),
                     ),
-                    last = LastTrade("0.00", LastTradeDirection.Up),
+                    last = LastTrade("0.000", LastTradeDirection.Up),
                 ),
             )
         }
@@ -571,13 +562,13 @@ class OrderRoutesApiTest {
                 OrderBook(
                     marketId = btcEthMarketId,
                     buy = listOf(
-                        OrderBookEntry(price = "17.50", size = "0.00012345".toBigDecimal()),
+                        OrderBookEntry(price = "17.500", size = "0.00012345".toBigDecimal()),
                     ),
                     sell = listOf(
                         // TODO: amount should be reduced since MM order was partially filled
-                        OrderBookEntry(price = "17.55", size = "0.00054321".toBigDecimal()),
+                        OrderBookEntry(price = "17.550", size = "0.00054321".toBigDecimal()),
                     ),
-                    last = LastTrade("17.55", LastTradeDirection.Up),
+                    last = LastTrade("17.550", LastTradeDirection.Up),
                 ),
             )
         }
@@ -688,9 +679,9 @@ class OrderRoutesApiTest {
                     marketId = btcEthMarketId,
                     buy = emptyList(),
                     sell = listOf(
-                        OrderBookEntry(price = "17.55", size = "0.00054321".toBigDecimal()),
+                        OrderBookEntry(price = "17.550", size = "0.00054321".toBigDecimal()),
                     ),
-                    last = LastTrade("17.50", LastTradeDirection.Down),
+                    last = LastTrade("17.500", LastTradeDirection.Down),
                 ),
             )
         }
@@ -735,9 +726,9 @@ class OrderRoutesApiTest {
                     marketId = btcEthMarketId,
                     buy = emptyList(),
                     sell = listOf(
-                        OrderBookEntry(price = "17.55", size = "0.00054321".toBigDecimal()),
+                        OrderBookEntry(price = "17.550", size = "0.00054321".toBigDecimal()),
                     ),
-                    last = LastTrade("17.50", LastTradeDirection.Down),
+                    last = LastTrade("17.500", LastTradeDirection.Down),
                 ),
             )
         }
@@ -751,7 +742,7 @@ class OrderRoutesApiTest {
                     marketId = btcEthMarketId,
                     buy = emptyList(),
                     sell = emptyList(),
-                    last = LastTrade("17.50", LastTradeDirection.Down),
+                    last = LastTrade("17.500", LastTradeDirection.Down),
                 ),
             )
         }
@@ -808,7 +799,7 @@ class OrderRoutesApiTest {
                     marketId = btcEthMarketId,
                     buy = emptyList(),
                     sell = emptyList(),
-                    last = LastTrade("17.50", LastTradeDirection.Down),
+                    last = LastTrade("17.500", LastTradeDirection.Down),
                 ),
             )
         }.close()

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/OrderRoutesApiTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/OrderRoutesApiTest.kt
@@ -7,19 +7,10 @@ import co.chainring.apps.api.model.CreateOrderApiRequest
 import co.chainring.apps.api.model.Order
 import co.chainring.apps.api.model.ReasonCode
 import co.chainring.apps.api.model.UpdateOrderApiRequest
-import co.chainring.apps.api.model.websocket.Balances
 import co.chainring.apps.api.model.websocket.LastTrade
 import co.chainring.apps.api.model.websocket.LastTradeDirection
 import co.chainring.apps.api.model.websocket.OrderBook
 import co.chainring.apps.api.model.websocket.OrderBookEntry
-import co.chainring.apps.api.model.websocket.OrderCreated
-import co.chainring.apps.api.model.websocket.OrderUpdated
-import co.chainring.apps.api.model.websocket.Orders
-import co.chainring.apps.api.model.websocket.OutgoingWSMessage
-import co.chainring.apps.api.model.websocket.SubscriptionTopic
-import co.chainring.apps.api.model.websocket.TradeCreated
-import co.chainring.apps.api.model.websocket.TradeUpdated
-import co.chainring.apps.api.model.websocket.Trades
 import co.chainring.core.model.EvmSignature
 import co.chainring.core.model.Symbol
 import co.chainring.core.model.db.ExecutionRole
@@ -41,11 +32,20 @@ import co.chainring.integrationtests.testutils.BalanceHelper
 import co.chainring.integrationtests.testutils.ExpectedBalance
 import co.chainring.integrationtests.testutils.Faucet
 import co.chainring.integrationtests.testutils.Wallet
+import co.chainring.integrationtests.testutils.assertBalancesMessageReceived
 import co.chainring.integrationtests.testutils.assertError
+import co.chainring.integrationtests.testutils.assertOrderBookMessageReceived
+import co.chainring.integrationtests.testutils.assertOrderCreatedMessageReceived
+import co.chainring.integrationtests.testutils.assertOrderUpdatedMessageReceived
+import co.chainring.integrationtests.testutils.assertOrdersMessageReceived
+import co.chainring.integrationtests.testutils.assertTradeCreatedMessageReceived
+import co.chainring.integrationtests.testutils.assertTradeUpdatedMessageReceived
+import co.chainring.integrationtests.testutils.assertTradesMessageReceived
 import co.chainring.integrationtests.testutils.blocking
-import co.chainring.integrationtests.testutils.receivedDecoded
-import co.chainring.integrationtests.testutils.subscribe
-import co.chainring.integrationtests.testutils.waitForMessage
+import co.chainring.integrationtests.testutils.subscribeToBalances
+import co.chainring.integrationtests.testutils.subscribeToOrderBook
+import co.chainring.integrationtests.testutils.subscribeToOrders
+import co.chainring.integrationtests.testutils.subscribeToTrades
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.withAlias
@@ -78,14 +78,8 @@ class OrderRoutesApiTest {
         val wallet = Wallet(apiClient)
 
         var wsClient = WebsocketClient.blocking(apiClient.authToken)
-        wsClient.subscribe(SubscriptionTopic.Orders)
-        val initialOrdersOverWs = wsClient.waitForMessage().let { message ->
-            assertEquals(SubscriptionTopic.Orders, message.topic)
-            message.data.let { data ->
-                assertIs<Orders>(data)
-                data.orders
-            }
-        }
+        wsClient.subscribeToOrders()
+        val initialOrdersOverWs = wsClient.assertOrdersMessageReceived().orders
 
         wsClient.subscribe(SubscriptionTopic.Balances)
         wsClient.waitForMessage().also { message ->
@@ -99,14 +93,10 @@ class OrderRoutesApiTest {
         BalanceHelper.waitForAndVerifyBalanceChange(apiClient, listOf(ExpectedBalance("DAI", amountToDeposit, amountToDeposit))) {
             deposit(wallet, "DAI", amountToDeposit)
         }
-        wsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Balances, message.topic)
-            message.data.let { data ->
-                assertIs<Balances>(data)
-                assertEquals(1, data.balances.size)
-                assertEquals(Symbol("DAI"), data.balances.first().symbol)
-                assertEquals(BigInteger("14000000000000000000"), data.balances.first().available)
-            }
+        wsClient.assertBalancesMessageReceived { msg ->
+            assertEquals(1, msg.balances.size)
+            assertEquals(Symbol("DAI"), msg.balances.first().symbol)
+            assertEquals(BigInteger("14000000000000000000"), msg.balances.first().available)
         }
 
         val limitOrderApiRequest = CreateOrderApiRequest.Limit(
@@ -134,28 +124,18 @@ class OrderRoutesApiTest {
         assertEquals(limitOrder.id, apiClient.createOrder(limitOrderApiRequest).id)
 
         // client is notified over websocket
-        wsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Orders, message.topic)
-            message.data.let { data ->
-                assertIs<OrderCreated>(data)
-                assertIs<Order.Limit>(data.order)
-                validateLimitOrders(limitOrder, data.order as Order.Limit, false)
-            }
+        wsClient.assertOrderCreatedMessageReceived { msg ->
+            assertIs<Order.Limit>(msg.order)
+            validateLimitOrders(limitOrder, msg.order as Order.Limit, false)
         }
         wsClient.close()
 
         // check that order is included in the orders list sent via websocket
         wsClient = WebsocketClient.blocking(apiClient.authToken)
-        wsClient.subscribe(SubscriptionTopic.Orders)
+        wsClient.subscribeToOrders()
         assertEquals(
             listOf(limitOrder) + initialOrdersOverWs,
-            wsClient.waitForMessage().let { message ->
-                assertEquals(SubscriptionTopic.Orders, message.topic)
-                message.data.let { data ->
-                    assertIs<Orders>(data)
-                    data.orders
-                }
-            },
+            wsClient.assertOrdersMessageReceived().orders,
         )
 
         // update order
@@ -169,25 +149,17 @@ class OrderRoutesApiTest {
         assertIs<Order.Limit>(updatedOrder)
         assertEquals(wallet.formatAmount("3", "USDC"), updatedOrder.amount)
         assertEquals(0, BigDecimal("2.01").compareTo(updatedOrder.price))
-        wsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Orders, message.topic)
-            message.data.let { data ->
-                assertIs<OrderUpdated>(data)
-                assertIs<Order.Limit>(data.order)
-                validateLimitOrders(updatedOrder, data.order as Order.Limit, true)
-            }
+        wsClient.assertOrderUpdatedMessageReceived { msg ->
+            assertIs<Order.Limit>(msg.order)
+            validateLimitOrders(updatedOrder, msg.order as Order.Limit, true)
         }
 
         // cancel order is idempotent
         apiClient.cancelOrder(limitOrder.id)
         val cancelledOrder = apiClient.getOrder(limitOrder.id)
-        wsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Orders, message.topic)
-            message.data.let { data ->
-                assertIs<OrderUpdated>(data)
-                assertEquals(cancelledOrder.id, data.order.id)
-                assertEquals(OrderStatus.Cancelled, data.order.status)
-            }
+        wsClient.assertOrderUpdatedMessageReceived { msg ->
+            assertEquals(cancelledOrder.id, msg.order.id)
+            assertEquals(OrderStatus.Cancelled, msg.order.status)
         }
         assertEquals(OrderStatus.Cancelled, apiClient.getOrder(limitOrder.id).status)
 
@@ -200,11 +172,8 @@ class OrderRoutesApiTest {
         val wallet = Wallet(apiClient)
 
         val wsClient = WebsocketClient.blocking(apiClient.authToken)
-        wsClient.subscribe(SubscriptionTopic.Orders)
-        wsClient.waitForMessage().let { message ->
-            assertEquals(SubscriptionTopic.Orders, message.topic)
-            assertIs<Orders>(message.data)
-        }
+        wsClient.subscribeToOrders()
+        wsClient.assertOrdersMessageReceived()
 
         wsClient.subscribe(SubscriptionTopic.Balances)
         wsClient.waitForMessage().also { message ->
@@ -218,14 +187,10 @@ class OrderRoutesApiTest {
         BalanceHelper.waitForAndVerifyBalanceChange(apiClient, listOf(ExpectedBalance("DAI", amountToDeposit, amountToDeposit))) {
             deposit(wallet, "DAI", amountToDeposit)
         }
-        wsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Balances, message.topic)
-            message.data.let { data ->
-                assertIs<Balances>(data)
-                assertEquals(1, data.balances.size)
-                assertEquals(Symbol("DAI"), data.balances.first().symbol)
-                assertEquals(BigInteger("20000000000000000000"), data.balances.first().available)
-            }
+        wsClient.assertBalancesMessageReceived { msg ->
+            assertEquals(1, msg.balances.size)
+            assertEquals(Symbol("DAI"), msg.balances.first().symbol)
+            assertEquals(BigInteger("20000000000000000000"), msg.balances.first().available)
         }
 
         // operation on non-existent order
@@ -258,20 +223,14 @@ class OrderRoutesApiTest {
         )
 
         assertIs<Order.Limit>(limitOrder)
-        wsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Orders, message.topic)
-            message.data.let { data ->
-                assertIs<OrderCreated>(data)
-                validateLimitOrders(limitOrder, data.order as Order.Limit, false)
-            }
-        }
 
-        wsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Orders, message.topic)
-            message.data.let { data ->
-                assertIs<OrderUpdated>(data)
-                assertEquals(limitOrder.id, data.order.id)
-                assertEquals(OrderStatus.CrossesMarket, data.order.status)
+        wsClient.apply {
+            assertOrderCreatedMessageReceived { msg ->
+                validateLimitOrders(limitOrder, msg.order as Order.Limit, false)
+            }
+            assertOrderUpdatedMessageReceived { msg ->
+                assertEquals(limitOrder.id, msg.order.id)
+                assertEquals(OrderStatus.CrossesMarket, msg.order.status)
             }
         }
 
@@ -352,14 +311,8 @@ class OrderRoutesApiTest {
         apiClient.cancelOpenOrders()
 
         val wsClient = WebsocketClient.blocking(apiClient.authToken)
-        wsClient.subscribe(SubscriptionTopic.Orders)
-        val initialOrdersOverWs = wsClient.waitForMessage().let { message ->
-            assertEquals(SubscriptionTopic.Orders, message.topic)
-            message.data.let { data ->
-                assertIs<Orders>(data)
-                data.orders
-            }
-        }
+        wsClient.subscribeToOrders()
+        val initialOrdersOverWs = wsClient.assertOrdersMessageReceived().orders
 
         wsClient.subscribe(SubscriptionTopic.Balances)
         wsClient.waitForMessage().also { message ->
@@ -373,14 +326,10 @@ class OrderRoutesApiTest {
         BalanceHelper.waitForAndVerifyBalanceChange(apiClient, listOf(ExpectedBalance("DAI", amountToDeposit, amountToDeposit))) {
             deposit(wallet, "DAI", amountToDeposit)
         }
-        wsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Balances, message.topic)
-            message.data.let { data ->
-                assertIs<Balances>(data)
-                assertEquals(1, data.balances.size)
-                assertEquals(Symbol("DAI"), data.balances.first().symbol)
-                assertEquals(BigInteger("30000000000000000000"), data.balances.first().available)
-            }
+        wsClient.assertBalancesMessageReceived { msg ->
+            assertEquals(1, msg.balances.size)
+            assertEquals(Symbol("DAI"), msg.balances.first().symbol)
+            assertEquals(BigInteger("30000000000000000000"), msg.balances.first().available)
         }
 
         val limitOrderApiRequest = CreateOrderApiRequest.Limit(
@@ -397,19 +346,13 @@ class OrderRoutesApiTest {
             apiClient.createOrder(wallet.signOrder(limitOrderApiRequest.copy(nonce = generateHexString(32))))
         }
         assertEquals(10, apiClient.listOrders().orders.count { it.status != OrderStatus.Cancelled })
-        wsClient.receivedDecoded().take(10).forEach {
-            assertIs<OrderCreated>((it as OutgoingWSMessage.Publish).data)
-        }
+        repeat(10) { wsClient.assertOrderCreatedMessageReceived() }
 
         apiClient.cancelOpenOrders()
 
-        wsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Orders, message.topic)
-            message.data.let { data ->
-                assertIs<Orders>(data)
-                assertNotEquals(initialOrdersOverWs, data.orders)
-                assertTrue(data.orders.all { it.status == OrderStatus.Cancelled })
-            }
+        wsClient.assertOrdersMessageReceived { msg ->
+            assertNotEquals(initialOrdersOverWs, msg.orders)
+            assertTrue(msg.orders.all { it.status == OrderStatus.Cancelled })
         }
 
         assertTrue(apiClient.listOrders().orders.all { it.status == OrderStatus.Cancelled })
@@ -446,35 +389,22 @@ class OrderRoutesApiTest {
         )
         assertIs<Order.Limit>(limitBuyOrder)
         assertEquals(limitBuyOrder.status, OrderStatus.Open)
-        makerWsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Orders, message.topic)
-            message.data.let { data ->
-                assertIs<OrderCreated>(data)
-                validateLimitOrders(
-                    limitBuyOrder,
-                    data.order as Order.Limit,
-                    false,
-                )
-            }
+        makerWsClient.assertOrderCreatedMessageReceived { msg ->
+            validateLimitOrders(limitBuyOrder, msg.order as Order.Limit, false)
         }
+
         listOf(makerWsClient, takerWsClient).forEach { wsClient ->
-            wsClient.waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.OrderBook(btcEthMarketId), message.topic)
-                message.data.let { data ->
-                    assertIs<OrderBook>(data)
-                    assertEquals(
-                        OrderBook(
-                            marketId = btcEthMarketId,
-                            buy = listOf(
-                                OrderBookEntry(price = "17.45", size = "0.00013345".toBigDecimal()),
-                            ),
-                            sell = emptyList(),
-                            last = LastTrade("0.00", LastTradeDirection.Up),
-                        ),
-                        data,
-                    )
-                }
-            }
+            wsClient.assertOrderBookMessageReceived(
+                btcEthMarketId,
+                OrderBook(
+                    marketId = btcEthMarketId,
+                    buy = listOf(
+                        OrderBookEntry(price = "17.45", size = "0.00013345".toBigDecimal()),
+                    ),
+                    sell = emptyList(),
+                    last = LastTrade("0.00", LastTradeDirection.Up),
+                ),
+            )
         }
 
         val updatedLimitBuyOrder = makerApiClient.updateOrder(
@@ -486,35 +416,21 @@ class OrderRoutesApiTest {
         )
         assertIs<Order.Limit>(updatedLimitBuyOrder)
 
-        makerWsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Orders, message.topic)
-            message.data.let { data ->
-                assertIs<OrderUpdated>(data)
-                validateLimitOrders(
-                    updatedLimitBuyOrder,
-                    data.order as Order.Limit,
-                    true,
-                )
-            }
+        makerWsClient.assertOrderUpdatedMessageReceived { msg ->
+            validateLimitOrders(updatedLimitBuyOrder, msg.order as Order.Limit, true)
         }
         listOf(makerWsClient, takerWsClient).forEach { wsClient ->
-            wsClient.waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.OrderBook(btcEthMarketId), message.topic)
-                message.data.let { data ->
-                    assertIs<OrderBook>(data)
-                    assertEquals(
-                        OrderBook(
-                            marketId = btcEthMarketId,
-                            buy = listOf(
-                                OrderBookEntry(price = "17.50", size = "0.00012345".toBigDecimal()),
-                            ),
-                            sell = emptyList(),
-                            last = LastTrade("0.00", LastTradeDirection.Up),
-                        ),
-                        data,
-                    )
-                }
-            }
+            wsClient.assertOrderBookMessageReceived(
+                btcEthMarketId,
+                OrderBook(
+                    marketId = btcEthMarketId,
+                    buy = listOf(
+                        OrderBookEntry(price = "17.50", size = "0.00012345".toBigDecimal()),
+                    ),
+                    sell = emptyList(),
+                    last = LastTrade("0.00", LastTradeDirection.Up),
+                ),
+            )
         }
 
         // place a sell order
@@ -533,33 +449,23 @@ class OrderRoutesApiTest {
         assertIs<Order.Limit>(limitSellOrder)
         assertEquals(limitSellOrder.status, OrderStatus.Open)
 
-        makerWsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Orders, message.topic)
-            message.data.let { data ->
-                assertIs<OrderCreated>(data)
-                validateLimitOrders(limitSellOrder, data.order as Order.Limit, false)
-            }
+        makerWsClient.assertOrderCreatedMessageReceived { msg ->
+            validateLimitOrders(limitSellOrder, msg.order as Order.Limit, false)
         }
         listOf(makerWsClient, takerWsClient).forEach { wsClient ->
-            wsClient.waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.OrderBook(btcEthMarketId), message.topic)
-                message.data.let { data ->
-                    assertIs<OrderBook>(data)
-                    assertEquals(
-                        OrderBook(
-                            marketId = btcEthMarketId,
-                            buy = listOf(
-                                OrderBookEntry(price = "17.50", size = "0.00012345".toBigDecimal()),
-                            ),
-                            sell = listOf(
-                                OrderBookEntry(price = "17.60", size = "0.00154321".toBigDecimal()),
-                            ),
-                            last = LastTrade("0.00", LastTradeDirection.Up),
-                        ),
-                        data,
-                    )
-                }
-            }
+            wsClient.assertOrderBookMessageReceived(
+                btcEthMarketId,
+                OrderBook(
+                    marketId = btcEthMarketId,
+                    buy = listOf(
+                        OrderBookEntry(price = "17.50", size = "0.00012345".toBigDecimal()),
+                    ),
+                    sell = listOf(
+                        OrderBookEntry(price = "17.60", size = "0.00154321".toBigDecimal()),
+                    ),
+                    last = LastTrade("0.00", LastTradeDirection.Up),
+                ),
+            )
         }
 
         // update amount and price of the sell
@@ -572,34 +478,24 @@ class OrderRoutesApiTest {
         )
         assertIs<Order.Limit>(updatedLimitSellOrder)
 
-        makerWsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Orders, message.topic)
-            message.data.let { data ->
-                assertIs<OrderUpdated>(data)
-                assertIs<Order.Limit>(data.order)
-                validateLimitOrders(updatedLimitSellOrder, data.order as Order.Limit, true)
-            }
+        makerWsClient.assertOrderUpdatedMessageReceived { msg ->
+            assertIs<Order.Limit>(msg.order)
+            validateLimitOrders(updatedLimitSellOrder, msg.order as Order.Limit, true)
         }
         listOf(makerWsClient, takerWsClient).forEach { wsClient ->
-            wsClient.waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.OrderBook(btcEthMarketId), message.topic)
-                message.data.let { data ->
-                    assertIs<OrderBook>(data)
-                    assertEquals(
-                        OrderBook(
-                            marketId = btcEthMarketId,
-                            buy = listOf(
-                                OrderBookEntry(price = "17.50", size = "0.00012345".toBigDecimal()),
-                            ),
-                            sell = listOf(
-                                OrderBookEntry(price = "17.55", size = "0.00054321".toBigDecimal()),
-                            ),
-                            last = LastTrade("0.00", LastTradeDirection.Up),
-                        ),
-                        data,
-                    )
-                }
-            }
+            wsClient.assertOrderBookMessageReceived(
+                btcEthMarketId,
+                OrderBook(
+                    marketId = btcEthMarketId,
+                    buy = listOf(
+                        OrderBookEntry(price = "17.50", size = "0.00012345".toBigDecimal()),
+                    ),
+                    sell = listOf(
+                        OrderBookEntry(price = "17.55", size = "0.00054321".toBigDecimal()),
+                    ),
+                    last = LastTrade("0.00", LastTradeDirection.Up),
+                ),
+            )
         }
 
         // place a buy order and see it gets executed
@@ -619,105 +515,71 @@ class OrderRoutesApiTest {
         assertEquals(marketBuyOrder.status, OrderStatus.Open)
 
         takerWsClient.apply {
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Orders, message.topic)
-                message.data.let { data ->
-                    assertIs<OrderCreated>(data)
-                    assertEquals(marketBuyOrder.id, data.order.id)
-                    assertEquals(marketBuyOrder.amount, data.order.amount)
-                    assertEquals(marketBuyOrder.side, data.order.side)
-                    assertEquals(marketBuyOrder.marketId, data.order.marketId)
-                    assertEquals(marketBuyOrder.timing.createdAt, data.order.timing.createdAt)
-                }
+            assertOrderCreatedMessageReceived { msg ->
+                assertEquals(marketBuyOrder.id, msg.order.id)
+                assertEquals(marketBuyOrder.amount, msg.order.amount)
+                assertEquals(marketBuyOrder.side, msg.order.side)
+                assertEquals(marketBuyOrder.marketId, msg.order.marketId)
+                assertEquals(marketBuyOrder.timing.createdAt, msg.order.timing.createdAt)
             }
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Trades, message.topic)
-                message.data.let { data ->
-                    assertIs<TradeCreated>(data)
-                    assertEquals(marketBuyOrder.id, data.trade.orderId)
-                    assertEquals(marketBuyOrder.marketId, data.trade.marketId)
-                    assertEquals(marketBuyOrder.side, data.trade.side)
-                    assertEquals(updatedLimitSellOrder.price, data.trade.price)
-                    assertEquals(marketBuyOrder.amount, data.trade.amount)
-                    assertEquals(SettlementStatus.Pending, data.trade.settlementStatus)
-                }
+            assertTradeCreatedMessageReceived { msg ->
+                assertEquals(marketBuyOrder.id, msg.trade.orderId)
+                assertEquals(marketBuyOrder.marketId, msg.trade.marketId)
+                assertEquals(marketBuyOrder.side, msg.trade.side)
+                assertEquals(updatedLimitSellOrder.price, msg.trade.price)
+                assertEquals(marketBuyOrder.amount, msg.trade.amount)
+                assertEquals(SettlementStatus.Pending, msg.trade.settlementStatus)
             }
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Orders, message.topic)
-                message.data.let { data ->
-                    assertIs<OrderUpdated>(data)
-                    assertEquals(OrderStatus.Filled, data.order.status)
-                    assertEquals(1, data.order.executions.size)
-                    assertEquals(data.order.executions[0].amount, takerWallet.formatAmount("0.00043210", "BTC"))
-                    assertEquals(0, data.order.executions[0].price.compareTo(BigDecimal("17.550")))
-                    assertEquals(data.order.executions[0].role, ExecutionRole.Taker)
-                }
+            assertOrderUpdatedMessageReceived { msg ->
+                assertEquals(OrderStatus.Filled, msg.order.status)
+                assertEquals(1, msg.order.executions.size)
+                assertEquals(msg.order.executions[0].amount, takerWallet.formatAmount("0.00043210", "BTC"))
+                assertEquals(0, msg.order.executions[0].price.compareTo(BigDecimal("17.550")))
+                assertEquals(msg.order.executions[0].role, ExecutionRole.Taker)
             }
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Balances, message.topic)
-                message.data.let { data ->
-                    assertIs<Balances>(data)
-                    assertEquals(BigInteger("1992416645000000000"), data.balances.first { it.symbol.value == "ETH" }.available)
-                    assertEquals(BigInteger("432100000000000"), data.balances.first { it.symbol.value == "BTC" }.available)
-                }
+            assertBalancesMessageReceived { msg ->
+                assertEquals(BigInteger("1992416645000000000"), msg.balances.first { it.symbol.value == "ETH" }.available)
+                assertEquals(BigInteger("432100000000000"), msg.balances.first { it.symbol.value == "BTC" }.available)
             }
         }
 
         makerWsClient.apply {
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Trades, message.topic)
-                message.data.let { data ->
-                    assertIs<TradeCreated>(data)
-                    assertEquals(updatedLimitSellOrder.id, data.trade.orderId)
-                    assertEquals(updatedLimitSellOrder.marketId, data.trade.marketId)
-                    assertEquals(updatedLimitSellOrder.side, data.trade.side)
-                    assertEquals(updatedLimitSellOrder.price, data.trade.price)
-                    assertEquals(takerWallet.formatAmount("0.00043210", "BTC"), data.trade.amount)
-                    assertEquals(SettlementStatus.Pending, data.trade.settlementStatus)
-                }
+            assertTradeCreatedMessageReceived { msg ->
+                assertEquals(updatedLimitSellOrder.id, msg.trade.orderId)
+                assertEquals(updatedLimitSellOrder.marketId, msg.trade.marketId)
+                assertEquals(updatedLimitSellOrder.side, msg.trade.side)
+                assertEquals(updatedLimitSellOrder.price, msg.trade.price)
+                assertEquals(takerWallet.formatAmount("0.00043210", "BTC"), msg.trade.amount)
+                assertEquals(SettlementStatus.Pending, msg.trade.settlementStatus)
             }
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Orders, message.topic)
-                message.data.let { data ->
-                    assertIs<OrderUpdated>(data)
-                    assertEquals(OrderStatus.Partial, data.order.status)
-                    assertEquals(1, data.order.executions.size)
-                    assertEquals(data.order.executions[0].amount, makerWallet.formatAmount("0.00043210", "BTC"))
-                    assertEquals(0, data.order.executions[0].price.compareTo(BigDecimal("17.550")))
-                    assertEquals(ExecutionRole.Maker, data.order.executions[0].role)
-                }
+            assertOrderUpdatedMessageReceived { msg ->
+                assertEquals(OrderStatus.Partial, msg.order.status)
+                assertEquals(1, msg.order.executions.size)
+                assertEquals(msg.order.executions[0].amount, makerWallet.formatAmount("0.00043210", "BTC"))
+                assertEquals(0, msg.order.executions[0].price.compareTo(BigDecimal("17.550")))
+                assertEquals(ExecutionRole.Maker, msg.order.executions[0].role)
             }
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Balances, message.topic)
-                message.data.let { data ->
-                    assertIs<Balances>(data)
-                    assertEquals(BigInteger("2007583355000000000"), data.balances.first { it.symbol.value == "ETH" }.available)
-                    assertEquals(BigInteger("199567900000000000"), data.balances.first { it.symbol.value == "BTC" }.available)
-                }
+            assertBalancesMessageReceived { msg ->
+                assertEquals(BigInteger("2007583355000000000"), msg.balances.first { it.symbol.value == "ETH" }.available)
+                assertEquals(BigInteger("199567900000000000"), msg.balances.first { it.symbol.value == "BTC" }.available)
             }
         }
 
         listOf(makerWsClient, takerWsClient).forEach { wsClient ->
-            wsClient.waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.OrderBook(btcEthMarketId), message.topic)
-                message.data.let { data ->
-                    assertIs<OrderBook>(data)
-                    assertEquals(
-                        OrderBook(
-                            marketId = btcEthMarketId,
-                            buy = listOf(
-                                OrderBookEntry(price = "17.50", size = "0.00012345".toBigDecimal()),
-                            ),
-                            sell = listOf(
-                                // TODO: amount should be reduced since MM order was partially filled
-                                OrderBookEntry(price = "17.55", size = "0.00054321".toBigDecimal()),
-                            ),
-                            last = LastTrade("17.55", LastTradeDirection.Up),
-                        ),
-                        data,
-                    )
-                }
-            }
+            wsClient.assertOrderBookMessageReceived(
+                btcEthMarketId,
+                OrderBook(
+                    marketId = btcEthMarketId,
+                    buy = listOf(
+                        OrderBookEntry(price = "17.50", size = "0.00012345".toBigDecimal()),
+                    ),
+                    sell = listOf(
+                        // TODO: amount should be reduced since MM order was partially filled
+                        OrderBookEntry(price = "17.55", size = "0.00054321".toBigDecimal()),
+                    ),
+                    last = LastTrade("17.55", LastTradeDirection.Up),
+                ),
+            )
         }
 
         val trade = getTradesForOrders(listOf(marketBuyOrder.id)).first()
@@ -726,21 +588,13 @@ class OrderRoutesApiTest {
         assertEquals(0, trade.price.compareTo(BigDecimal("17.550")))
 
         waitForSettlementToFinish(listOf(trade.id.value))
-        takerWsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Trades, message.topic)
-            message.data.let { data ->
-                assertIs<TradeUpdated>(data)
-                assertEquals(marketBuyOrder.id, data.trade.orderId)
-                assertEquals(SettlementStatus.Completed, data.trade.settlementStatus)
-            }
+        takerWsClient.assertTradeUpdatedMessageReceived { msg ->
+            assertEquals(marketBuyOrder.id, msg.trade.orderId)
+            assertEquals(SettlementStatus.Completed, msg.trade.settlementStatus)
         }
-        makerWsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Trades, message.topic)
-            message.data.let { data ->
-                assertIs<TradeUpdated>(data)
-                assertEquals(updatedLimitSellOrder.id, data.trade.orderId)
-                assertEquals(SettlementStatus.Completed, data.trade.settlementStatus)
-            }
+        makerWsClient.assertTradeUpdatedMessageReceived { msg ->
+            assertEquals(updatedLimitSellOrder.id, msg.trade.orderId)
+            assertEquals(SettlementStatus.Completed, msg.trade.settlementStatus)
         }
 
         val baseQuantity = takerWallet.formatAmount("0.00043210", "BTC")
@@ -777,102 +631,68 @@ class OrderRoutesApiTest {
         assertEquals(marketSellOrder.status, OrderStatus.Open)
 
         takerWsClient.apply {
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Orders, message.topic)
-                message.data.let { data ->
-                    assertIs<OrderCreated>(data)
-                    assertEquals(marketSellOrder.id, data.order.id)
-                    assertEquals(marketSellOrder.amount, data.order.amount)
-                    assertEquals(marketSellOrder.side, data.order.side)
-                    assertEquals(marketSellOrder.marketId, data.order.marketId)
-                    assertEquals(marketSellOrder.timing.createdAt, data.order.timing.createdAt)
-                }
+            assertOrderCreatedMessageReceived { msg ->
+                assertEquals(marketSellOrder.id, msg.order.id)
+                assertEquals(marketSellOrder.amount, msg.order.amount)
+                assertEquals(marketSellOrder.side, msg.order.side)
+                assertEquals(marketSellOrder.marketId, msg.order.marketId)
+                assertEquals(marketSellOrder.timing.createdAt, msg.order.timing.createdAt)
             }
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Trades, message.topic)
-                message.data.let { data ->
-                    assertIs<TradeCreated>(data)
-                    assertEquals(marketSellOrder.id, data.trade.orderId)
-                    assertEquals(marketSellOrder.marketId, data.trade.marketId)
-                    assertEquals(marketSellOrder.side, data.trade.side)
-                    assertEquals(0, data.trade.price.compareTo(BigDecimal("17.500")))
-                    assertEquals(makerWallet.formatAmount("0.00012345", "BTC"), data.trade.amount)
-                    assertEquals(SettlementStatus.Pending, data.trade.settlementStatus)
-                }
+            assertTradeCreatedMessageReceived { msg ->
+                assertEquals(marketSellOrder.id, msg.trade.orderId)
+                assertEquals(marketSellOrder.marketId, msg.trade.marketId)
+                assertEquals(marketSellOrder.side, msg.trade.side)
+                assertEquals(0, msg.trade.price.compareTo(BigDecimal("17.500")))
+                assertEquals(makerWallet.formatAmount("0.00012345", "BTC"), msg.trade.amount)
+                assertEquals(SettlementStatus.Pending, msg.trade.settlementStatus)
             }
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Orders, message.topic)
-                message.data.let { data ->
-                    assertIs<OrderUpdated>(data)
-                    assertEquals(OrderStatus.Partial, data.order.status)
-                    assertEquals(1, data.order.executions.size)
-                    assertEquals(data.order.executions[0].amount, takerWallet.formatAmount("0.00012345", "BTC"))
-                    assertEquals(0, data.order.executions[0].price.compareTo(BigDecimal("17.500")))
-                    assertEquals(ExecutionRole.Taker, data.order.executions[0].role)
-                }
+            assertOrderUpdatedMessageReceived { msg ->
+                assertEquals(OrderStatus.Partial, msg.order.status)
+                assertEquals(1, msg.order.executions.size)
+                assertEquals(msg.order.executions[0].amount, takerWallet.formatAmount("0.00012345", "BTC"))
+                assertEquals(0, msg.order.executions[0].price.compareTo(BigDecimal("17.500")))
+                assertEquals(ExecutionRole.Taker, msg.order.executions[0].role)
             }
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Balances, message.topic)
-                message.data.let { data ->
-                    assertIs<Balances>(data)
-                    assertEquals(BigInteger("1994577020000000000"), data.balances.first { it.symbol.value == "ETH" }.available)
-                    assertEquals(BigInteger("308650000000000"), data.balances.first { it.symbol.value == "BTC" }.available)
-                }
+            assertBalancesMessageReceived { msg ->
+                assertEquals(BigInteger("1994577020000000000"), msg.balances.first { it.symbol.value == "ETH" }.available)
+                assertEquals(BigInteger("308650000000000"), msg.balances.first { it.symbol.value == "BTC" }.available)
             }
         }
 
         makerWsClient.apply {
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Trades, message.topic)
-                message.data.let { data ->
-                    assertIs<TradeCreated>(data)
-                    assertEquals(updatedLimitBuyOrder.id, data.trade.orderId)
-                    assertEquals(updatedLimitBuyOrder.marketId, data.trade.marketId)
-                    assertEquals(updatedLimitBuyOrder.side, data.trade.side)
-                    assertEquals(updatedLimitBuyOrder.price, data.trade.price)
-                    assertEquals(makerWallet.formatAmount("0.00012345", "BTC"), data.trade.amount)
-                    assertEquals(SettlementStatus.Pending, data.trade.settlementStatus)
-                }
+            assertTradeCreatedMessageReceived { msg ->
+                assertEquals(updatedLimitBuyOrder.id, msg.trade.orderId)
+                assertEquals(updatedLimitBuyOrder.marketId, msg.trade.marketId)
+                assertEquals(updatedLimitBuyOrder.side, msg.trade.side)
+                assertEquals(updatedLimitBuyOrder.price, msg.trade.price)
+                assertEquals(makerWallet.formatAmount("0.00012345", "BTC"), msg.trade.amount)
+                assertEquals(SettlementStatus.Pending, msg.trade.settlementStatus)
             }
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Orders, message.topic)
-                message.data.let { data ->
-                    assertIs<OrderUpdated>(data)
-                    assertEquals(OrderStatus.Filled, data.order.status)
-                    assertEquals(1, data.order.executions.size)
-                    assertEquals(data.order.executions[0].amount, takerWallet.formatAmount("0.00012345", "BTC"))
-                    assertEquals(0, data.order.executions[0].price.compareTo(BigDecimal("17.500")))
-                    assertEquals(ExecutionRole.Maker, data.order.executions[0].role)
-                }
+            assertOrderUpdatedMessageReceived { msg ->
+                assertEquals(OrderStatus.Filled, msg.order.status)
+                assertEquals(1, msg.order.executions.size)
+                assertEquals(msg.order.executions[0].amount, takerWallet.formatAmount("0.00012345", "BTC"))
+                assertEquals(0, msg.order.executions[0].price.compareTo(BigDecimal("17.500")))
+                assertEquals(ExecutionRole.Maker, msg.order.executions[0].role)
             }
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Balances, message.topic)
-                message.data.let { data ->
-                    assertIs<Balances>(data)
-                    assertEquals(BigInteger("2005422980000000000"), data.balances.first { it.symbol.value == "ETH" }.available)
-                    assertEquals(BigInteger("199691350000000000"), data.balances.first { it.symbol.value == "BTC" }.available)
-                }
+            assertBalancesMessageReceived { msg ->
+                assertEquals(BigInteger("2005422980000000000"), msg.balances.first { it.symbol.value == "ETH" }.available)
+                assertEquals(BigInteger("199691350000000000"), msg.balances.first { it.symbol.value == "BTC" }.available)
             }
         }
 
         listOf(makerWsClient, takerWsClient).forEach { wsClient ->
-            wsClient.waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.OrderBook(btcEthMarketId), message.topic)
-                message.data.let { data ->
-                    assertIs<OrderBook>(data)
-                    assertEquals(
-                        OrderBook(
-                            marketId = btcEthMarketId,
-                            buy = emptyList(),
-                            sell = listOf(
-                                OrderBookEntry(price = "17.55", size = "0.00054321".toBigDecimal()),
-                            ),
-                            last = LastTrade("17.50", LastTradeDirection.Down),
-                        ),
-                        data,
-                    )
-                }
-            }
+            wsClient.assertOrderBookMessageReceived(
+                btcEthMarketId,
+                OrderBook(
+                    marketId = btcEthMarketId,
+                    buy = emptyList(),
+                    sell = listOf(
+                        OrderBookEntry(price = "17.55", size = "0.00054321".toBigDecimal()),
+                    ),
+                    last = LastTrade("17.50", LastTradeDirection.Down),
+                ),
+            )
         }
 
         val trade2 = getTradesForOrders(listOf(marketSellOrder.id)).first()
@@ -880,21 +700,13 @@ class OrderRoutesApiTest {
         assertEquals(0, trade2.price.compareTo(BigDecimal("17.500")))
 
         waitForSettlementToFinish(listOf(trade2.id.value))
-        takerWsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Trades, message.topic)
-            message.data.let { data ->
-                assertIs<TradeUpdated>(data)
-                assertEquals(marketSellOrder.id, data.trade.orderId)
-                assertEquals(SettlementStatus.Completed, data.trade.settlementStatus)
-            }
+        takerWsClient.assertTradeUpdatedMessageReceived { msg ->
+            assertEquals(marketSellOrder.id, msg.trade.orderId)
+            assertEquals(SettlementStatus.Completed, msg.trade.settlementStatus)
         }
-        makerWsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Trades, message.topic)
-            message.data.let { data ->
-                assertIs<TradeUpdated>(data)
-                assertEquals(updatedLimitBuyOrder.id, data.trade.orderId)
-                assertEquals(SettlementStatus.Completed, data.trade.settlementStatus)
-            }
+        makerWsClient.assertTradeUpdatedMessageReceived { msg ->
+            assertEquals(updatedLimitBuyOrder.id, msg.trade.orderId)
+            assertEquals(SettlementStatus.Completed, msg.trade.settlementStatus)
         }
 
         val baseQuantity2 = takerWallet.formatAmount("0.00012345", "BTC")
@@ -915,63 +727,42 @@ class OrderRoutesApiTest {
         )
 
         takerApiClient.cancelOpenOrders()
-        takerWsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Orders, message.topic)
-            assertIs<Orders>(message.data)
-        }
+        takerWsClient.assertOrdersMessageReceived()
         listOf(makerWsClient, takerWsClient).forEach { wsClient ->
-            wsClient.waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.OrderBook(btcEthMarketId), message.topic)
-                message.data.let { data ->
-                    assertIs<OrderBook>(data)
-                    assertEquals(
-                        OrderBook(
-                            marketId = btcEthMarketId,
-                            buy = emptyList(),
-                            sell = listOf(
-                                OrderBookEntry(price = "17.55", size = "0.00054321".toBigDecimal()),
-                            ),
-                            last = LastTrade("17.50", LastTradeDirection.Down),
-                        ),
-                        data,
-                    )
-                }
-            }
+            wsClient.assertOrderBookMessageReceived(
+                btcEthMarketId,
+                OrderBook(
+                    marketId = btcEthMarketId,
+                    buy = emptyList(),
+                    sell = listOf(
+                        OrderBookEntry(price = "17.55", size = "0.00054321".toBigDecimal()),
+                    ),
+                    last = LastTrade("17.50", LastTradeDirection.Down),
+                ),
+            )
         }
 
         makerApiClient.cancelOpenOrders()
-        makerWsClient.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.Orders, message.topic)
-            assertIs<Orders>(message.data)
-        }
+        makerWsClient.assertOrdersMessageReceived()
         listOf(makerWsClient, takerWsClient).forEach { wsClient ->
-            wsClient.waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.OrderBook(btcEthMarketId), message.topic)
-                message.data.let { data ->
-                    assertIs<OrderBook>(data)
-                    assertEquals(
-                        OrderBook(
-                            marketId = btcEthMarketId,
-                            buy = emptyList(),
-                            sell = emptyList(),
-                            last = LastTrade("17.50", LastTradeDirection.Down),
-                        ),
-                        data,
-                    )
-                }
-            }
+            wsClient.assertOrderBookMessageReceived(
+                btcEthMarketId,
+                OrderBook(
+                    marketId = btcEthMarketId,
+                    buy = emptyList(),
+                    sell = emptyList(),
+                    last = LastTrade("17.50", LastTradeDirection.Down),
+                ),
+            )
         }
 
         // verify that client's websocket gets same orders, trades and order book on reconnect
         takerWsClient.close()
         WebsocketClient.blocking(takerApiClient.authToken).apply {
-            subscribe(SubscriptionTopic.Orders)
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Orders, message.topic)
-                assertIs<Orders>(message.data)
-                val orders = (message.data as Orders).orders
-                assertEquals(2, orders.size)
-                orders[0].also { order ->
+            subscribeToOrders()
+            assertOrdersMessageReceived { msg ->
+                assertEquals(2, msg.orders.size)
+                msg.orders[0].also { order ->
                     assertIs<Order.Market>(order)
                     assertEquals(marketSellOrder.id, order.id)
                     assertEquals(marketSellOrder.marketId, order.marketId)
@@ -979,7 +770,7 @@ class OrderRoutesApiTest {
                     assertEquals(marketSellOrder.amount, order.amount)
                     assertEquals(OrderStatus.Cancelled, order.status)
                 }
-                orders[1].also { order ->
+                msg.orders[1].also { order ->
                     assertIs<Order.Market>(order)
                     assertEquals(marketBuyOrder.id, order.id)
                     assertEquals(marketBuyOrder.marketId, order.marketId)
@@ -989,13 +780,10 @@ class OrderRoutesApiTest {
                 }
             }
 
-            subscribe(SubscriptionTopic.Trades)
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Trades, message.topic)
-                assertIs<Trades>(message.data)
-                val trades = (message.data as Trades).trades
-                assertEquals(2, trades.size)
-                trades[0].apply {
+            subscribeToTrades()
+            assertTradesMessageReceived { msg ->
+                assertEquals(2, msg.trades.size)
+                msg.trades[0].apply {
                     assertEquals(marketSellOrder.id, orderId)
                     assertEquals(marketSellOrder.marketId, marketId)
                     assertEquals(marketSellOrder.side, side)
@@ -1003,7 +791,7 @@ class OrderRoutesApiTest {
                     assertEquals(makerWallet.formatAmount("0.00012345", "BTC"), amount)
                     assertEquals(SettlementStatus.Completed, settlementStatus)
                 }
-                trades[1].apply {
+                msg.trades[1].apply {
                     assertEquals(marketBuyOrder.id, orderId)
                     assertEquals(marketBuyOrder.marketId, marketId)
                     assertEquals(marketBuyOrder.side, side)
@@ -1013,22 +801,16 @@ class OrderRoutesApiTest {
                 }
             }
 
-            subscribe(SubscriptionTopic.OrderBook(btcEthMarketId))
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.OrderBook(btcEthMarketId), message.topic)
-                message.data.let { data ->
-                    assertIs<OrderBook>(data)
-                    assertEquals(
-                        OrderBook(
-                            marketId = btcEthMarketId,
-                            buy = emptyList(),
-                            sell = emptyList(),
-                            last = LastTrade("17.50", LastTradeDirection.Down),
-                        ),
-                        data,
-                    )
-                }
-            }
+            subscribeToOrderBook(btcEthMarketId)
+            assertOrderBookMessageReceived(
+                btcEthMarketId,
+                OrderBook(
+                    marketId = btcEthMarketId,
+                    buy = emptyList(),
+                    sell = emptyList(),
+                    last = LastTrade("17.50", LastTradeDirection.Down),
+                ),
+            )
         }.close()
 
         makerWsClient.close()
@@ -1070,9 +852,7 @@ class OrderRoutesApiTest {
         )
 
         assertEquals(3, createBatchLimitOrders.orders.count { it.status == OrderStatus.Open })
-        makerWsClient.receivedDecoded().take(3).forEach {
-            assertIs<OrderCreated>((it as OutgoingWSMessage.Publish).data)
-        }
+        repeat(3) { makerWsClient.assertOrderCreatedMessageReceived() }
 
         val batchOrderResponse = makerApiClient.batchOrders(
             BatchOrdersApiRequest(
@@ -1111,13 +891,8 @@ class OrderRoutesApiTest {
         assertEquals(5, batchOrderResponse.orders.count { it.status == OrderStatus.Open })
         assertEquals(1, batchOrderResponse.orders.count { it.status == OrderStatus.Cancelled })
 
-        makerWsClient.receivedDecoded().take(3).forEach {
-            assertIs<OrderCreated>((it as OutgoingWSMessage.Publish).data)
-        }
-
-        makerWsClient.receivedDecoded().take(3).forEach {
-            assertIs<OrderUpdated>((it as OutgoingWSMessage.Publish).data)
-        }
+        repeat(3) { makerWsClient.assertOrderCreatedMessageReceived() }
+        repeat(3) { makerWsClient.assertOrderUpdatedMessageReceived() }
 
         assertEquals(5, makerApiClient.listOrders().orders.count { it.status == OrderStatus.Open })
 
@@ -1136,23 +911,17 @@ class OrderRoutesApiTest {
             },
         )
 
-        takerWsClient.receivedDecoded().take(1).forEach {
-            assertIs<OrderCreated>((it as OutgoingWSMessage.Publish).data)
+        takerWsClient.apply {
+            assertOrderCreatedMessageReceived()
+            repeat(5) { assertTradeCreatedMessageReceived() }
+            assertOrderUpdatedMessageReceived()
         }
 
-        takerWsClient.receivedDecoded().take(5).forEach {
-            assertIs<TradeCreated>((it as OutgoingWSMessage.Publish).data)
-        }
-        takerWsClient.receivedDecoded().take(1).forEach {
-            assertIs<OrderUpdated>((it as OutgoingWSMessage.Publish).data)
+        makerWsClient.apply {
+            repeat(5) { assertTradeCreatedMessageReceived() }
+            assertOrderUpdatedMessageReceived()
         }
 
-        makerWsClient.receivedDecoded().take(5).forEach {
-            assertIs<TradeCreated>((it as OutgoingWSMessage.Publish).data)
-        }
-        makerWsClient.receivedDecoded().take(5).forEach {
-            assertIs<OrderUpdated>((it as OutgoingWSMessage.Publish).data)
-        }
         // should be 8 filled orders
         val takerOrders = takerApiClient.listOrders().orders
         assertEquals(1, takerOrders.count { it.status == OrderStatus.Filled })
@@ -1221,27 +990,17 @@ class OrderRoutesApiTest {
         val wallet = Wallet(apiClient)
 
         val wsClient = WebsocketClient.blocking(apiClient.authToken).apply {
-            subscribe(SubscriptionTopic.OrderBook(marketId))
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.OrderBook(marketId), message.topic)
-                assertIs<OrderBook>(message.data)
-            }
+            subscribeToOrderBook(marketId)
+            assertOrderBookMessageReceived(marketId)
 
-            subscribe(SubscriptionTopic.Orders)
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Orders, message.topic)
-                assertIs<Orders>(message.data)
-            }
-            subscribe(SubscriptionTopic.Trades)
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Trades, message.topic)
-                assertIs<Trades>(message.data)
-            }
-            subscribe(SubscriptionTopic.Balances)
-            waitForMessage().also { message ->
-                assertEquals(SubscriptionTopic.Balances, message.topic)
-                assertIs<Balances>(message.data)
-            }
+            subscribeToOrders()
+            assertOrdersMessageReceived()
+
+            subscribeToTrades()
+            assertTradesMessageReceived()
+
+            subscribeToBalances()
+            assertBalancesMessageReceived()
         }
 
         Faucet.fund(wallet.address, wallet.formatAmount(nativeAmount, "BTC"))
@@ -1262,9 +1021,7 @@ class OrderRoutesApiTest {
             deposit(wallet, mintSymbol, formattedMintAmount)
             formattedNativeAmount?.let { deposit(wallet, "BTC", it) }
         }
-        wsClient.receivedDecoded().take(expectedBalances.size).forEach {
-            assertIs<Balances>((it as OutgoingWSMessage.Publish).data)
-        }
+        repeat(expectedBalances.size) { wsClient.assertBalancesMessageReceived() }
 
         return Triple(apiClient, wallet, wsClient)
     }

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/exchange/OrderBookTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/exchange/OrderBookTest.kt
@@ -35,8 +35,6 @@ class OrderBookTest {
             message.data.also { orderBook ->
                 assertIs<OrderBook>(orderBook)
                 assertEquals("BTC/ETH", orderBook.marketId.value)
-                assertEquals(9, orderBook.buy.size)
-                assertEquals(10, orderBook.sell.size)
             }
         }
 

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/exchange/OrderBookTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/exchange/OrderBookTest.kt
@@ -1,18 +1,15 @@
 package co.chainring.integrationtests.exchange
 
-import co.chainring.apps.api.model.websocket.OrderBook
-import co.chainring.apps.api.model.websocket.SubscriptionTopic
 import co.chainring.core.model.db.MarketId
 import co.chainring.integrationtests.testutils.ApiClient
 import co.chainring.integrationtests.testutils.AppUnderTestRunner
+import co.chainring.integrationtests.testutils.assertOrderBookMessageReceived
 import co.chainring.integrationtests.testutils.blocking
-import co.chainring.integrationtests.testutils.subscribe
-import co.chainring.integrationtests.testutils.waitForMessage
+import co.chainring.integrationtests.testutils.subscribeToOrderBook
 import org.http4k.client.WebsocketClient
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import kotlin.test.assertIs
 
 @ExtendWith(AppUnderTestRunner::class)
 class OrderBookTest {
@@ -28,14 +25,10 @@ class OrderBookTest {
 
     private fun `test order book over websocket`(auth: String?) {
         val client = WebsocketClient.blocking(auth)
-        client.subscribe(SubscriptionTopic.OrderBook(MarketId("BTC/ETH")))
+        client.subscribeToOrderBook(MarketId("BTC/ETH"))
 
-        client.waitForMessage().also { message ->
-            assertEquals(SubscriptionTopic.OrderBook(MarketId("BTC/ETH")), message.topic)
-            message.data.also { orderBook ->
-                assertIs<OrderBook>(orderBook)
-                assertEquals("BTC/ETH", orderBook.marketId.value)
-            }
+        client.assertOrderBookMessageReceived(MarketId("BTC/ETH")) { msg ->
+            assertEquals("BTC/ETH", msg.marketId.value)
         }
 
         client.close()

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/testutils/WebsocketClient.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/testutils/WebsocketClient.kt
@@ -1,14 +1,27 @@
 package co.chainring.integrationtests.testutils
 
+import co.chainring.apps.api.model.websocket.Balances
 import co.chainring.apps.api.model.websocket.IncomingWSMessage
+import co.chainring.apps.api.model.websocket.OrderBook
+import co.chainring.apps.api.model.websocket.OrderCreated
+import co.chainring.apps.api.model.websocket.OrderUpdated
+import co.chainring.apps.api.model.websocket.Orders
 import co.chainring.apps.api.model.websocket.OutgoingWSMessage
+import co.chainring.apps.api.model.websocket.Prices
+import co.chainring.apps.api.model.websocket.Publishable
 import co.chainring.apps.api.model.websocket.SubscriptionTopic
+import co.chainring.apps.api.model.websocket.TradeCreated
+import co.chainring.apps.api.model.websocket.TradeUpdated
+import co.chainring.apps.api.model.websocket.Trades
+import co.chainring.core.model.db.MarketId
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.http4k.client.WebsocketClient
 import org.http4k.core.Uri
 import org.http4k.websocket.WsClient
 import org.http4k.websocket.WsMessage
+import org.junit.jupiter.api.Assertions.assertEquals
+import kotlin.test.assertIs
 
 fun WebsocketClient.blocking(auth: String?): WsClient =
     blocking(Uri.of(apiServerRootUrl.replace("http:", "ws:").replace("https:", "wss:") + "/connect" + (auth?.let { "?auth=$auth" } ?: "")))
@@ -17,8 +30,24 @@ fun WsClient.send(message: IncomingWSMessage) {
     send(WsMessage(Json.encodeToString(message)))
 }
 
-fun WsClient.subscribe(topic: SubscriptionTopic) {
-    send(IncomingWSMessage.Subscribe(topic))
+fun WsClient.subscribeToOrderBook(marketId: MarketId) {
+    send(IncomingWSMessage.Subscribe(SubscriptionTopic.OrderBook(marketId)))
+}
+
+fun WsClient.subscribeToPrices(marketId: MarketId) {
+    send(IncomingWSMessage.Subscribe(SubscriptionTopic.Prices(marketId)))
+}
+
+fun WsClient.subscribeToOrders() {
+    send(IncomingWSMessage.Subscribe(SubscriptionTopic.Orders))
+}
+
+fun WsClient.subscribeToTrades() {
+    send(IncomingWSMessage.Subscribe(SubscriptionTopic.Trades))
+}
+
+fun WsClient.subscribeToBalances() {
+    send(IncomingWSMessage.Subscribe(SubscriptionTopic.Balances))
 }
 
 fun WsClient.receivedDecoded(): Sequence<OutgoingWSMessage> =
@@ -26,6 +55,45 @@ fun WsClient.receivedDecoded(): Sequence<OutgoingWSMessage> =
         Json.decodeFromString<OutgoingWSMessage>(it.bodyString())
     }
 
-fun WsClient.waitForMessage(): OutgoingWSMessage.Publish {
-    return receivedDecoded().first() as OutgoingWSMessage.Publish
+inline fun <reified M : Publishable> WsClient.assertMessageReceived(topic: SubscriptionTopic, dataAssertions: (M) -> Unit = {}): M {
+    val message = receivedDecoded().first() as OutgoingWSMessage.Publish
+    assertEquals(topic, message.topic)
+
+    assertIs<M>(message.data)
+    val data = message.data as M
+    dataAssertions(data)
+
+    return data
 }
+
+fun WsClient.assertOrdersMessageReceived(assertions: (Orders) -> Unit = {}): Orders =
+    assertMessageReceived<Orders>(SubscriptionTopic.Orders, assertions)
+
+fun WsClient.assertOrderCreatedMessageReceived(assertions: (OrderCreated) -> Unit = {}): OrderCreated =
+    assertMessageReceived<OrderCreated>(SubscriptionTopic.Orders, assertions)
+
+fun WsClient.assertOrderUpdatedMessageReceived(assertions: (OrderUpdated) -> Unit = {}): OrderUpdated =
+    assertMessageReceived<OrderUpdated>(SubscriptionTopic.Orders, assertions)
+
+fun WsClient.assertTradesMessageReceived(assertions: (Trades) -> Unit = {}): Trades =
+    assertMessageReceived<Trades>(SubscriptionTopic.Trades, assertions)
+
+fun WsClient.assertTradeCreatedMessageReceived(assertions: (TradeCreated) -> Unit = {}): TradeCreated =
+    assertMessageReceived<TradeCreated>(SubscriptionTopic.Trades, assertions)
+
+fun WsClient.assertTradeUpdatedMessageReceived(assertions: (TradeUpdated) -> Unit = {}): TradeUpdated =
+    assertMessageReceived<TradeUpdated>(SubscriptionTopic.Trades, assertions)
+
+fun WsClient.assertBalancesMessageReceived(assertions: (Balances) -> Unit = {}): Balances =
+    assertMessageReceived<Balances>(SubscriptionTopic.Balances, assertions)
+
+fun WsClient.assertPricesMessageReceived(marketId: MarketId, assertions: (Prices) -> Unit = {}): Prices =
+    assertMessageReceived<Prices>(SubscriptionTopic.Prices(marketId), assertions)
+
+fun WsClient.assertOrderBookMessageReceived(marketId: MarketId, assertions: (OrderBook) -> Unit = {}): OrderBook =
+    assertMessageReceived<OrderBook>(SubscriptionTopic.OrderBook(marketId), assertions)
+
+fun WsClient.assertOrderBookMessageReceived(marketId: MarketId, expected: OrderBook): OrderBook =
+    assertMessageReceived<OrderBook>(SubscriptionTopic.OrderBook(marketId)) { msg ->
+        assertEquals(expected, msg)
+    }


### PR DESCRIPTION
Order book projection is reconstructed from the database by Broadcaster whenever it receives `GlobalNotification.OrderBook`. `ExchangeService` sends this event to `Broacaster` whenever it processes sequencer response and there were any created/updated orders.