### PR TITLE
CHAIN-88 initial tracing / load testing infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ run_backend:
 run_sequencer:
 	SANDBOX_MODE=true ./gradlew :sequencer:run
 
+run_mocker:
+	./gradlew :mocker:run
+
 run_ui:
 	cd web-ui && pnpm install && pnpm run dev
 

--- a/backend/src/main/kotlin/co/chainring/apps/api/ApiApp.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/ApiApp.kt
@@ -3,6 +3,7 @@ package co.chainring.apps.api
 import co.chainring.apps.BaseApp
 import co.chainring.apps.api.middleware.HttpTransactionLogger
 import co.chainring.apps.api.middleware.RequestProcessingExceptionHandler
+import co.chainring.apps.api.middleware.Tracer
 import co.chainring.apps.api.services.ExchangeApiService
 import co.chainring.core.blockchain.BlockchainClient
 import co.chainring.core.blockchain.BlockchainClientConfig
@@ -87,6 +88,7 @@ class ApiApp(config: ApiAppConfig = ApiAppConfig()) : BaseApp(config.dbConfig) {
                 },
                 endReportFn = { _, _, _ ->
                     MDC.remove("traceId")
+                    Tracer.reset()
                 },
             ),
         )

--- a/backend/src/main/kotlin/co/chainring/apps/api/middleware/Tracer.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/middleware/Tracer.kt
@@ -2,7 +2,7 @@ package co.chainring.apps.api.middleware
 
 object ServerSpans {
     val app = "app"
-    val sqrCli = "sqrCli"
+    val sqrClt = "sqrClt"
     val gtw = "gtw"
     val sqr = "sqr"
 }

--- a/backend/src/main/kotlin/co/chainring/apps/api/middleware/Tracer.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/middleware/Tracer.kt
@@ -1,0 +1,72 @@
+package co.chainring.apps.api.middleware
+
+object ServerSpans {
+    val app = "app"
+    val sqrCli = "sqrCli"
+    val gtw = "gtw"
+    val sqr = "sqr"
+}
+
+data class Span(
+    val name: String,
+    val start: Long?,
+    val duration: Long,
+)
+
+object Tracer {
+    private val traces = ThreadLocal.withInitial { mutableListOf<Span>() }
+
+    fun <T> newSpan(name: String, body: () -> T): T {
+        System.nanoTime().let { start ->
+            return body().also {
+                val duration = System.nanoTime() - start
+                traces.get().add(Span(name, start, duration))
+            }
+        }
+    }
+
+    suspend fun <T> newCoroutineSpan(name: String, body: suspend () -> T): T {
+        System.nanoTime().let { start ->
+            return body().also {
+                val duration = System.nanoTime() - start
+                traces.get().add(Span(name, start, duration))
+            }
+        }
+    }
+
+    fun newSpan(name: String, duration: Long, start: Long? = null) {
+        traces.get().add(Span(name, start, duration))
+    }
+
+    fun getDuration(name: String): Long? = traces.get().firstOrNull { it.name == name }?.duration
+
+    fun serialize(): String = buildString {
+        val traces: List<Span> = traces.get()
+
+        traces.forEachIndexed { index, key ->
+            if (index > 0) {
+                append(", ")
+            }
+            append("${key.name};dur=${key.duration}")
+            key.start?.let { append(";start=$it") }
+        }
+    }
+
+    fun deserialize(value: String): List<Span> {
+        if (value.isBlank()) return emptyList()
+
+        return value.split(", ").map { spanString ->
+            val fields = spanString.split(";")
+            val spanName = fields[0]
+            val duration = fields.firstOrNull { it.startsWith("dur=") }?.split("=")?.get(1)?.toLong()
+                ?: throw IllegalArgumentException("Unexpected span duration")
+            val start = fields.firstOrNull { it.startsWith("start=") }?.split("=")?.get(1)?.toLong()
+
+            Span(spanName, start, duration)
+        }
+    }
+
+    fun reset() {
+        traces.get().clear()
+    }
+}

