### PR TITLE
Remove unnecessary responsibilities from blockchain client

### DIFF
--- a/backend/src/main/kotlin/co/chainring/apps/api/ApiApp.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/ApiApp.kt
@@ -7,6 +7,7 @@ import co.chainring.core.blockchain.BlockchainClient
 import co.chainring.core.blockchain.BlockchainClientConfig
 import co.chainring.core.blockchain.BlockchainDepositHandler
 import co.chainring.core.blockchain.BlockchainTransactionHandler
+import co.chainring.core.blockchain.ContractsPublisher
 import co.chainring.core.db.DbConfig
 import co.chainring.core.sequencer.SequencerClient
 import co.chainring.core.services.ExchangeService
@@ -64,6 +65,7 @@ class ApiApp(config: ApiAppConfig = ApiAppConfig()) : BaseApp(config.dbConfig) {
     private val enableTestRoutes = (System.getenv("ENABLE_TEST_ROUTES") ?: "true") == "true"
 
     private val blockchainClient = BlockchainClient(config.blockchainClientConfig)
+    private val contractsPublisher = ContractsPublisher(blockchainClient)
 
     private val sequencerClient = SequencerClient()
     private val broadcaster = Broadcaster(db)
@@ -135,7 +137,7 @@ class ApiApp(config: ApiAppConfig = ApiAppConfig()) : BaseApp(config.dbConfig) {
         super.start()
         server.start()
         broadcaster.start()
-        blockchainClient.updateContracts()
+        contractsPublisher.updateContracts()
         blockchainTransactionHandler.start()
         blockchainDepositHandler.start()
         logger.info { "Started" }

--- a/backend/src/main/kotlin/co/chainring/apps/api/ApiApp.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/ApiApp.kt
@@ -5,6 +5,8 @@ import co.chainring.apps.api.middleware.HttpTransactionLogger
 import co.chainring.apps.api.middleware.RequestProcessingExceptionHandler
 import co.chainring.core.blockchain.BlockchainClient
 import co.chainring.core.blockchain.BlockchainClientConfig
+import co.chainring.core.blockchain.BlockchainDepositHandler
+import co.chainring.core.blockchain.BlockchainTransactionHandler
 import co.chainring.core.db.DbConfig
 import co.chainring.core.sequencer.SequencerClient
 import co.chainring.core.services.ExchangeService
@@ -62,10 +64,13 @@ class ApiApp(config: ApiAppConfig = ApiAppConfig()) : BaseApp(config.dbConfig) {
     private val enableTestRoutes = (System.getenv("ENABLE_TEST_ROUTES") ?: "true") == "true"
 
     private val blockchainClient = BlockchainClient(config.blockchainClientConfig)
+
     private val sequencerClient = SequencerClient()
     private val broadcaster = Broadcaster(db)
 
     private val exchangeService = ExchangeService(blockchainClient, sequencerClient)
+    private val blockchainTransactionHandler = BlockchainTransactionHandler(blockchainClient, exchangeService)
+    private val blockchainDepositHandler = BlockchainDepositHandler(blockchainClient, exchangeService)
 
     private val withdrawalRoutes = WithdrawalRoutes(exchangeService)
     private val balanceRoutes = BalanceRoutes()
@@ -123,12 +128,17 @@ class ApiApp(config: ApiAppConfig = ApiAppConfig()) : BaseApp(config.dbConfig) {
     private val server = PolyHandler(
         httpHandler,
         websockets(websocketApi.connect()),
-    )
-        .asServer(Netty(config.httpPort, ServerConfig.StopMode.Graceful(ofSeconds(1))))
+    ).asServer(Netty(config.httpPort, ServerConfig.StopMode.Graceful(ofSeconds(1))))
 
     override fun start() {
-        startServer()
-        updateContracts()
+        logger.info { "Starting" }
+        super.start()
+        server.start()
+        broadcaster.start()
+        blockchainClient.updateContracts()
+        blockchainTransactionHandler.start()
+        blockchainDepositHandler.start()
+        logger.info { "Started" }
     }
 
     override fun stop() {
@@ -136,23 +146,8 @@ class ApiApp(config: ApiAppConfig = ApiAppConfig()) : BaseApp(config.dbConfig) {
         super.stop()
         broadcaster.stop()
         server.stop()
-        blockchainClient.stop()
+        blockchainTransactionHandler.stop()
+        blockchainDepositHandler.stop()
         logger.info { "Stopped" }
-    }
-
-    fun startServer() {
-        logger.info { "Starting" }
-        super.start()
-        server.start()
-        broadcaster.start()
-        logger.info { "Started" }
-    }
-
-    fun updateContracts() {
-        blockchainClient.updateContracts()
-        blockchainClient.start(
-            exchangeService,
-            exchangeService,
-        )
     }
 }

--- a/backend/src/main/kotlin/co/chainring/core/blockchain/BlockchainClient.kt
+++ b/backend/src/main/kotlin/co/chainring/core/blockchain/BlockchainClient.kt
@@ -5,15 +5,10 @@ import co.chainring.contracts.generated.Exchange
 import co.chainring.contracts.generated.UUPSUpgradeable
 import co.chainring.core.evm.EIP712Transaction
 import co.chainring.core.model.Address
-import co.chainring.core.model.TxHash
-import co.chainring.core.model.db.BlockchainTransactionData
 import co.chainring.core.model.db.ChainId
 import co.chainring.core.model.db.DeployedSmartContractEntity
-import co.chainring.core.model.db.DepositEntity
 import co.chainring.core.model.db.ExchangeTransactionEntity
 import co.chainring.core.model.db.SymbolEntity
-import co.chainring.core.model.db.WalletEntity
-import co.chainring.core.services.TxConfirmationCallback
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.reactivex.Flowable
 import kotlinx.coroutines.future.await
@@ -28,14 +23,13 @@ import org.web3j.protocol.core.DefaultBlockParameter
 import org.web3j.protocol.core.DefaultBlockParameterName
 import org.web3j.protocol.core.methods.request.EthFilter
 import org.web3j.protocol.core.methods.request.Transaction
+import org.web3j.protocol.core.methods.response.Log
 import org.web3j.protocol.core.methods.response.TransactionReceipt
 import org.web3j.protocol.http.HttpService
-import org.web3j.tx.Contract
 import org.web3j.tx.RawTransactionManager
 import org.web3j.tx.response.PollingTransactionReceiptProcessor
 import org.web3j.utils.Async
 import java.math.BigInteger
-import java.util.concurrent.TimeUnit
 
 enum class ContractType {
     Exchange,
@@ -55,45 +49,13 @@ data class BlockchainClientConfig(
         System.getenv(
             "EVM_FEE_ACCOUNT_ADDRESS",
         ) ?: "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
-    val deploymentPollingIntervalInMs: Long = longValue("DEPLOYMENT_POLLING_INTERVAL_MS", 1000L),
-    val maxPollingAttempts: Long = longValue("MAX_POLLING_ATTEMPTS", 120L),
-    val contractCreationLimit: BigInteger = bigIntegerValue("CONTRACT_CREATION_LIMIT", BigInteger.valueOf(5_000_000)),
-    val contractInvocationLimit: BigInteger = bigIntegerValue("CONTRACT_INVOCATION_LIMIT", BigInteger.valueOf(3_000_000)),
-    val defaultMaxPriorityFeePerGasInWei: BigInteger = bigIntegerValue("DEFAULT_MAX_PRIORITY_FEE_PER_GAS_WEI", BigInteger.valueOf(5_000_000_000)),
+    val deploymentPollingIntervalInMs: Long = System.getenv("DEPLOYMENT_POLLING_INTERVAL_MS")?.toLongOrNull() ?: 1000L,
+    val maxPollingAttempts: Long = System.getenv("MAX_POLLING_ATTEMPTS")?.toLongOrNull() ?: 120L,
+    val contractCreationLimit: BigInteger = System.getenv("CONTRACT_CREATION_LIMIT")?.toBigIntegerOrNull() ?: BigInteger.valueOf(5_000_000),
+    val contractInvocationLimit: BigInteger = System.getenv("CONTRACT_INVOCATION_LIMIT")?.toBigIntegerOrNull() ?: BigInteger.valueOf(3_000_000),
+    val defaultMaxPriorityFeePerGasInWei: BigInteger = System.getenv("DEFAULT_MAX_PRIORITY_FEE_PER_GAS_WEI")?.toBigIntegerOrNull() ?: BigInteger.valueOf(5_000_000_000),
     val enableWeb3jLogging: Boolean = (System.getenv("ENABLE_WEB3J_LOGGING") ?: "true") == "true",
-    val pollingIntervalInMs: Long = longValue("POLLING_INTERVAL_MS", 500L),
-    val numConfirmations: Int = intValue("NUM_CONFIRMATIONS", 1),
-) {
-    companion object {
-        fun longValue(name: String, defaultValue: Long): Long {
-            return try {
-                System.getenv(name)?.toLong() ?: defaultValue
-            } catch (e: Exception) {
-                defaultValue
-            }
-        }
-
-        fun intValue(name: String, defaultValue: Int): Int {
-            return try {
-                System.getenv(name)?.toInt() ?: defaultValue
-            } catch (e: Exception) {
-                defaultValue
-            }
-        }
-
-        fun bigIntegerValue(name: String, defaultValue: BigInteger): BigInteger {
-            return try {
-                System.getenv(name)?.let { BigInteger(it) } ?: defaultValue
-            } catch (e: Exception) {
-                defaultValue
-            }
-        }
-    }
-}
-
-interface DepositConfirmationCallback {
-    fun onExchangeContractDepositConfirmation(deposit: DepositEntity)
-}
+)
 
 class BlockchainServerException(message: String) : Exception(message)
 class BlockchainClientException(message: String) : Exception(message)
@@ -101,41 +63,13 @@ class BlockchainClientException(message: String) : Exception(message)
 open class TransactionManagerWithNonceOverride(
     web3j: Web3j,
     val credentials: Credentials,
-    val nonceOverride: BigInteger?,
+    private val nonceOverride: BigInteger,
 ) : RawTransactionManager(web3j, credentials) {
-    lateinit var currentNonce: BigInteger
-
-    override fun getNonce(): BigInteger {
-        currentNonce = nonceOverride ?: super.getNonce()
-        return currentNonce
-    }
-
-    open fun sendPendingTransaction(transactionData: BlockchainTransactionData, gasProvider: GasProvider): BlockchainTransactionData {
-        val response = try {
-            super.sendEIP1559Transaction(
-                gasProvider.chainId,
-                gasProvider.getMaxPriorityFeePerGas(""),
-                gasProvider.getMaxFeePerGas(""),
-                gasProvider.gasLimit,
-                transactionData.to,
-                transactionData.data,
-                transactionData.value,
-            )
-        } catch (e: Exception) {
-            throw BlockchainServerException(e.message ?: "unknown error")
-        }
-        return response.transactionHash?.let {
-            transactionData.copy(
-                nonce = currentNonce,
-                txHash = response.transactionHash,
-            )
-        } ?: response.error?.let { throw BlockchainClientException(it.message) }
-            ?: throw BlockchainServerException("unknown error")
-    }
+    override fun getNonce(): BigInteger =
+        nonceOverride
 }
 
 open class BlockchainClient(private val config: BlockchainClientConfig = BlockchainClientConfig()) {
-
     protected val web3jService: HttpService = httpService(config.url, config.enableWeb3jLogging)
     protected val web3j: Web3j = Web3j.build(
         web3jService,
@@ -155,7 +89,9 @@ open class BlockchainClient(private val config: BlockchainClientConfig = Blockch
         chainId.value.toLong(),
         receiptProcessor,
     )
+
     protected val submitterCredentials = Credentials.create(config.submitterPrivateKeyHex)
+    val submitterAddress: Address = Address(submitterCredentials.address)
 
     val gasProvider = GasProvider(
         contractCreationLimit = config.contractCreationLimit,
@@ -168,11 +104,7 @@ open class BlockchainClient(private val config: BlockchainClientConfig = Blockch
 
     private lateinit var exchangeContract: Exchange
 
-    private var blockchainTransactionHandler: BlockchainTransactionHandler? = null
-    private var blockchainDepositHandler: BlockchainDepositHandler? = null
-
     companion object {
-
         val logger = KotlinLogging.logger {}
         fun httpService(url: String, logging: Boolean): HttpService {
             val builder = OkHttpClient.Builder()
@@ -308,6 +240,9 @@ open class BlockchainClient(private val config: BlockchainClientConfig = Blockch
             getExchangeBalances(walletAddress, tokenAddresses)
         }
 
+    fun loadExchangeContract(): Exchange =
+        loadExchangeContract(contractMap.getValue(ContractType.Exchange))
+
     fun loadExchangeContract(address: Address): Exchange {
         return Exchange.load(address.value, web3j, transactionManager, gasProvider)
     }
@@ -357,83 +292,6 @@ open class BlockchainClient(private val config: BlockchainClientConfig = Blockch
         }
     }
 
-    fun start(txConfirmationCallback: TxConfirmationCallback, depositConfirmationCallback: DepositConfirmationCallback) {
-        blockchainTransactionHandler = BlockchainTransactionHandler(
-            blockchainClient = this,
-            submitterCredentials = submitterCredentials,
-            numConfirmations = config.numConfirmations,
-            pollingIntervalInMs = config.pollingIntervalInMs,
-        ).also {
-            it.start(txConfirmationCallback)
-        }
-
-        blockchainDepositHandler = BlockchainDepositHandler(
-            blockchainClient = this,
-            numConfirmations = config.numConfirmations,
-            pollingIntervalInMs = config.pollingIntervalInMs,
-        ).also {
-            it.start(depositConfirmationCallback)
-        }
-
-        registerDepositEventsConsumer()
-    }
-
-    fun stop() {
-        blockchainTransactionHandler?.stop()
-        blockchainDepositHandler?.stop()
-    }
-
-    private fun registerDepositEventsConsumer() {
-        val exchangeContract = loadExchangeContract(contractMap[ContractType.Exchange]!!)
-
-        val startFromBlock = maxSeenBlockNumber()
-            ?: System.getenv("EVM_NETWORK_EARLIEST_BLOCK")?.let { DefaultBlockParameter.valueOf(it.toBigInteger()) }
-            ?: DefaultBlockParameterName.EARLIEST
-
-        val filter = EthFilter(startFromBlock, DefaultBlockParameterName.LATEST, exchangeContract.contractAddress)
-
+    fun ethLogFlowable(filter: EthFilter): Flowable<Log> =
         web3j.ethLogFlowable(filter)
-            .retryWhen { f: Flowable<Throwable> -> f.take(5).delay(300, TimeUnit.MILLISECONDS) }
-            .subscribe(
-                { eventLog ->
-                    // listen to all events of the exchange contract and manually check for DEPOSIT_EVENT
-                    // exchangeContract.depositEventFlowable(filter) fails with null pointer on any other event form the contract
-                    if (Contract.staticExtractEventParameters(Exchange.DEPOSIT_EVENT, eventLog) != null) {
-                        val depositEventResponse = Exchange.getDepositEventFromLog(eventLog)
-                        logger.debug { "Received deposit event (from: ${depositEventResponse.from}, amount: ${depositEventResponse.amount}, token: ${depositEventResponse.token}, txHash: ${depositEventResponse.log.transactionHash})" }
-
-                        val blockNumber = depositEventResponse.log.blockNumber
-                        val txHash = TxHash(depositEventResponse.log.transactionHash)
-
-                        transaction {
-                            if (DepositEntity.findByTxHash(txHash) != null) {
-                                logger.debug { "Skipping already recorded deposit (tx hash: $txHash)" }
-                            } else {
-                                val walletAddress = Address(depositEventResponse.from)
-                                val wallet = WalletEntity.getOrCreate(walletAddress)
-                                val tokenAddress = Address(depositEventResponse.token).takeIf { it != Address.zero }
-                                val amount = depositEventResponse.amount
-
-                                DepositEntity.create(
-                                    chainId = chainId,
-                                    wallet = wallet,
-                                    tokenAddress = tokenAddress,
-                                    amount = amount,
-                                    blockNumber = blockNumber,
-                                    transactionHash = txHash,
-                                )
-                            }
-                        }
-                    }
-                },
-                { throwable: Throwable ->
-                    logger.error(throwable) { "Unexpected error occurred while processing deposit events" }
-                    registerDepositEventsConsumer()
-                },
-            )
-    }
-
-    private fun maxSeenBlockNumber() = transaction {
-        DepositEntity.maxBlockNumber()?.let { DefaultBlockParameter.valueOf(it) }
-    }
 }

--- a/backend/src/main/kotlin/co/chainring/core/blockchain/BlockchainDepositHandler.kt
+++ b/backend/src/main/kotlin/co/chainring/core/blockchain/BlockchainDepositHandler.kt
@@ -61,13 +61,13 @@ class BlockchainDepositHandler(
     }
 
     private fun registerDepositEventsConsumer() {
-        val exchangeContract = blockchainClient.loadExchangeContract()
+        val exchangeContractAddress = blockchainClient.getContractAddress(ContractType.Exchange)!!.value
 
         val startFromBlock = maxSeenBlockNumber()
             ?: System.getenv("EVM_NETWORK_EARLIEST_BLOCK")?.let { DefaultBlockParameter.valueOf(it.toBigInteger()) }
             ?: DefaultBlockParameterName.EARLIEST
 
-        val filter = EthFilter(startFromBlock, DefaultBlockParameterName.LATEST, exchangeContract.contractAddress)
+        val filter = EthFilter(startFromBlock, DefaultBlockParameterName.LATEST, exchangeContractAddress)
 
         blockchainClient.ethLogFlowable(filter)
             .retryWhen { f: Flowable<Throwable> -> f.take(5).delay(300, TimeUnit.MILLISECONDS) }

--- a/backend/src/main/kotlin/co/chainring/core/blockchain/ContractsPublisher.kt
+++ b/backend/src/main/kotlin/co/chainring/core/blockchain/ContractsPublisher.kt
@@ -1,0 +1,52 @@
+package co.chainring.core.blockchain
+
+import co.chainring.core.model.Address
+import co.chainring.core.model.db.DeployedSmartContractEntity
+import co.chainring.core.model.db.SymbolEntity
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.math.BigInteger
+
+class ContractsPublisher(val blockchainClient: BlockchainClient) {
+    val logger = KotlinLogging.logger {}
+
+    fun updateContracts() {
+        transaction {
+            ContractType.entries.forEach { contractType ->
+                val deployedContract = DeployedSmartContractEntity
+                    .findLastDeployedContractByNameAndChain(contractType.name, blockchainClient.chainId)
+
+                if (deployedContract == null) {
+                    logger.info { "Deploying contract: $contractType" }
+                    deployOrUpgradeWithProxy(contractType, null)
+                } else if (deployedContract.deprecated) {
+                    logger.info { "Upgrading contract: $contractType" }
+                    deployOrUpgradeWithProxy(contractType, deployedContract.proxyAddress)
+                } else {
+                    blockchainClient.setContractAddress(contractType, deployedContract.proxyAddress)
+                }
+            }
+        }
+    }
+
+    private fun deployOrUpgradeWithProxy(contractType: ContractType, existingProxyAddress: Address?) {
+        blockchainClient.deployOrUpgradeWithProxy(
+            when (contractType) {
+                ContractType.Exchange -> BlockchainClient.DeployContractParams.Exchange(
+                    nativePrecision = SymbolEntity.forChain(blockchainClient.chainId)
+                        .firstOrNull { it.contractAddress == null }?.decimals?.toInt()?.toBigInteger()
+                        ?: BigInteger("18"),
+                )
+            },
+            existingProxyAddress,
+        ).also {
+            DeployedSmartContractEntity.create(
+                name = contractType.name,
+                chainId = blockchainClient.chainId,
+                implementationAddress = it.implementationAddress,
+                proxyAddress = it.proxyAddress,
+                version = it.version,
+            )
+        }
+    }
+}

--- a/backend/src/main/kotlin/co/chainring/core/model/db/BlockchainNonce.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/BlockchainNonce.kt
@@ -1,5 +1,6 @@
 package co.chainring.core.model.db
 
+import co.chainring.core.model.Address
 import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
@@ -21,33 +22,32 @@ object BlockchainNonceTable : IntIdTable("blockchain_nonce") {
 
 class BlockchainNonceEntity(id: EntityID<Int>) : IntEntity(id) {
     companion object : IntEntityClass<BlockchainNonceEntity>(BlockchainNonceTable) {
-
-        fun findByKeyAndChain(key: String, chainId: ChainId): BlockchainNonceEntity? {
+        fun findByKeyAndChain(address: Address, chainId: ChainId): BlockchainNonceEntity? {
             return BlockchainNonceEntity.find {
-                BlockchainNonceTable.key eq Keys.toChecksumAddress(key) and
+                BlockchainNonceTable.key eq Keys.toChecksumAddress(address.value) and
                     BlockchainNonceTable.chainId.eq(chainId)
             }.firstOrNull()
         }
 
-        fun create(key: String, chainId: ChainId) {
+        fun create(address: Address, chainId: ChainId) {
             BlockchainNonceTable.insert {
-                it[BlockchainNonceTable.key] = Keys.toChecksumAddress(key)
+                it[BlockchainNonceTable.key] = Keys.toChecksumAddress(address.value)
                 it[BlockchainNonceTable.chainId] = chainId
             }
         }
 
-        fun lockForUpdate(key: String, chainId: ChainId): BlockchainNonceEntity {
+        fun lockForUpdate(address: Address, chainId: ChainId): BlockchainNonceEntity {
             return BlockchainNonceTable.selectAll().where {
-                BlockchainNonceTable.key eq Keys.toChecksumAddress(key) and
+                BlockchainNonceTable.key eq Keys.toChecksumAddress(address.value) and
                     BlockchainNonceTable.chainId.eq(chainId)
             }.forUpdate().map {
                 BlockchainNonceEntity.wrapRow(it)
             }.single()
         }
 
-        fun clearNonce(key: String, chainId: ChainId) {
+        fun clearNonce(address: Address, chainId: ChainId) {
             BlockchainNonceTable.update({
-                BlockchainNonceTable.key eq Keys.toChecksumAddress(key) and
+                BlockchainNonceTable.key eq Keys.toChecksumAddress(address.value) and
                     BlockchainNonceTable.chainId.eq(chainId)
             }) {
                 it[this.nonce] = null

--- a/backend/src/main/kotlin/co/chainring/core/services/ExchangeService.kt
+++ b/backend/src/main/kotlin/co/chainring/core/services/ExchangeService.kt
@@ -13,7 +13,8 @@ import co.chainring.apps.api.model.websocket.TradeCreated
 import co.chainring.apps.api.model.websocket.TradeUpdated
 import co.chainring.core.blockchain.BlockchainClient
 import co.chainring.core.blockchain.ContractType
-import co.chainring.core.blockchain.DepositConfirmationCallback
+import co.chainring.core.blockchain.DepositConfirmationHandler
+import co.chainring.core.blockchain.TxConfirmationHandler
 import co.chainring.core.evm.ECHelper
 import co.chainring.core.evm.EIP712Helper
 import co.chainring.core.evm.EIP712Transaction
@@ -70,15 +71,10 @@ fun BroadcasterNotifications.add(address: Address, publishable: Publishable) {
     this.getOrPut(address) { mutableListOf() }.add(publishable)
 }
 
-interface TxConfirmationCallback {
-    fun onTxConfirmation(tx: EIP712Transaction, error: String?)
-}
-
 class ExchangeService(
     val blockchainClient: BlockchainClient,
     val sequencerClient: SequencerClient,
-) : TxConfirmationCallback, DepositConfirmationCallback {
-
+) : TxConfirmationHandler, DepositConfirmationHandler {
     private val symbolMap = mutableMapOf<String, SymbolEntity>()
     private val marketMap = mutableMapOf<MarketId, MarketEntity>()
     private val logger = KotlinLogging.logger {}

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/testutils/Faucet.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/testutils/Faucet.kt
@@ -16,7 +16,7 @@ object Faucet {
         return blockchainClient.depositNative(address, amount ?: BigDecimal("0.05").toFundamentalUnits(18))
     }
 
-    fun mine(numberOfBlocks: Int = blockchainClient.config.numConfirmations) {
+    fun mine(numberOfBlocks: Int = 1) {
         blockchainClient.mine(numberOfBlocks)
     }
 }

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/testutils/TestBlockchainClient.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/testutils/TestBlockchainClient.kt
@@ -35,7 +35,7 @@ class TestBlockchainClient(val config: BlockchainClientConfig = BlockchainClient
         return EvmSignature((signature.r + signature.s + signature.v).toHex())
     }
 
-    fun mine(numberOfBlocks: Int = config.numConfirmations) {
+    fun mine(numberOfBlocks: Int = 1) {
         Request(
             "anvil_mine",
             listOf(numberOfBlocks),

--- a/src/main/kotlin/co/chainring/tasks/SeedDatabase.kt
+++ b/src/main/kotlin/co/chainring/tasks/SeedDatabase.kt
@@ -23,8 +23,8 @@ fun seedDatabase(fixtures: Fixtures, symbolContractAddresses: List<SymbolContrac
                 ChainEntity.create(chain.id, chain.name).flush()
                 println("Created chain ${chain.name} with id=${chain.id}")
             }
-            if (BlockchainNonceEntity.findByKeyAndChain(chain.submitterAddress.value, chain.id) == null) {
-                BlockchainNonceEntity.create(chain.submitterAddress.value, chain.id)
+            if (BlockchainNonceEntity.findByKeyAndChain(chain.submitterAddress, chain.id) == null) {
+                BlockchainNonceEntity.create(chain.submitterAddress, chain.id)
             }
         }
 


### PR DESCRIPTION
I think `BlockchainClient` should not contain any db logic or threads and should rather be a thin client

- `BlockchainTransactionHandler` and `BlockchainDepositHandler` are separate components that use BlockchainClient
- Removed circular dependency between `BlockchainClient` and `BlockchainTransactionHandler`/`BlockchainDepositHandler`
- Extracted `ContractsPublisher` from `BlockchainClient`