### PR TITLE
use duration enum values instead of ms

### DIFF
--- a/backend/src/main/kotlin/co/chainring/apps/api/model/websocket/OutgoingWSMessage.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/model/websocket/OutgoingWSMessage.kt
@@ -72,7 +72,7 @@ data class OHLC(
     val high: Double,
     val low: Double,
     val close: Double,
-    val durationMs: Long,
+    val duration: OHLCDuration,
 )
 
 @Serializable

--- a/backend/src/main/kotlin/co/chainring/core/model/db/OHLC.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/OHLC.kt
@@ -116,7 +116,7 @@ class OHLCEntity(guid: EntityID<OHLCId>) : GUIDEntity<OHLCId>(guid) {
             high = this.high.toDouble(),
             low = this.low.toDouble(),
             close = this.close.toDouble(),
-            durationMs = this.duration.durationMs(),
+            duration = this.duration,
         )
     }
 

--- a/backend/src/main/kotlin/co/chainring/core/model/db/OHLC.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/OHLC.kt
@@ -34,6 +34,7 @@ import org.jetbrains.exposed.sql.statements.UpsertStatement
 import org.jetbrains.exposed.sql.upsert
 import java.math.BigDecimal
 import java.math.BigInteger
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
@@ -68,14 +69,14 @@ enum class OHLCDuration {
         }
     }
 
-    fun durationMs(): Long {
+    fun interval(): Duration {
         return when (this) {
-            P1M -> 1.minutes.inWholeMilliseconds
-            P5M -> 5.minutes.inWholeMilliseconds
-            P15M -> 15.minutes.inWholeMilliseconds
-            P1H -> 1.hours.inWholeMilliseconds
-            P4H -> 4.hours.inWholeMilliseconds
-            P1D -> 1.days.inWholeMilliseconds
+            P1M -> 1.minutes
+            P5M -> 5.minutes
+            P15M -> 15.minutes
+            P1H -> 1.hours
+            P4H -> 4.hours
+            P1D -> 1.days
         }
     }
 }

--- a/backend/src/main/kotlin/co/chainring/core/utils/PgListener.kt
+++ b/backend/src/main/kotlin/co/chainring/core/utils/PgListener.kt
@@ -11,6 +11,7 @@ class PgListener(
     private val database: Database,
     private val threadName: String,
     private val channel: String,
+    onReconnect: () -> Unit,
     onNotifyLogic: (PGNotification) -> Unit,
 ) {
     private var reconnectDebounceMs = 1000L
@@ -55,6 +56,7 @@ class PgListener(
             } catch (t: Throwable) {
                 logger.error(t) { "Caught an exception" }
                 Thread.sleep(reconnectDebounceMs)
+                onReconnect()
             }
         }
     }

--- a/backend/src/test/kotlin/co/chainring/core/ohlc/OHLCDurationTest.kt
+++ b/backend/src/test/kotlin/co/chainring/core/ohlc/OHLCDurationTest.kt
@@ -77,7 +77,7 @@ class OHLCDurationTest : TestWithDb() {
                         high = tradePrice.toDouble(),
                         low = tradePrice.toDouble(),
                         close = tradePrice.toDouble(),
-                        durationMs = it.durationMs(),
+                        duration = it,
                     )
                 }.toSet(),
                 actual = OHLCEntity.all().toSet().map { it.toWSResponse() }.toSet(),
@@ -99,7 +99,7 @@ class OHLCDurationTest : TestWithDb() {
                         high = higherTradePrice.toDouble(),
                         low = tradePrice.toDouble(),
                         close = higherTradePrice.toDouble(),
-                        durationMs = it.durationMs(),
+                        duration = it,
                     )
                 }.toSet(),
                 actual = OHLCEntity.all().map { it.toWSResponse() }.toSet(),
@@ -124,7 +124,7 @@ class OHLCDurationTest : TestWithDb() {
                         high = higherTradePrice.toDouble(),
                         low = lowerTradePrice.toDouble(),
                         close = lowerTradePrice.toDouble(),
-                        durationMs = it.durationMs(),
+                        duration = it,
                     )
                 }.toSet(),
                 actual = OHLCEntity.all().map { it.toWSResponse() }.toSet(),
