### PR TITLE
SSH Key loadtest chainring

### DIFF
--- a/terraform/modules/loadtest/main.tf
+++ b/terraform/modules/loadtest/main.tf
@@ -1,0 +1,85 @@
+data "aws_iam_policy_document" "loadtest_node_doc" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "loadtest_node_role" {
+  name_prefix        = "${var.name_prefix}-loadtest-node-role"
+  assume_role_policy = data.aws_iam_policy_document.loadtest_node_doc.json
+}
+
+resource "aws_iam_role_policy_attachment" "loadtest_node_role_policy" {
+  role       = aws_iam_role.loadtest_node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "loadtest_node" {
+  name_prefix = "${var.name_prefix}-loadtest-node-profile"
+  path        = "/ecs/instance/"
+  role        = aws_iam_role.loadtest_node_role.name
+}
+
+resource "aws_security_group" "loadtest" {
+  vpc_id = var.vpc.id
+  name   = "${var.name_prefix}-loadtest"
+  ingress {
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    cidr_blocks      = ["${var.bastion_ip}/32"]
+    ipv6_cidr_blocks = []
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = []
+  }
+}
+
+data "aws_ssm_parameter" "loadtest_node_ami" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
+}
+
+resource "aws_launch_template" "loadtest_ec2" {
+  name_prefix            = "${var.name_prefix}-loadtest-ec2-"
+  image_id               = data.aws_ssm_parameter.loadtest_node_ami.value
+  instance_type          = var.instance_type
+  vpc_security_group_ids = [aws_security_group.loadtest.id]
+  key_name               = "loadtest-key"
+
+  iam_instance_profile { arn = aws_iam_instance_profile.loadtest_node.arn }
+  monitoring { enabled = true }
+
+  update_default_version = true
+}
+
+
+resource "aws_autoscaling_group" "loadtest" {
+  name_prefix         = "${var.name_prefix}-loadtest-asg-"
+  vpc_zone_identifier = [var.subnet_id]
+  // we only want one instance for now
+  min_size              = 1
+  max_size              = 1
+  protect_from_scale_in = true
+
+  launch_template {
+    id      = aws_launch_template.loadtest_ec2.id
+    version = "$Latest"
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "${var.name_prefix}-loadtest-cluster"
+    propagate_at_launch = true
+  }
+}

--- a/terraform/modules/loadtest/variables.tf
+++ b/terraform/modules/loadtest/variables.tf
@@ -1,0 +1,7 @@
+variable "subnet_id" {}
+variable "instance_type" {
+  default = "t3.large"
+}
+variable "vpc" {}
+variable "name_prefix" {}
+variable "bastion_ip" {}

--- a/terraform/modules/loadtest/versions.tf
+++ b/terraform/modules/loadtest/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.40.0"
+    }
+  }
+  required_version = ">= 1.5.7"
+}
+

--- a/terraform/shared/main.tf
+++ b/terraform/shared/main.tf
@@ -190,3 +190,8 @@ resource "aws_key_pair" "deployer" {
   key_name   = "deployer-key"
   public_key = var.deployer_key
 }
+
+resource "aws_key_pair" "loadtest" {
+  key_name   = "loadtest-key"
+  public_key = var.loadtest_key
+}

--- a/terraform/shared/variables.tf
+++ b/terraform/shared/variables.tf
@@ -22,6 +22,11 @@ variable "deployer_key" {
   default = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE7/1w7LSANgOrUQ1gSpwk+vJfc2vDAkOQHCFdHpg0uR deployer-key@chainring"
 }
 
+variable "loadtest_key" {
+  default = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP8nY8Ix9r2Rh2Lxj0Kk9gQ0TupmCR4e+Sgh86sEPjUO loadtest-key@chainring"
+}
+
+
 terraform {
   required_version = "1.5.7"
 

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -147,3 +147,11 @@ module "sequencer" {
   vpc                                     = module.vpc.vpc
   service_discovery_private_dns_namespace = module.vpc.service_discovery_private_dns_namespace
 }
+
+module "loadtest" {
+  source           = "../modules/loadtest"
+  name_prefix      = local.name_prefix
+  subnet_id        = module.vpc.private_subnet_id_2
+  vpc              = module.vpc.vpc
+  bastion_ip       = module.bastion.private_ip
+}


### PR DESCRIPTION
 - ec2 instance for loadtest, type can be adjusted later
 - ssh key is in the 1Password`SSH Key loadtest chainring`
 SSH connection works via bastion (`ssh -J ec2-user@test-bastion.chainring.co 10.10.3.134`) by adding host to the ssh hosts
 - java is installed manually, as well as chainring project copied into home


EC2 instance still can't connect to `test-api.chainring.co`