### PR TITLE
Reduce BlockchainClient noise in logs

### DIFF
--- a/backend/src/main/kotlin/co/chainring/core/model/db/BlockchainTransaction.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/BlockchainTransaction.kt
@@ -63,7 +63,6 @@ object BlockchainTransactionTable : GUIDTable<BlockchainTransactionId>("blockcha
 }
 
 class BlockchainTransactionEntity(guid: EntityID<BlockchainTransactionId>) : GUIDEntity<BlockchainTransactionId>(guid) {
-
     companion object : EntityClass<BlockchainTransactionId, BlockchainTransactionEntity>(BlockchainTransactionTable) {
         fun create(
             chainId: ChainId,
@@ -83,7 +82,7 @@ class BlockchainTransactionEntity(guid: EntityID<BlockchainTransactionId>) : GUI
             return entity
         }
 
-        fun getPending(chainId: ChainId): List<BlockchainTransactionEntity> {
+        fun getUncompleted(chainId: ChainId): List<BlockchainTransactionEntity> {
             return BlockchainTransactionEntity.find {
                 BlockchainTransactionTable.chainId.eq(chainId) and
                     BlockchainTransactionTable.status.inList(


### PR DESCRIPTION
- when refreshing transactions in `BlockchainTransactionHandler` request block number only if there are any pending transactions
- when refreshing deposits in `BlockchainDepositHandler` request block number only if there any pending deposits
- log RPC calls in `BlockchainClient` with one log statement
- filter out RPC calls to get exchange contract events unless we actually get any events in response (`BlockchainDepositHandler` makes this call every 300 ms)