@@ -150,7 +150,7 @@ class OHLCDurationTest : TestWithDb() {
                                 high = higherTradePrice.toDouble(),
                                 low = lowerTradePrice.toDouble(),
                                 close = lowerTradePrice.toDouble(),
-                                durationMs = it.durationMs(),
+                                duration = it,
                             ),
                             OHLC(
                                 start = it.durationStart(nextMinute),
@@ -158,7 +158,7 @@ class OHLCDurationTest : TestWithDb() {
                                 high = lowerTradePrice.toDouble(),
                                 low = lowerTradePrice.toDouble(),
                                 close = lowerTradePrice.toDouble(),
-                                durationMs = it.durationMs(),
+                                duration = it,
                             ),
                         )
 
@@ -169,7 +169,7 @@ class OHLCDurationTest : TestWithDb() {
                                 high = higherTradePrice.toDouble(),
                                 low = lowerTradePrice.toDouble(),
                                 close = lowerTradePrice.toDouble(),
-                                durationMs = it.durationMs(),
+                                duration = it,
                             ),
                         )
                     }
@@ -194,7 +194,7 @@ class OHLCDurationTest : TestWithDb() {
                                 high = higherTradePrice.toDouble(),
                                 low = lowerTradePrice.toDouble(),
                                 close = lowerTradePrice.toDouble(),
-                                durationMs = it.durationMs(),
+                                duration = it,
                             ),
                             OHLC(
                                 start = it.durationStart(nextMinute),
@@ -202,7 +202,7 @@ class OHLCDurationTest : TestWithDb() {
                                 high = lowerTradePrice.toDouble(),
                                 low = lowerTradePrice.toDouble(),
                                 close = lowerTradePrice.toDouble(),
-                                durationMs = it.durationMs(),
+                                duration = it,
                             ),
                             OHLC(
                                 start = it.durationStart(nextFiveMinutes),
@@ -210,7 +210,7 @@ class OHLCDurationTest : TestWithDb() {
                                 high = higherTradePrice.toDouble(),
                                 low = higherTradePrice.toDouble(),
                                 close = higherTradePrice.toDouble(),
-                                durationMs = it.durationMs(),
+                                duration = it,
                             ),
                         )
 
@@ -221,7 +221,7 @@ class OHLCDurationTest : TestWithDb() {
                                 high = higherTradePrice.toDouble(),
                                 low = lowerTradePrice.toDouble(),
                                 close = lowerTradePrice.toDouble(),
-                                durationMs = it.durationMs(),
+                                duration = it,
                             ),
                             OHLC(
                                 start = it.durationStart(nextFiveMinutes),
@@ -229,7 +229,7 @@ class OHLCDurationTest : TestWithDb() {
                                 high = higherTradePrice.toDouble(),
                                 low = higherTradePrice.toDouble(),
                                 close = higherTradePrice.toDouble(),
-                                durationMs = it.durationMs(),
+                                duration = it,
                             ),
                         )
 
@@ -240,7 +240,7 @@ class OHLCDurationTest : TestWithDb() {
                                 high = higherTradePrice.toDouble(),
                                 low = lowerTradePrice.toDouble(),
                                 close = higherTradePrice.toDouble(),
-                                durationMs = it.durationMs(),
+                                duration = it,
                             ),
                         )
                     }

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/OrderRoutesApiTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/OrderRoutesApiTest.kt
@@ -590,7 +590,7 @@ class OrderRoutesApiTest {
                     high = 17.55,
                     low = 17.55,
                     close = 17.55,
-                    durationMs = 300000,
+                    duration = OHLCDuration.P5M,
                 ),
                 msg.ohlc.last(),
             )
@@ -603,7 +603,7 @@ class OrderRoutesApiTest {
                     high = 17.55,
                     low = 17.55,
                     close = 17.55,
-                    durationMs = 300000,
+                    duration = OHLCDuration.P5M,
                 ),
                 msg.ohlc.last(),
             )
