### PR TITLE
use default price if ohlc is empty

### DIFF
--- a/mocker/src/main/kotlin/co/chainring/mocker/core/Maker.kt
+++ b/mocker/src/main/kotlin/co/chainring/mocker/core/Maker.kt
@@ -56,7 +56,7 @@ class Maker(private val tightness: Int, private val skew: Int, private val level
                 wsClient.subscribeToPrices(it, OHLCDuration.P1M)
                 val prices = (wsClient.receivedDecoded().first() as OutgoingWSMessage.Publish).data as Prices
                 wsClient.unsubscribe(SubscriptionTopic.Prices(it, OHLCDuration.P1M))
-                createQuotes(it, levels, prices.ohlc.last().close.toBigDecimal())
+                createQuotes(it, levels, prices.ohlc.lastOrNull()?.close?.toBigDecimal() ?: 2.toBigDecimal())
             }
             marketIds.forEach {
                 wsClient.subscribeToPrices(it)

--- a/mocker/src/main/kotlin/co/chainring/mocker/core/Taker.kt
+++ b/mocker/src/main/kotlin/co/chainring/mocker/core/Taker.kt
@@ -53,6 +53,7 @@ class Taker(
     private var stopping = false
 
     fun start(marketIds: List<MarketId>) {
+        marketIds.forEach { marketPrices[it] = 2.toBigDecimal() }
         val config = apiClient.getConfiguration()
         markets = config.markets.toSet()
         listenerThread = thread(start = true, name = "tkr-listen-$id", isDaemon = false) {


### PR DESCRIPTION
In case when OHLC is empty for the market use default price to start the loadtest