--- a/backend/src/main/kotlin/co/chainring/core/sequencer/SequencerClient.kt
+++ b/backend/src/main/kotlin/co/chainring/core/sequencer/SequencerClient.kt
@@ -93,7 +93,7 @@ open class SequencerClient {
         ordersToCancel: List<OrderId>,
         cancelAll: Boolean = false,
     ): SequencerResponse {
-        return Tracer.newCoroutineSpan(ServerSpans.sqrCli) {
+        return Tracer.newCoroutineSpan(ServerSpans.sqrClt) {
             stub.applyOrderBatch(
                 orderBatch {
                     this.marketId = marketId.value
@@ -117,7 +117,7 @@ open class SequencerClient {
     }
 
     suspend fun createMarket(marketId: String, tickSize: BigDecimal = "0.05".toBigDecimal(), marketPrice: BigDecimal, baseDecimals: Int, quoteDecimals: Int): SequencerResponse {
-        return Tracer.newCoroutineSpan(ServerSpans.sqrCli) {
+        return Tracer.newCoroutineSpan(ServerSpans.sqrClt) {
             stub.addMarket(
                 market {
                     this.guid = UUID.randomUUID().toString()
@@ -142,7 +142,7 @@ open class SequencerClient {
         amount: BigInteger,
         depositId: DepositId,
     ): SequencerResponse {
-        return Tracer.newCoroutineSpan(ServerSpans.sqrCli) {
+        return Tracer.newCoroutineSpan(ServerSpans.sqrClt) {
             stub.applyBalanceBatch(
                 balanceBatch {
                     this.guid = UUID.randomUUID().toString()
@@ -170,7 +170,7 @@ open class SequencerClient {
         evmSignature: EvmSignature,
         withdrawalId: WithdrawalId,
     ): SequencerResponse {
-        return Tracer.newCoroutineSpan(ServerSpans.sqrCli) {
+        return Tracer.newCoroutineSpan(ServerSpans.sqrClt) {
             stub.applyBalanceBatch(
                 balanceBatch {
                     this.guid = UUID.randomUUID().toString()

--- a/backend/src/main/resources/log4j2.xml
+++ b/backend/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration packages="co.chainring.core.utils" status="INFO">
     <Properties>
-        <Property name="LOG_PATTERN">%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1} [traceId:%X{traceId}] - %m%n</Property>
+        <Property name="LOG_PATTERN">%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1} - %m%n</Property>
     </Properties>
 
     <Appenders>

--- a/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/ApiClient.kt
+++ b/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/ApiClient.kt
@@ -44,7 +44,7 @@ import org.web3j.crypto.Keys
 import java.net.HttpURLConnection
 import java.util.Base64
 
-val apiServerRootUrl = System.getenv("API_URL") ?: "http://localhost:9000"
+val apiServerRootUrl = System.getenv("API_URL") ?: "http://localhost:9999"
 val httpClient = OkHttpClient.Builder().build()
 val applicationJson = "application/json".toMediaType()
 

--- a/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/ApiClient.kt
+++ b/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/ApiClient.kt
@@ -44,7 +44,7 @@ import org.web3j.crypto.Keys
 import java.net.HttpURLConnection
 import java.util.Base64
 
-val apiServerRootUrl = System.getenv("API_URL") ?: "http://localhost:9999"
+val apiServerRootUrl = System.getenv("API_URL") ?: "http://localhost:9000"
 val httpClient = OkHttpClient.Builder().build()
 val applicationJson = "application/json".toMediaType()
 
@@ -55,7 +55,7 @@ data class ApiCallFailure(
     val error: ApiError,
 )
 
-class ApiClient(val ecKeyPair: ECKeyPair = Keys.createEcKeyPair()) {
+class ApiClient(val ecKeyPair: ECKeyPair = Keys.createEcKeyPair(), val traceRecorder: TraceRecorder = TraceRecorder.noOp) {
     val authToken: String = issueAuthToken(ecKeyPair = ecKeyPair)
 
     companion object {
@@ -160,7 +160,8 @@ class ApiClient(val ecKeyPair: ECKeyPair = Keys.createEcKeyPair()) {
         tryGetConfiguration().assertSuccess()
 
     fun tryGetConfiguration(): Either<ApiCallFailure, ConfigurationApiResponse> =
-        execute(
+        executeAndTrace(
+            TraceRecorder.Op.GetConfiguration,
             Request.Builder()
                 .url("$apiServerRootUrl/v1/config")
                 .get()
@@ -171,7 +172,8 @@ class ApiClient(val ecKeyPair: ECKeyPair = Keys.createEcKeyPair()) {
         tryCreateOrder(apiRequest).assertSuccess()
 
     fun tryCreateOrder(apiRequest: CreateOrderApiRequest): Either<ApiCallFailure, CreateOrderApiResponse> =
-        execute(
+        executeAndTrace(
+            TraceRecorder.Op.CreateOrder,
             Request.Builder()
                 .url("$apiServerRootUrl/v1/orders")
                 .post(Json.encodeToString(apiRequest).toRequestBody(applicationJson))
@@ -183,7 +185,8 @@ class ApiClient(val ecKeyPair: ECKeyPair = Keys.createEcKeyPair()) {
         tryBatchOrders(apiRequest).assertSuccess()
 
     fun tryBatchOrders(apiRequest: BatchOrdersApiRequest): Either<ApiCallFailure, BatchOrdersApiResponse> =
-        execute(
+        executeAndTrace(
+            TraceRecorder.Op.BatchOrders,
             Request.Builder()
                 .url("$apiServerRootUrl/v1/batch/orders")
                 .post(Json.encodeToString(apiRequest).toRequestBody(applicationJson))
@@ -196,7 +199,8 @@ class ApiClient(val ecKeyPair: ECKeyPair = Keys.createEcKeyPair()) {
     }
 
     fun tryUpdateOrder(apiRequest: UpdateOrderApiRequest): Either<ApiCallFailure, UpdateOrderApiResponse> =
-        execute(
+        executeAndTrace(
+            TraceRecorder.Op.UpdateOrder,
             Request.Builder()
                 .url("$apiServerRootUrl/v1/orders/${apiRequest.orderId}")
                 .patch(Json.encodeToString(apiRequest).toRequestBody(applicationJson))
@@ -208,7 +212,8 @@ class ApiClient(val ecKeyPair: ECKeyPair = Keys.createEcKeyPair()) {
         tryCancelOrder(id).assertSuccess()
 
     fun tryCancelOrder(id: OrderId): Either<ApiCallFailure, Unit> =
-        execute(
+        executeAndTrace(
+            TraceRecorder.Op.CancelOrder,
             Request.Builder()
                 .url("$apiServerRootUrl/v1/orders/$id")
                 .delete()
@@ -220,7 +225,8 @@ class ApiClient(val ecKeyPair: ECKeyPair = Keys.createEcKeyPair()) {
         tryGetOrder(id).assertSuccess()
 
     fun tryGetOrder(id: OrderId): Either<ApiCallFailure, Order> =
-        execute(
+        executeAndTrace(
+            TraceRecorder.Op.GetOrder,
             Request.Builder()
                 .url("$apiServerRootUrl/v1/orders/$id")
                 .get()
@@ -232,7 +238,8 @@ class ApiClient(val ecKeyPair: ECKeyPair = Keys.createEcKeyPair()) {
         tryListOrders().assertSuccess()
 
     fun tryListOrders(): Either<ApiCallFailure, OrdersApiResponse> =
-        execute(
+        executeAndTrace(
+            TraceRecorder.Op.ListOrders,
             Request.Builder()
                 .url("$apiServerRootUrl/v1/orders")
                 .get()
@@ -244,7 +251,8 @@ class ApiClient(val ecKeyPair: ECKeyPair = Keys.createEcKeyPair()) {
         tryCancelOpenOrders().assertSuccess()
 
     fun tryCancelOpenOrders(): Either<ApiCallFailure, Unit> =
-        execute(
+        executeAndTrace(
+            TraceRecorder.Op.CancelOpenOrders,
             Request.Builder()
                 .url("$apiServerRootUrl/v1/orders")
                 .delete()
@@ -256,7 +264,8 @@ class ApiClient(val ecKeyPair: ECKeyPair = Keys.createEcKeyPair()) {
         tryCreateWithdrawal(apiRequest).assertSuccess()
 
     fun tryCreateWithdrawal(apiRequest: CreateWithdrawalApiRequest): Either<ApiCallFailure, WithdrawalApiResponse> =
-        execute(
+        executeAndTrace(
+            TraceRecorder.Op.CreateWithdrawal,
             Request.Builder()
                 .url("$apiServerRootUrl/v1/withdrawals")
                 .post(Json.encodeToString(apiRequest).toRequestBody(applicationJson))
@@ -268,7 +277,8 @@ class ApiClient(val ecKeyPair: ECKeyPair = Keys.createEcKeyPair()) {
         tryGetWithdrawal(id).assertSuccess()
 
     fun tryGetWithdrawal(id: WithdrawalId): Either<ApiCallFailure, WithdrawalApiResponse> =
-        execute(
+        executeAndTrace(
+            TraceRecorder.Op.GetWithdrawal,
             Request.Builder()
                 .url("$apiServerRootUrl/v1/withdrawals/$id")
                 .get()
@@ -280,7 +290,8 @@ class ApiClient(val ecKeyPair: ECKeyPair = Keys.createEcKeyPair()) {
         tryGetBalances().assertSuccess()
 
     fun tryGetBalances(): Either<ApiCallFailure, BalancesApiResponse> =
-        execute(
+        executeAndTrace(
+            TraceRecorder.Op.GetBalances,
             Request.Builder()
                 .url("$apiServerRootUrl/v1/balances")
                 .get()
@@ -288,8 +299,11 @@ class ApiClient(val ecKeyPair: ECKeyPair = Keys.createEcKeyPair()) {
                 .withAuthHeaders(ecKeyPair),
         ).toErrorOrPayload(expectedStatusCode = HttpURLConnection.HTTP_OK)
 
-    private fun execute(request: Request): Response =
-        httpClient.newCall(request).execute()
+    private fun executeAndTrace(op: TraceRecorder.Op, request: Request): Response {
+        return traceRecorder.record(op) {
+            httpClient.newCall(request).execute()
+        }
+    }
 }
 
 val json = Json {

--- a/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/ApiClient.kt
+++ b/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/ApiClient.kt
@@ -44,7 +44,7 @@ import org.web3j.crypto.Keys
 import java.net.HttpURLConnection
 import java.util.Base64
 
-val apiServerRootUrl = System.getenv("API_URL") ?: "http://localhost:9999"
+val apiServerRootUrl = System.getenv("API_URL") ?: "http://localhost:9000"
 val httpClient = OkHttpClient.Builder().build()
 val applicationJson = "application/json".toMediaType()
 

--- a/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/Percentiles.kt
+++ b/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/Percentiles.kt
@@ -1,0 +1,24 @@
+package co.chainring.integrationtests.utils
+
+import kotlin.math.ceil
+
+fun percentile(latencies: List<Long>, percentile: Double): Long {
+    if (latencies.isEmpty()) throw IllegalArgumentException("Latencies cannot be empty")
+
+    return latencies.sorted().let { sortedLatencies ->
+        val index = ceil(percentile / 100.0 * sortedLatencies.size).toInt()
+        sortedLatencies[index - 1]
+    }
+}
+
+fun percentiles(latencies: List<Long>, percentiles: List<Double> = listOf(50.0, 66.0, 75.0, 80.0, 90.0, 95.0, 98.0, 99.0, 100.0)): List<Pair<Double, Long>> {
+    if (latencies.isEmpty()) throw IllegalArgumentException("Latencies cannot be empty")
+    if (percentiles.isEmpty()) throw IllegalArgumentException("Percentiles cannot be empty")
+
+    return latencies.sorted().let { sortedLatencies ->
+        percentiles.map { percentile ->
+            val index = ceil(percentile / 100.0 * sortedLatencies.size).toInt()
+            percentile to sortedLatencies[index - 1]
+        }
+    }
+}

--- a/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/TraceRecorder.kt
+++ b/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/TraceRecorder.kt
@@ -1,0 +1,173 @@
+package co.chainring.integrationtests.utils
+
+import co.chainring.apps.api.middleware.ServerSpans
+import co.chainring.apps.api.middleware.Span
+import co.chainring.apps.api.middleware.Tracer
+import io.github.oshai.kotlinlogging.KotlinLogging
+import okhttp3.Response
+import java.text.DecimalFormat
+
+interface TraceRecorder {
+    enum class Op {
+        GetConfiguration,
+        CreateOrder,
+        UpdateOrder,
+        CancelOrder,
+        GetOrder,
+        ListOrders,
+        CancelOpenOrders,
+        BatchOrders,
+        ListTrades,
+        GetBalances,
+        GetWithdrawal,
+        CreateWithdrawal,
+        WS,
+    }
+
+    data class Trace(
+        val spans: List<Span>,
+        val amzTraceId: String? = null,
+    )
+
+    data class PendingSpan(
+        val name: String,
+        val startedAt: Long,
+    )
+
+    fun record(op: Op, spans: List<Span>, amzTraceId: String?)
+    fun record(op: Op, request: () -> Response): Response
+
+    fun startWSRecording(id: String, spanName: String)
+    fun finishWSRecording(id: String, spanName: String, multivalue: Boolean = false)
+
+    fun printStatsAndFlush()
+
+    companion object {
+        val noOp = NoOpTraceRecorder()
+        val full = FullTraceRecorder()
+    }
+}
+
+class NoOpTraceRecorder : TraceRecorder {
+    override fun record(op: TraceRecorder.Op, spans: List<Span>, amzTraceId: String?) {}
+    override fun record(op: TraceRecorder.Op, request: () -> Response): Response {
+        return request()
+    }
+
+    override fun startWSRecording(id: String, spanName: String) {}
+
+    override fun finishWSRecording(id: String, spanName: String, multivalue: Boolean) {}
+    override fun printStatsAndFlush() {}
+}
+
+object ClientSpans {
+    val apiClient = "apiClient"
+}
+object WSSpans {
+    val orderCreated = "orderCreated"
+    val orderFilled = "orderFilled"
+    val tradeCreated = "tradeCreated"
+    val tradeSettled = "tradeSettled"
+}
+
+class FullTraceRecorder : TraceRecorder {
+    private val logger = KotlinLogging.logger {}
+    private var tracesByOp: MutableMap<TraceRecorder.Op, MutableList<TraceRecorder.Trace>> = mutableMapOf()
+    private var pendingEvents: MutableMap<String, TraceRecorder.PendingSpan> = mutableMapOf()
+
+    override fun startWSRecording(id: String, spanName: String) {
+        val nanoTime = System.nanoTime()
+        pendingEvents.getOrPut(id + spanName) {
+            TraceRecorder.PendingSpan(spanName, nanoTime)
+        }
+    }
+
+    override fun finishWSRecording(id: String, spanName: String, multivalue: Boolean) {
+        val nanoTime = System.nanoTime()
+        val pendingRecord = if (multivalue) {
+            pendingEvents[id + spanName]
+        } else {
+            pendingEvents.remove(id + spanName)
+        }
+
+        pendingRecord?.let { pendingSpan ->
+            record(
+                op = TraceRecorder.Op.WS,
+                spans = listOf(Span(pendingSpan.name, pendingSpan.startedAt, nanoTime - pendingSpan.startedAt)),
+                amzTraceId = null,
+            )
+        }
+    }
+
+    override fun record(op: TraceRecorder.Op, spans: List<Span>, amzTraceId: String?) {
+        tracesByOp.getOrPut(op) { mutableListOf() }.apply {
+            this.add(TraceRecorder.Trace(spans, amzTraceId))
+        }
+    }
+
+    override fun record(op: TraceRecorder.Op, request: () -> Response): Response {
+        System.nanoTime().let { start ->
+            return request().also { response ->
+                val duration = System.nanoTime() - start
+
+                val amznTraceId = response.headers["X-Amzn-Trace-Id"]
+                val serverSpans = response.headers["Server-Timing"]?.let { Tracer.deserialize(it) } ?: emptyList()
+                val clientSpan = Span(ClientSpans.apiClient, null, duration)
+
+                record(op, serverSpans + clientSpan, amznTraceId)
+            }
+        }
+    }
+
+    private val padding = 25
+    private val decimalFormat = DecimalFormat("#,###.##")
+    private val spansOrder = listOf(
+        ClientSpans.apiClient,
+        ServerSpans.app,
+        ServerSpans.sqrCli,
+        ServerSpans.gtw,
+        ServerSpans.sqr,
+        WSSpans.orderCreated,
+        WSSpans.orderFilled,
+        WSSpans.tradeCreated,
+        WSSpans.tradeSettled,
+    ).withIndex().associate { it.value to it.index }
+    override fun printStatsAndFlush() {
+        val traces = tracesByOp
+        tracesByOp = mutableMapOf()
+
+        val output = buildString {
+            traces.entries.toList().sortedBy { it.key }.forEach { (op, traces: MutableList<TraceRecorder.Trace>) ->
+                append("\n===================\n")
+                append("Stats for: ${op.name}\n")
+                append("Total Traces: ${traces.size}\n")
+
+                val latencies: Map<String, List<Long>> = traces.map { it.spans }.flatten().groupBy(
+                    keySelector = { span -> span.name },
+                    valueTransform = { span -> span.duration },
+                )
+
+                val sortedSpans = latencies.keys.sortedWith { a, b ->
+                    (spansOrder[a] ?: Int.MAX_VALUE).compareTo(spansOrder[b] ?: Int.MAX_VALUE)
+                }
+
+                sortedSpans.forEach { spanName ->
+                    val samplesCount = (latencies[spanName]?.size ?: 0).let { count ->
+                        if (traces.size != count) " ($count)" else ""
+                    }
+                    append((spanName + samplesCount).padEnd(padding))
+                }
+                append("\n")
+                listOf(50.0, 66.0, 75.0, 80.0, 90.0, 95.0, 98.0, 99.0, 100.0).forEach { p ->
+                    sortedSpans.forEach { span ->
+                        val value = latencies[span]?.let { percentile(it, p) } ?: "NA"
+                        append(" $p%: ${decimalFormat.format(value)}".padEnd(padding))
+                    }
+                    append("\n")
+                }
+            }
+        }
+
+        logger.debug { output }
+    }
+}

--- a/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/TraceRecorder.kt
+++ b/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/TraceRecorder.kt
@@ -139,7 +139,7 @@ class FullTraceRecorder : TraceRecorder {
         val output = buildString {
             append("\n========= ${header()} =========\n")
             traces.entries.toList().sortedBy { it.key }.forEach { (op, traces: MutableList<TraceRecorder.Trace>) ->
-                append("Stats for: ${op.name}\n")
+                append("\nStats for: ${op.name}\n")
                 append("Total Traces: ${traces.size}\n")
 
                 val latencies: Map<String, List<Long>> = traces.map { it.spans }.flatten().groupBy(

--- a/mocker/build.gradle.kts
+++ b/mocker/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
 
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.5.0")
+
     implementation("org.http4k:http4k-format-kotlinx-serialization:$http4kVersion")
     implementation("org.http4k:http4k-client-websocket:$http4kVersion")
     implementation("io.github.oshai:kotlin-logging-jvm:6.0.3")

--- a/mocker/build.gradle.kts
+++ b/mocker/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm") version "1.9.23"
+    application
 }
 
 group = "co.chainring"
@@ -38,4 +39,8 @@ tasks.test {
 }
 kotlin {
     jvmToolchain(17)
+}
+
+application {
+    mainClass = "co.chainring.MainKt"
 }

--- a/mocker/src/main/kotlin/co/chainring/Main.kt
+++ b/mocker/src/main/kotlin/co/chainring/Main.kt
@@ -4,39 +4,74 @@ import co.chainring.core.Maker
 import co.chainring.core.Taker
 import co.chainring.core.model.db.MarketId
 import co.chainring.core.toFundamentalUnits
+import co.chainring.integrationtests.utils.TraceRecorder
 import java.math.BigDecimal
+import java.util.Timer
+import kotlin.concurrent.timerTask
 import kotlin.random.Random
+import kotlin.time.Duration.Companion.minutes
+
+
+val interval = 10.minutes
+const val initialTakers = 5
+const val maxTakers = 100
+val newTakerInterval = interval / (maxTakers - initialTakers)
+
+val statsInterval = 1.minutes
 
 fun main() {
+    val timer = Timer()
+
+    // maker
     val maker = Maker(
         tightness = 5, skew = 0, levels = 10,
         native = BigDecimal.TEN.movePointRight(18).toBigInteger(),
         assets = mapOf(
             //"ETH" to 200.toFundamentalUnits(18),
-            "USDC" to 1000.toFundamentalUnits(6),
-            "DAI" to 500.toFundamentalUnits(18)
+            "USDC" to 10000.toFundamentalUnits(6),
+            "DAI" to 5000.toFundamentalUnits(18)
         )
     )
     val usdcDai = MarketId("USDC/DAI")
     val btcEth = MarketId("BTC/ETH")
     maker.start(listOf(usdcDai))
-    val takers = (1..5).map {
-        Taker(
-            rate = Random.nextLong(5000, 20000),
-            sizeFactor = Random.nextDouble(5.0, 20.0),
-            native = null,
-            assets = mapOf(
-                "USDC" to 100.toFundamentalUnits(6),
-                "DAI" to 50.toFundamentalUnits(18)
-            )
-        )
+
+
+    // takers
+    val takers = mutableListOf<Taker>()
+    (1..initialTakers).map {
+        takers.add(startTaker(usdcDai))
     }
-    takers.forEach {
-        it.start(listOf(usdcDai))
+    timer.scheduleAtFixedRate(timerTask {
+        takers.add(startTaker(usdcDai))
+    }, newTakerInterval.inWholeMilliseconds, newTakerInterval.inWholeMilliseconds)
+
+    // print metrics
+    val statsTask = timerTask {
+        TraceRecorder.full.printStatsAndFlush()
     }
-    Thread.sleep(600000)
+    timer.scheduleAtFixedRate(statsTask, statsInterval.inWholeMilliseconds, statsInterval.inWholeMilliseconds)
+
+    // tear down
+    Thread.sleep(interval.inWholeMilliseconds)
+    statsTask.cancel()
     maker.stop()
     takers.forEach {
         it.stop()
     }
+    timer.cancel()
+}
+
+private fun startTaker(usdcDai: MarketId): Taker {
+    val taker = Taker(
+        rate = Random.nextLong(5000, 20000),
+        sizeFactor = Random.nextDouble(5.0, 20.0),
+        native = null,
+        assets = mapOf(
+            "USDC" to 100.toFundamentalUnits(6),
+            "DAI" to 50.toFundamentalUnits(18)
+        )
+    )
+    taker.start(listOf(usdcDai))
+    return taker
 }

--- a/mocker/src/main/kotlin/co/chainring/core/Actor.kt
+++ b/mocker/src/main/kotlin/co/chainring/core/Actor.kt
@@ -3,6 +3,7 @@ package co.chainring.core
 import co.chainring.apps.api.model.Trade
 import co.chainring.integrationtests.utils.ApiClient
 import co.chainring.integrationtests.utils.Faucet
+import co.chainring.integrationtests.utils.TraceRecorder
 import co.chainring.integrationtests.utils.Wallet
 import org.web3j.crypto.Keys
 import java.math.BigInteger
@@ -11,7 +12,7 @@ import java.util.UUID
 open class Actor(val native: BigInteger?, val assets: Map<String, BigInteger>) {
     protected val id = UUID.randomUUID().toString()
     protected val keyPair = Keys.createEcKeyPair()
-    protected val apiClient = ApiClient(keyPair)
+    protected val apiClient = ApiClient(keyPair, traceRecorder = TraceRecorder.full)
     protected val wallet = Wallet(apiClient)
     protected var balances = mutableMapOf<String, BigInteger>()
     protected var pendingTrades = mutableListOf<Trade>()


### PR DESCRIPTION
* http latencies are provided by BE as response header. 
```Server-Timing "app;dur=3280542;start=725995102412958, sqrCli;dur=2045458;start=725995103559750, gtw;dur=261708, sqr;dur=110667"```
* on load test side new spans for api call and web socket messages are added
* number of takers increases over time
* starts for last minute printed to console, no saving to file so far, can add later if needed (or upload to s3)
* output `for 1 minute` for running 1 maker and 100 takers locally. 
   * NANOSECONDS.
   * Optimizing from using Threads to Java 21 Virtual threads is not included
```
===================
Stats for: GetConfiguration
Total Traces: 18
apiClient                app                      
 50.0%: 1,679,334         50.0%: 1,414,250        
 66.0%: 1,903,167         66.0%: 1,610,333        
 75.0%: 2,010,666         75.0%: 1,658,166        
 80.0%: 2,079,042         80.0%: 1,739,625        
 90.0%: 2,323,625         90.0%: 1,991,750        
 95.0%: 2,942,292         95.0%: 2,610,958        
 98.0%: 2,942,292         98.0%: 2,610,958        
 99.0%: 2,942,292         99.0%: 2,610,958        
 100.0%: 2,942,292        100.0%: 2,610,958       

===================
Stats for: CreateOrder
Total Traces: 141
apiClient                app                      sqrCli                   gtw                      sqr                      
 50.0%: 2,093,083         50.0%: 1,748,584         50.0%: 1,036,834         50.0%: 179,209           50.0%: 80,458           
 66.0%: 2,271,291         66.0%: 1,878,042         66.0%: 1,113,833         66.0%: 186,417           66.0%: 88,750           
 75.0%: 2,367,459         75.0%: 1,956,000         75.0%: 1,288,000         75.0%: 196,375           75.0%: 93,625           
 80.0%: 2,553,875         80.0%: 2,125,291         80.0%: 1,397,750         80.0%: 203,250           80.0%: 95,917           
 90.0%: 2,874,792         90.0%: 2,411,375         90.0%: 1,637,708         90.0%: 277,333           90.0%: 115,750          
 95.0%: 3,948,125         95.0%: 3,249,208         95.0%: 2,260,000         95.0%: 318,791           95.0%: 146,000          
 98.0%: 5,479,125         98.0%: 4,739,083         98.0%: 2,878,083         98.0%: 407,791           98.0%: 164,916          
 99.0%: 7,108,459         99.0%: 6,230,750         99.0%: 3,690,125         99.0%: 477,750           99.0%: 241,792          
 100.0%: 9,403,458        100.0%: 7,255,709        100.0%: 6,476,041        100.0%: 594,917          100.0%: 268,667         

===================
Stats for: ListOrders
Total Traces: 58
apiClient                app                      
 50.0%: 962,274,459       50.0%: 958,289,792      
 66.0%: 988,535,416       66.0%: 984,629,500      
 75.0%: 1,005,172,542     75.0%: 1,004,186,833    
 80.0%: 1,010,155,166     80.0%: 1,009,163,958    
 90.0%: 1,063,104,208     90.0%: 1,061,598,791    
 95.0%: 1,347,225,667     95.0%: 1,338,016,291    
 98.0%: 1,370,524,417     98.0%: 1,366,175,917    
 99.0%: 1,382,234,250     99.0%: 1,381,186,083    
 100.0%: 1,382,234,250    100.0%: 1,381,186,083   

===================
Stats for: BatchOrders
Total Traces: 58
apiClient                app                      sqrCli                   gtw                      sqr                      
 50.0%: 5,346,666         50.0%: 5,022,250         50.0%: 1,055,667         50.0%: 184,750           50.0%: 94,042           
 66.0%: 5,516,333         66.0%: 5,150,917         66.0%: 1,102,416         66.0%: 209,916           66.0%: 131,291          
 75.0%: 5,625,292         75.0%: 5,297,166         75.0%: 1,141,167         75.0%: 225,292           75.0%: 139,125          
 80.0%: 5,706,250         80.0%: 5,341,041         80.0%: 1,191,875         80.0%: 236,667           80.0%: 144,875          
 90.0%: 5,967,917         90.0%: 5,558,167         90.0%: 1,368,250         90.0%: 264,875           90.0%: 189,875          
 95.0%: 6,265,917         95.0%: 5,957,375         95.0%: 1,838,500         95.0%: 283,666           95.0%: 194,833          
 98.0%: 7,270,792         98.0%: 6,904,666         98.0%: 1,882,875         98.0%: 311,417           98.0%: 196,083          
 99.0%: 13,315,083        99.0%: 12,782,292        99.0%: 6,976,250         99.0%: 384,041           99.0%: 305,250          
 100.0%: 13,315,083       100.0%: 12,782,292       100.0%: 6,976,250        100.0%: 384,041          100.0%: 305,250         

===================
Stats for: GetBalances
Total Traces: 14
apiClient                app                      
 50.0%: 2,069,500         50.0%: 1,769,334        
 66.0%: 3,146,000         66.0%: 2,811,125        
 75.0%: 3,630,833         75.0%: 3,233,667        
 80.0%: 4,346,292         80.0%: 3,727,459        
 90.0%: 7,136,625         90.0%: 6,879,125        
 95.0%: 7,644,416         95.0%: 7,145,042        
 98.0%: 7,644,416         98.0%: 7,145,042        
 99.0%: 7,644,416         99.0%: 7,145,042        
 100.0%: 7,644,416        100.0%: 7,145,042       

===================
Stats for: WS
Total Traces: 605
orderCreated (138)       orderFilled (138)        tradeCreated (162)       tradeSettled (167)       
 50.0%: 21,093,750        50.0%: 22,068,167        50.0%: 22,133,750        50.0%: 834,112,917      
 66.0%: 22,594,083        66.0%: 24,061,917        66.0%: 24,234,750        66.0%: 911,195,958      
 75.0%: 23,907,625        75.0%: 25,266,667        75.0%: 25,051,000        75.0%: 973,483,917      
 80.0%: 25,329,333        80.0%: 27,299,125        80.0%: 27,253,625        80.0%: 1,009,611,125    
 90.0%: 52,112,542        90.0%: 54,078,250        90.0%: 56,503,292        90.0%: 1,046,620,125    
 95.0%: 135,165,208       95.0%: 137,358,834       95.0%: 120,711,833       95.0%: 1,064,858,959    
 98.0%: 834,006,625       98.0%: 834,052,375       98.0%: 663,716,041       98.0%: 1,299,153,208    
 99.0%: 914,451,500       99.0%: 914,625,833       99.0%: 914,527,958       99.0%: 1,832,425,417    
 100.0%: 1,222,882,958    100.0%: 1,222,932,666    100.0%: 1,222,893,000    100.0%: 1,832,450,750   
```