@@ -728,7 +728,7 @@ class OrderRoutesApiTest {
                     high = 17.55,
                     low = 17.5,
                     close = 17.5,
-                    durationMs = 300000,
+                    duration = OHLCDuration.P5M,
                 ),
                 msg.ohlc.last(),
             )
@@ -741,7 +741,7 @@ class OrderRoutesApiTest {
                     high = 17.55,
                     low = 17.5,
                     close = 17.5,
-                    durationMs = 300000,
+                    duration = OHLCDuration.P5M,
                 ),
                 msg.ohlc.last(),
             )

--- a/web-ui/src/components/Screens/HomeScreen/BalancesWidget.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/BalancesWidget.tsx
@@ -1,6 +1,6 @@
 import { Address, formatUnits } from 'viem'
 import { Balance, TradingSymbol } from 'apiClient'
-import React, { Fragment, useMemo, useState } from 'react'
+import React, { Fragment, useCallback, useMemo, useState } from 'react'
 import DepositModal from 'components/Screens/HomeScreen/DepositModal'
 import WithdrawalModal from 'components/Screens/HomeScreen/WithdrawalModal'
 import { Widget } from 'components/common/Widget'
@@ -53,11 +53,11 @@ function BalancesTable({
   const [balances, setBalances] = useState<Balance[]>(() => [])
   useWebsocketSubscription({
     topics: useMemo(() => [balancesTopic], []),
-    handler: (message: Publishable) => {
+    handler: useCallback((message: Publishable) => {
       if (message.type === 'Balances') {
         setBalances(message.balances)
       }
-    }
+    }, [])
   })
 
   function openDepositModal(symbol: TradingSymbol) {

--- a/web-ui/src/components/Screens/HomeScreen/OrderBookWidget.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/OrderBookWidget.tsx
@@ -1,6 +1,6 @@
 import { Widget } from 'components/common/Widget'
 import { calculateTickSpacing } from 'utils/orderBookUtils'
-import { Fragment, useEffect, useMemo, useState } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 import Spinner from 'components/common/Spinner'
 import { OrderBook, Publishable, orderBookTopic } from 'websocketMessages'
 import { useWebsocketSubscription } from 'contexts/websocket'
@@ -77,11 +77,11 @@ export function OrderBookWidget({ marketId }: { marketId: string }) {
 
   useWebsocketSubscription({
     topics: useMemo(() => [orderBookTopic(marketId)], [marketId]),
-    handler: (message: Publishable) => {
+    handler: useCallback((message: Publishable) => {
       if (message.type === 'OrderBook') {
         setOrderBook(message)
       }
-    }
+    }, [])
   })
 
   useEffect(() => {

--- a/web-ui/src/components/Screens/HomeScreen/OrdersAndTradesWidget.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/OrdersAndTradesWidget.tsx
@@ -1,5 +1,5 @@
 import { apiClient, Order, Trade, UpdateOrderRequest } from 'apiClient'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Widget } from 'components/common/Widget'
 import { TrashIcon } from '@heroicons/react/24/outline'
 import { formatUnits, parseUnits } from 'viem'
@@ -30,7 +30,7 @@ export default function OrdersAndTradesWidget({
 
   useWebsocketSubscription({
     topics: useMemo(() => [ordersTopic, tradesTopic], []),
-    handler: (message: Publishable) => {
+    handler: useCallback((message: Publishable) => {
       if (message.type === 'Orders') {
         setOrders(message.orders)
       } else if (message.type === 'OrderCreated') {
@@ -69,7 +69,7 @@ export default function OrdersAndTradesWidget({
           })
         )
       }
-    }
+    }, [])
   })
 
   function cancelOrder(id: string) {

--- a/web-ui/src/components/Screens/HomeScreen/PricesWidget.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/PricesWidget.tsx
@@ -16,7 +16,7 @@ import {
   pricesTopic,
   Publishable
 } from 'websocketMessages'
-import { mergeOHLC } from 'utils/pricesUtils'
+import { mergeOHLC, olhcDurationsMs } from 'utils/pricesUtils'
 import { useWebsocketSubscription } from 'contexts/websocket'
 import { useWindowDimensions, widgetSize, WindowDimensions } from 'utils/layout'
 import { produce } from 'immer'
@@ -38,15 +38,6 @@ type PriceParameters = {
   tickRange: number
   gridSpacing: number
   ticks: number[]
-}
-
-const durationsMs: Record<OHLCDuration, number> = {
-  ['P1M']: 60 * 1000,
-  ['P5M']: 5 * 60 * 1000,
-  ['P15M']: 15 * 60 * 1000,
-  ['P1H']: 60 * 60 * 1000,
-  ['P4H']: 4 * 60 * 60 * 1000,
-  ['P1D']: 24 * 60 * 60 * 1000
 }
 
 type ViewPort = {
@@ -122,11 +113,11 @@ export function PricesWidget({ marketId }: { marketId: string }) {
       (message: Publishable) => {
         if (message.type === 'Prices') {
           if (message.full) {
-            setOhlc(mergeOHLC([], message.ohlc, durationsMs[duration]))
+            setOhlc(mergeOHLC([], message.ohlc, duration))
           } else {
             setOhlc(
               produce((draft) => {
-                mergeOHLC(draft, message.ohlc, durationsMs[duration])
+                mergeOHLC(draft, message.ohlc, duration)
               })
             )
           }
@@ -487,7 +478,7 @@ export function PricesWidget({ marketId }: { marketId: string }) {
       viewPort.latestStart
         ? viewPort.latestStart.getTime()
         : lastDate.getTime() +
-          durationsMs[viewportOhlc[viewportOhlc.length - 1].duration]
+          olhcDurationsMs[viewportOhlc[viewportOhlc.length - 1].duration]
     )
     if (endDate.getDate() == startDate.getDate()) {
       return `${startDate.toLocaleDateString()}, ${startDate.toLocaleTimeString()} to ${endDate.toLocaleTimeString()}`

--- a/web-ui/src/contexts/websocket.tsx
+++ b/web-ui/src/contexts/websocket.tsx
@@ -172,8 +172,6 @@ export function useWebsocketSubscription({
   topics: SubscriptionTopic[]
   handler: SubscriptionEventHandler
 }) {
-  const handlerRef = useRef(handler)
-
   const context = useContext(WebsocketContext)
   if (!context) {
     throw Error(
@@ -183,11 +181,10 @@ export function useWebsocketSubscription({
   const { subscribe, unsubscribe } = context
 
   useEffect(() => {
-    const handler = handlerRef.current
     topics.forEach((t) => subscribe(t, handler))
 
     return () => {
       topics.forEach((t) => unsubscribe(t, handler))
     }
-  }, [topics, subscribe, unsubscribe])
+  }, [topics, subscribe, unsubscribe, handler])
 }

--- a/web-ui/src/utils/pricesUtils.ts
+++ b/web-ui/src/utils/pricesUtils.ts
@@ -1,12 +1,21 @@
-import { OHLC } from 'websocketMessages'
+import { OHLC, OHLCDuration } from 'websocketMessages'
+
+export const olhcDurationsMs: Record<OHLCDuration, number> = {
+  ['P1M']: 60 * 1000,
+  ['P5M']: 5 * 60 * 1000,
+  ['P15M']: 15 * 60 * 1000,
+  ['P1H']: 60 * 60 * 1000,
+  ['P4H']: 4 * 60 * 60 * 1000,
+  ['P1D']: 24 * 60 * 60 * 1000
+}
 
 export function mergeOHLC(
   draft: OHLC[],
   incoming: OHLC[],
-  durationMs: number
+  duration: OHLCDuration
 ): OHLC[] {
   // update completes of last item before merge
-  updateLastItemCompleteness(draft, durationMs)
+  updateLastItemCompleteness(draft, olhcDurationsMs[duration])
 
   // merge new data
   incoming.forEach((newItem) => {
@@ -16,7 +25,7 @@ export function mergeOHLC(
     )
     if (index == -1) {
       // fill gaps before pushing new ohlc
-      fillGaps(draft, newItem, durationMs)
+      fillGaps(draft, newItem, olhcDurationsMs[duration])
 
       draft.push(newItem)
     } else {
@@ -24,7 +33,7 @@ export function mergeOHLC(
     }
   })
   // update completes of last item after merge
-  updateLastItemCompleteness(draft, durationMs)
+  updateLastItemCompleteness(draft, olhcDurationsMs[duration])
   return draft
 }
 

--- a/web-ui/src/utils/pricesUtils.ts
+++ b/web-ui/src/utils/pricesUtils.ts
@@ -11,7 +11,7 @@ export function mergeOHLC(
   // merge new data
   incoming.forEach((newItem) => {
     // lookup if recent item is being replaced
-    const index = draft.findLastIndex(
+    const index = draft.findIndex(
       (i) => i.start.getTime() == newItem.start.getTime()
     )
     if (index == -1) {

--- a/web-ui/src/utils/test.ts
+++ b/web-ui/src/utils/test.ts
@@ -48,7 +48,7 @@ describe('PricesUtils', () => {
       mergeOHLC(
         [ohlc(60000, 'P1M', 2, 4, 1, 3)],
         [ohlc(12000, 'P1M', 2, 4, 1, 3)],
-        60000
+        'P1M'
       )
     ).toStrictEqual([ohlc(1000, 'P1M', 2, 4, 1, 3)])
   })
@@ -57,7 +57,7 @@ describe('PricesUtils', () => {
       mergeOHLC(
         [ohlc(60000, 'P1M', 2, 4, 1, 3)],
         [ohlc(60000, 'P1M', 2, 5, 1, 5)],
-        60000
+        'P1M'
       )
     ).toStrictEqual([ohlc(60000, 'P1M', 2, 5, 1, 5)])
   })
@@ -66,7 +66,7 @@ describe('PricesUtils', () => {
       mergeOHLC(
         [ohlc(60000, 'P1M', 2, 4, 1, 3), ohlc(120000, 'P1M', 2, 4, 1, 3)],
         [ohlc(120000, 'P1M', 2, 5, 1, 5), ohlc(180000, 'P1M', 3, 3, 3, 3)],
-        60000
+        'P1M'
       )
     ).toStrictEqual([
       ohlc(60000, 'P1M', 2, 4, 1, 3),
@@ -79,7 +79,7 @@ describe('PricesUtils', () => {
       mergeOHLC(
         [ohlc(60000, 'P1M', 2, 4, 1, 3), ohlc(120000, 'P1M', 3, 5, 0, 4)],
         [ohlc(300000, 'P1M', 2, 5, 1, 5)],
-        60000
+        'P1M'
       )
     ).toStrictEqual([
       ohlc(60000, 'P1M', 2, 4, 1, 3),

--- a/web-ui/src/utils/test.ts
+++ b/web-ui/src/utils/test.ts
@@ -1,5 +1,6 @@
 import { calculateTickSpacing } from 'utils/orderBookUtils'
 import { mergeOHLC } from 'utils/pricesUtils'
+import { OHLCDuration } from 'websocketMessages'
 
 describe('OrderBookUtils', () => {
   it('should work for different values', () => {
@@ -24,7 +25,7 @@ describe('OrderBookUtils', () => {
 describe('PricesUtils', () => {
   function ohlc(
     startMs: number,
-    durationMs: number,
+    duration: OHLCDuration,
     open: number,
     high: number,
     low: number,
@@ -37,7 +38,7 @@ describe('PricesUtils', () => {
       high,
       low,
       close,
-      durationMs,
+      duration,
       incomplete
     }
   }
@@ -45,47 +46,47 @@ describe('PricesUtils', () => {
   it('should work as a no-op', () => {
     expect(
       mergeOHLC(
-        [ohlc(1000, 1000, 2, 4, 1, 3)],
-        [ohlc(1000, 1000, 2, 4, 1, 3)],
-        1000
+        [ohlc(60000, 'P1M', 2, 4, 1, 3)],
+        [ohlc(12000, 'P1M', 2, 4, 1, 3)],
+        60000
       )
-    ).toStrictEqual([ohlc(1000, 1000, 2, 4, 1, 3)])
+    ).toStrictEqual([ohlc(1000, 'P1M', 2, 4, 1, 3)])
   })
   it('should replace ohlc matched by start', () => {
     expect(
       mergeOHLC(
-        [ohlc(1000, 1000, 2, 4, 1, 3)],
-        [ohlc(1000, 1000, 2, 5, 1, 5)],
-        1000
+        [ohlc(60000, 'P1M', 2, 4, 1, 3)],
+        [ohlc(60000, 'P1M', 2, 5, 1, 5)],
+        60000
       )
-    ).toStrictEqual([ohlc(1000, 1000, 2, 5, 1, 5)])
+    ).toStrictEqual([ohlc(60000, 'P1M', 2, 5, 1, 5)])
   })
   it('should replace and add ohlc matched by start', () => {
     expect(
       mergeOHLC(
-        [ohlc(2000, 1000, 2, 4, 1, 3), ohlc(3000, 1000, 2, 4, 1, 3)],
-        [ohlc(3000, 1000, 2, 5, 1, 5), ohlc(4000, 1000, 3, 3, 3, 3)],
-        1000
+        [ohlc(60000, 'P1M', 2, 4, 1, 3), ohlc(120000, 'P1M', 2, 4, 1, 3)],
+        [ohlc(120000, 'P1M', 2, 5, 1, 5), ohlc(180000, 'P1M', 3, 3, 3, 3)],
+        60000
       )
     ).toStrictEqual([
-      ohlc(2000, 1000, 2, 4, 1, 3),
-      ohlc(3000, 1000, 2, 5, 1, 5),
-      ohlc(4000, 1000, 3, 3, 3, 3)
+      ohlc(60000, 'P1M', 2, 4, 1, 3),
+      ohlc(120000, 'P1M', 2, 5, 1, 5),
+      ohlc(180000, 'P1M', 3, 3, 3, 3)
     ])
   })
   it('should fill-in any gaps', () => {
     expect(
       mergeOHLC(
-        [ohlc(1000, 500, 2, 4, 1, 3), ohlc(1500, 500, 3, 5, 0, 4)],
-        [ohlc(3000, 500, 2, 5, 1, 5)],
-        500
+        [ohlc(60000, 'P1M', 2, 4, 1, 3), ohlc(120000, 'P1M', 3, 5, 0, 4)],
+        [ohlc(300000, 'P1M', 2, 5, 1, 5)],
+        60000
       )
     ).toStrictEqual([
-      ohlc(1000, 500, 2, 4, 1, 3),
-      ohlc(1500, 500, 3, 5, 0, 4),
-      ohlc(2000, 500, 4, 4, 4, 4),
-      ohlc(2500, 500, 4, 4, 4, 4),
-      ohlc(3000, 500, 2, 5, 1, 5)
+      ohlc(60000, 'P1M', 2, 4, 1, 3),
+      ohlc(120000, 'P1M', 3, 5, 0, 4),
+      ohlc(180000, 'P1M', 4, 4, 4, 4),
+      ohlc(240000, 'P1M', 4, 4, 4, 4),
+      ohlc(300000, 'P1M', 2, 5, 1, 5)
     ])
   })
 })

--- a/web-ui/src/websocketMessages.ts
+++ b/web-ui/src/websocketMessages.ts
@@ -51,9 +51,19 @@ export const OrderBookSchema = z.object({
 })
 export type OrderBook = z.infer<typeof OrderBookSchema>
 
+export const OHLCDurationSchema = z.enum([
+  'P1M',
+  'P5M',
+  'P15M',
+  'P1H',
+  'P4H',
+  'P1D'
+])
+export type OHLCDuration = z.infer<typeof OHLCDurationSchema>
+
 const OHLCSchema = z.object({
   start: z.coerce.date(),
-  durationMs: z.number(),
+  duration: OHLCDurationSchema,
   open: z.number(),
   high: z.number(),
   low: z.number(),


### PR DESCRIPTION
- duration enum instead of ms for OHLC messages
- fix ohlc gap filling on other intervals than 5m
- re-fetch full prices when pg listener reconnects