### PR TITLE
CHAIN-145 place initial bestBid/bestOffer on market boundaries

### DIFF
--- a/sequencer/src/main/kotlin/co/chainring/sequencer/apps/SequencerApp.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/apps/SequencerApp.kt
@@ -32,7 +32,6 @@ import net.openhft.chronicle.queue.TailerDirection
 import net.openhft.chronicle.queue.TailerState
 import net.openhft.chronicle.queue.impl.RollingChronicleQueue
 import java.lang.Thread.UncaughtExceptionHandler
-import java.math.BigDecimal
 import java.math.BigInteger
 import java.nio.file.Path
 import kotlin.concurrent.thread
@@ -60,14 +59,11 @@ class SequencerApp(
                     error = SequencerError.MarketExists
                 } else {
                     val tickSize = market.tickSize.toBigDecimal()
-                    val halfTick = tickSize.setScale(tickSize.scale() + 1).divide(BigDecimal.valueOf(2))
                     val marketPrice = market.marketPrice.toBigDecimal()
                     state.markets[marketId] = Market(
                         id = marketId,
                         tickSize = tickSize,
                         marketPrice = marketPrice,
-                        bestBid = marketPrice - halfTick,
-                        bestOffer = marketPrice + halfTick,
                         maxLevels = market.maxLevels,
                         maxOrdersPerLevel = market.maxOrdersPerLevel,
                         baseDecimals = market.baseDecimals,

--- a/sequencer/src/test/kotlin/co/chainring/TestSequencer.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestSequencer.kt
@@ -538,8 +538,8 @@ class TestSequencer {
         val response4 = sequencer.addOrder(marketId, BigInteger.ONE, "17.55", maker, Order.Type.LimitSell)
         assertEquals(OrderDisposition.Accepted, response4.ordersChangedList.first().disposition)
 
-        // can change the price to cross the book, disposition is 'Accepted' since there is no liquidity in the market
-        val response5 = sequencer.changeOrder(marketId, response.orderGuid().toOrderGuid(), 999L, "17.50", maker)
+        // can change the price to cross the market, disposition is 'Accepted' since there is no liquidity yet available in the market
+        val response5 = sequencer.changeOrder(marketId, response.orderGuid().toOrderGuid(), 999L, "15.50", maker)
         assertEquals(OrderDisposition.Accepted, response5.ordersChangedList.first().disposition)
 
         // check for a limit buy

--- a/sequencer/src/test/kotlin/co/chainring/TestSequencerCheckpoints.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestSequencerCheckpoints.kt
@@ -404,8 +404,6 @@ class TestSequencerCheckpoints {
                         marketPrice = BigDecimal("17.525"),
                         baseDecimals = 18,
                         quoteDecimals = 18,
-                        bestBid = BigDecimal("17.52"),
-                        bestOffer = BigDecimal("17.53"),
                     ),
                 ),
             ),
@@ -434,8 +432,6 @@ class TestSequencerCheckpoints {
                         marketPrice = BigDecimal("17.525"),
                         baseDecimals = 18,
                         quoteDecimals = 18,
-                        bestBid = BigDecimal("17.52"),
-                        bestOffer = BigDecimal("17.53"),
                     ).also { market ->
                         listOf(
                             order {
@@ -487,8 +483,6 @@ class TestSequencerCheckpoints {
                         marketPrice = BigDecimal("17.525"),
                         baseDecimals = 18,
                         quoteDecimals = 18,
-                        bestBid = BigDecimal("17.52"),
-                        bestOffer = BigDecimal("17.53"),
                     ).also { market ->
                         listOf(
                             order {
@@ -542,8 +536,6 @@ class TestSequencerCheckpoints {
                         marketPrice = BigDecimal("17.525"),
                         baseDecimals = 18,
                         quoteDecimals = 18,
-                        bestBid = BigDecimal("17.52"),
-                        bestOffer = BigDecimal("17.53"),
                     ).also { market ->
                         listOf(
                             order {
@@ -594,8 +586,6 @@ class TestSequencerCheckpoints {
                         marketPrice = BigDecimal("70000"),
                         baseDecimals = 18,
                         quoteDecimals = 18,
-                        bestBid = BigDecimal("69999"),
-                        bestOffer = BigDecimal("70001"),
                     ).also { market ->
                         listOf(
                             order {


### PR DESCRIPTION
allows to avoid check for market order being rejected on initial empty market.