### PR TITLE
Implement fees

### DIFF
--- a/backend/src/main/kotlin/co/chainring/apps/api/ConfigRoutes.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/ConfigRoutes.kt
@@ -3,6 +3,7 @@ package co.chainring.apps.api
 import co.chainring.apps.api.model.Chain
 import co.chainring.apps.api.model.ConfigurationApiResponse
 import co.chainring.apps.api.model.DeployedContract
+import co.chainring.apps.api.model.FeeRatesInBps
 import co.chainring.apps.api.model.Market
 import co.chainring.apps.api.model.SymbolInfo
 import co.chainring.core.model.Address
@@ -10,6 +11,7 @@ import co.chainring.core.model.Symbol
 import co.chainring.core.model.db.ChainEntity
 import co.chainring.core.model.db.ChainId
 import co.chainring.core.model.db.DeployedSmartContractEntity
+import co.chainring.core.model.db.KeyValueStore
 import co.chainring.core.model.db.MarketEntity
 import co.chainring.core.model.db.SymbolEntity
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -73,6 +75,10 @@ object ConfigRoutes {
                                 tickSize = "0.01".toBigDecimal(),
                             ),
                         ),
+                        feeRatesInBps = FeeRatesInBps(
+                            maker = 100,
+                            taker = 200,
+                        ),
                     ),
             )
         } bindContract Method.GET to { _ ->
@@ -109,6 +115,10 @@ object ConfigRoutes {
                                     tickSize = market.tickSize,
                                 )
                             },
+                            feeRatesInBps = FeeRatesInBps(
+                                maker = KeyValueStore.getInt("MakerFeeRateInBps") ?: 0,
+                                taker = KeyValueStore.getInt("TakerFeeRateInBps") ?: 0,
+                            ),
                         ),
                 )
             }

--- a/backend/src/main/kotlin/co/chainring/apps/api/ConfigRoutes.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/ConfigRoutes.kt
@@ -3,15 +3,15 @@ package co.chainring.apps.api
 import co.chainring.apps.api.model.Chain
 import co.chainring.apps.api.model.ConfigurationApiResponse
 import co.chainring.apps.api.model.DeployedContract
-import co.chainring.apps.api.model.FeeRatesInBps
 import co.chainring.apps.api.model.Market
 import co.chainring.apps.api.model.SymbolInfo
 import co.chainring.core.model.Address
+import co.chainring.core.model.FeeRate
 import co.chainring.core.model.Symbol
 import co.chainring.core.model.db.ChainEntity
 import co.chainring.core.model.db.ChainId
 import co.chainring.core.model.db.DeployedSmartContractEntity
-import co.chainring.core.model.db.KeyValueStore
+import co.chainring.core.model.db.FeeRates
 import co.chainring.core.model.db.MarketEntity
 import co.chainring.core.model.db.SymbolEntity
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -75,9 +75,9 @@ object ConfigRoutes {
                                 tickSize = "0.01".toBigDecimal(),
                             ),
                         ),
-                        feeRatesInBps = FeeRatesInBps(
-                            maker = 100,
-                            taker = 200,
+                        feeRates = FeeRates(
+                            maker = FeeRate.fromPercents(1.0),
+                            taker = FeeRate.fromPercents(2.0),
                         ),
                     ),
             )
@@ -115,10 +115,7 @@ object ConfigRoutes {
                                     tickSize = market.tickSize,
                                 )
                             },
-                            feeRatesInBps = FeeRatesInBps(
-                                maker = KeyValueStore.getInt("MakerFeeRateInBps") ?: 0,
-                                taker = KeyValueStore.getInt("TakerFeeRateInBps") ?: 0,
-                            ),
+                            feeRates = FeeRates.fetch(),
                         ),
                 )
             }

--- a/backend/src/main/kotlin/co/chainring/apps/api/model/Configuration.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/model/Configuration.kt
@@ -3,19 +3,14 @@ package co.chainring.apps.api.model
 import co.chainring.core.model.Address
 import co.chainring.core.model.Symbol
 import co.chainring.core.model.db.ChainId
+import co.chainring.core.model.db.FeeRates
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class ConfigurationApiResponse(
     val chains: List<Chain>,
     val markets: List<Market>,
-    val feeRatesInBps: FeeRatesInBps,
-)
-
-@Serializable
-data class FeeRatesInBps(
-    val maker: Int,
-    val taker: Int,
+    val feeRates: FeeRates,
 )
 
 @Serializable

--- a/backend/src/main/kotlin/co/chainring/apps/api/model/Configuration.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/model/Configuration.kt
@@ -9,6 +9,13 @@ import kotlinx.serialization.Serializable
 data class ConfigurationApiResponse(
     val chains: List<Chain>,
     val markets: List<Market>,
+    val feeRatesInBps: FeeRatesInBps,
+)
+
+@Serializable
+data class FeeRatesInBps(
+    val maker: Int,
+    val taker: Int,
 )
 
 @Serializable

--- a/backend/src/main/kotlin/co/chainring/core/evm/EIP712Transaction.kt
+++ b/backend/src/main/kotlin/co/chainring/core/evm/EIP712Transaction.kt
@@ -14,7 +14,6 @@ import org.web3j.abi.DefaultFunctionEncoder
 import org.web3j.abi.datatypes.DynamicStruct
 import org.web3j.crypto.StructuredData
 import org.web3j.crypto.transaction.type.TransactionType
-import java.math.BigInteger
 
 fun serializeTx(txType: ExchangeTransactions.TransactionType, struct: DynamicStruct): ByteArray {
     return listOf(txType.ordinal.toByte()).toByteArray() + Hex.decode(DefaultFunctionEncoder().encodeParameters(listOf(struct)))
@@ -168,6 +167,8 @@ sealed class EIP712Transaction {
         val takerOrder: Order,
         val makerOrder: Order,
         val tradeId: TradeId,
+        val takerFee: BigIntegerJson,
+        val makerFee: BigIntegerJson,
         override val signature: EvmSignature = EvmSignature.emptySignature(),
     ) : EIP712Transaction() {
 
@@ -187,14 +188,14 @@ sealed class EIP712Transaction {
             return serializeTx(
                 ExchangeTransactions.TransactionType.SettleTrade,
                 ExchangeTransactions.SettleTrade(
-                    sequence,
-                    baseToken.value,
-                    quoteToken.value,
-                    amount,
-                    price,
-                    BigInteger.ZERO,
-                    BigInteger.ZERO,
-                    ExchangeTransactions.OrderWithSignature(
+                    sequence = sequence,
+                    baseToken = baseToken.value,
+                    quoteToken = quoteToken.value,
+                    amount = amount,
+                    price = price,
+                    takerFee = takerFee,
+                    makerFee = makerFee,
+                    takerOrder = ExchangeTransactions.OrderWithSignature(
                         ExchangeTransactions.Order(
                             takerOrder.sender.value,
                             takerOrder.amount,
@@ -203,7 +204,7 @@ sealed class EIP712Transaction {
                         ),
                         takerOrder.signature.toByteArray(),
                     ),
-                    ExchangeTransactions.OrderWithSignature(
+                    makerOrder = ExchangeTransactions.OrderWithSignature(
                         ExchangeTransactions.Order(
                             makerOrder.sender.value,
                             makerOrder.amount,

--- a/backend/src/main/kotlin/co/chainring/core/model/FeeRate.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/FeeRate.kt
@@ -1,0 +1,19 @@
+package co.chainring.core.model
+
+import kotlinx.serialization.Serializable
+import java.math.BigDecimal
+
+@Serializable
+@JvmInline
+value class FeeRate(val value: Long) {
+    init {
+        require(value in 1..MAX_VALUE) { "Invalid fee rate" }
+    }
+
+    companion object {
+        const val MAX_VALUE = 1_000_000L
+
+        fun fromPercents(percents: Double): FeeRate =
+            FeeRate((BigDecimal(percents) * BigDecimal(MAX_VALUE) / BigDecimal(100)).toLong())
+    }
+}

--- a/backend/src/main/kotlin/co/chainring/core/model/db/FeeRates.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/FeeRates.kt
@@ -1,0 +1,29 @@
+package co.chainring.core.model.db
+
+import co.chainring.core.model.FeeRate
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FeeRates(
+    val maker: FeeRate,
+    val taker: FeeRate,
+) {
+    companion object {
+        fun fetch(): FeeRates =
+            FeeRates(
+                maker = FeeRate(KeyValueStore.getLong("MakerFeeRate") ?: 0),
+                taker = FeeRate(KeyValueStore.getLong("TakerFeeRate") ?: 0),
+            )
+
+        fun fromPercents(maker: Double, taker: Double): FeeRates =
+            FeeRates(
+                maker = FeeRate.fromPercents(maker),
+                taker = FeeRate.fromPercents(taker),
+            )
+    }
+
+    fun persist() {
+        KeyValueStore.setLong("MakerFeeRate", maker.value)
+        KeyValueStore.setLong("TakerFeeRate", taker.value)
+    }
+}

--- a/backend/src/main/kotlin/co/chainring/core/model/db/KeyValueStore.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/KeyValueStore.kt
@@ -23,6 +23,14 @@ object KeyValueStore : Table("key_value_store") {
         }
     }
 
+    fun getInt(key: String): Int? {
+        return getValue(key)?.toInt()
+    }
+
+    fun setInt(key: String, value: Int) {
+        setValue(key, value.toString())
+    }
+
     fun getLong(key: String): Long? {
         return getValue(key)?.toLong()
     }

--- a/backend/src/main/kotlin/co/chainring/core/model/db/KeyValueStore.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/KeyValueStore.kt
@@ -23,14 +23,6 @@ object KeyValueStore : Table("key_value_store") {
         }
     }
 
-    fun getInt(key: String): Int? {
-        return getValue(key)?.toInt()
-    }
-
-    fun setInt(key: String, value: Int) {
-        setValue(key, value.toString())
-    }
-
     fun getLong(key: String): Long? {
         return getValue(key)?.toLong()
     }

--- a/backend/src/main/kotlin/co/chainring/core/sequencer/SequencerClient.kt
+++ b/backend/src/main/kotlin/co/chainring/core/sequencer/SequencerClient.kt
@@ -8,6 +8,7 @@ import co.chainring.core.model.EvmSignature
 import co.chainring.core.model.SequencerOrderId
 import co.chainring.core.model.SequencerWalletId
 import co.chainring.core.model.db.DepositId
+import co.chainring.core.model.db.FeeRates
 import co.chainring.core.model.db.MarketId
 import co.chainring.core.model.db.OrderId
 import co.chainring.core.model.db.WithdrawalId
@@ -21,7 +22,7 @@ import co.chainring.sequencer.proto.balanceBatch
 import co.chainring.sequencer.proto.cancelOrder
 import co.chainring.sequencer.proto.deposit
 import co.chainring.sequencer.proto.failedWithdrawal
-import co.chainring.sequencer.proto.feeRatesInBps
+import co.chainring.sequencer.proto.feeRates
 import co.chainring.sequencer.proto.getStateRequest
 import co.chainring.sequencer.proto.market
 import co.chainring.sequencer.proto.order
@@ -139,14 +140,14 @@ open class SequencerClient {
         }.sequencerResponse
     }
 
-    suspend fun setFeeRates(maker: Int, taker: Int): SequencerResponse {
+    suspend fun setFeeRates(feeRates: FeeRates): SequencerResponse {
         return Tracer.newCoroutineSpan(ServerSpans.sqrClt) {
             stub.setFeeRates(
                 setFeeRatesRequest {
                     this.guid = UUID.randomUUID().toString()
-                    this.feeRates = feeRatesInBps {
-                        this.maker = maker
-                        this.taker = taker
+                    this.feeRates = feeRates {
+                        this.maker = feeRates.maker.value
+                        this.taker = feeRates.taker.value
                     }
                 },
             )

--- a/integrationtests/build.gradle.kts
+++ b/integrationtests/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
 
     implementation(project(":backend"))
     implementation(project(":sequencer"))
+    implementation(project(":sequencercommon"))
     testImplementation(project(mapOf("path" to ":")))
 }
 

--- a/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/ExchangeClient.kt
+++ b/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/ExchangeClient.kt
@@ -1,0 +1,33 @@
+package co.chainring.integrationtests.utils
+
+import co.chainring.apps.api.model.SymbolInfo
+import co.chainring.core.blockchain.BlockchainClientConfig
+import co.chainring.core.blockchain.ContractType
+import co.chainring.core.model.Address
+import kotlinx.coroutines.runBlocking
+import org.web3j.crypto.Keys
+import java.math.BigInteger
+
+class ExchangeClient {
+    private val blockchainClient = TestBlockchainClient(BlockchainClientConfig())
+
+    private val symbols: Map<String, SymbolInfo>
+
+    init {
+        val config = TestApiClient.getConfiguration()
+        val chain = config.chains.first()
+        symbols = chain.symbols.associateBy { it.name }
+        blockchainClient.setContractAddress(ContractType.Exchange, chain.contracts.first { it.name == "Exchange" }.address)
+    }
+
+    fun getFeeBalance(symbol: String): BigInteger {
+        val feeAccountAddress = blockchainClient.exchangeContract.feeAccount().send().let {
+            Address(Keys.toChecksumAddress(it))
+        }
+        val tokenAddress = symbols.getValue(symbol).contractAddress ?: Address.zero
+
+        return runBlocking {
+            blockchainClient.getExchangeBalance(feeAccountAddress, tokenAddress)
+        }
+    }
+}

--- a/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/ExchangeContractManager.kt
+++ b/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/ExchangeContractManager.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.runBlocking
 import org.web3j.crypto.Keys
 import java.math.BigInteger
 
-class ExchangeClient {
+class ExchangeContractManager {
     private val blockchainClient = TestBlockchainClient(BlockchainClientConfig())
 
     private val symbols: Map<String, SymbolInfo>

--- a/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/TestApiClient.kt
+++ b/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/TestApiClient.kt
@@ -28,6 +28,7 @@ import co.chainring.core.client.rest.applicationJson
 import co.chainring.core.client.rest.httpClient
 import co.chainring.core.client.rest.json
 import co.chainring.core.model.db.DepositId
+import co.chainring.core.model.db.FeeRates
 import co.chainring.core.model.db.OrderId
 import co.chainring.core.model.db.WithdrawalId
 import co.chainring.core.utils.TraceRecorder
@@ -100,8 +101,8 @@ class TestApiClient(ecKeyPair: ECKeyPair = Keys.createEcKeyPair(), traceRecorder
             }
         }
 
-        fun setFeeRatesInSequencer(maker: Int, taker: Int) =
-            setFeeRatesInSequencer(TestRoutes.Companion.SetFeeRatesInSequencer(maker = maker, taker = taker))
+        fun setFeeRatesInSequencer(feeRates: FeeRates) =
+            setFeeRatesInSequencer(TestRoutes.Companion.SetFeeRatesInSequencer(maker = feeRates.maker, taker = feeRates.taker))
 
         fun setFeeRatesInSequencer(apiRequest: TestRoutes.Companion.SetFeeRatesInSequencer) {
             execute(

--- a/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/TestApiClient.kt
+++ b/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/TestApiClient.kt
@@ -100,6 +100,36 @@ class TestApiClient(ecKeyPair: ECKeyPair = Keys.createEcKeyPair(), traceRecorder
             }
         }
 
+        fun setFeeRatesInSequencer(maker: Int, taker: Int) =
+            setFeeRatesInSequencer(TestRoutes.Companion.SetFeeRatesInSequencer(maker = maker, taker = taker))
+
+        fun setFeeRatesInSequencer(apiRequest: TestRoutes.Companion.SetFeeRatesInSequencer) {
+            execute(
+                Request.Builder()
+                    .url("$apiServerRootUrl/v1/sequencer-fee-rates")
+                    .put(Json.encodeToString(apiRequest).toRequestBody(applicationJson))
+                    .build(),
+            ).also { httpResponse ->
+                if (httpResponse.code != HttpURLConnection.HTTP_OK) {
+                    throw AbnormalApiResponseException(httpResponse)
+                }
+            }
+        }
+
+        fun getConfiguration(): ConfigurationApiResponse {
+            val httpResponse = execute(
+                Request.Builder()
+                    .url("$apiServerRootUrl/v1/config")
+                    .get()
+                    .build(),
+            )
+
+            return when (httpResponse.code) {
+                HttpURLConnection.HTTP_OK -> json.decodeFromString<ConfigurationApiResponse>(httpResponse.body?.string()!!)
+                else -> throw AbnormalApiResponseException(httpResponse)
+            }
+        }
+
         private fun execute(request: Request): Response =
             httpClient.newCall(request).execute()
     }

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/ConfigRouteTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/ConfigRouteTest.kt
@@ -1,8 +1,9 @@
 package co.chainring.integrationtests.api
 
-import co.chainring.apps.api.model.FeeRatesInBps
 import co.chainring.core.blockchain.BlockchainClient
 import co.chainring.core.blockchain.ContractType
+import co.chainring.core.model.FeeRate
+import co.chainring.core.model.db.FeeRates
 import co.chainring.integrationtests.testutils.AppUnderTestRunner
 import co.chainring.integrationtests.utils.TestApiClient
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -30,6 +31,9 @@ class ConfigRouteTest {
         assertEquals("BTC", nativeToken.name)
         assertEquals(18.toUByte(), nativeToken.decimals)
 
-        assertEquals(FeeRatesInBps(maker = 100, taker = 200), config.feeRatesInBps)
+        assertEquals(
+            FeeRates(maker = FeeRate.fromPercents(1.0), taker = FeeRate.fromPercents(2.0)),
+            config.feeRates,
+        )
     }
 }

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/ConfigRouteTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/ConfigRouteTest.kt
@@ -1,0 +1,35 @@
+package co.chainring.integrationtests.api
+
+import co.chainring.apps.api.model.FeeRatesInBps
+import co.chainring.core.blockchain.BlockchainClient
+import co.chainring.core.blockchain.ContractType
+import co.chainring.integrationtests.testutils.AppUnderTestRunner
+import co.chainring.integrationtests.utils.TestApiClient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.Test
+
+@ExtendWith(AppUnderTestRunner::class)
+class ConfigRouteTest {
+    @Test
+    fun testConfiguration() {
+        val apiClient = TestApiClient()
+
+        val config = apiClient.getConfiguration()
+        val chainConfig = config.chains.first()
+        assertEquals(chainConfig.contracts.size, 1)
+        assertEquals(chainConfig.contracts[0].name, ContractType.Exchange.name)
+        val client = BlockchainClient().loadExchangeContract(chainConfig.contracts[0].address)
+        assertEquals(client.version.send().toInt(), 1)
+
+        assertNotNull(chainConfig.symbols.firstOrNull { it.name == "ETH" })
+        assertNotNull(chainConfig.symbols.firstOrNull { it.name == "USDC" })
+
+        val nativeToken = chainConfig.symbols.first { it.contractAddress == null }
+        assertEquals("BTC", nativeToken.name)
+        assertEquals(18.toUByte(), nativeToken.decimals)
+
+        assertEquals(FeeRatesInBps(maker = 100, taker = 200), config.feeRatesInBps)
+    }
+}

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/OrderRoutesApiTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/OrderRoutesApiTest.kt
@@ -45,7 +45,7 @@ import co.chainring.core.utils.toFundamentalUnits
 import co.chainring.integrationtests.testutils.AppUnderTestRunner
 import co.chainring.integrationtests.testutils.waitForBalance
 import co.chainring.integrationtests.testutils.waitForFinalizedWithdrawal
-import co.chainring.integrationtests.utils.ExchangeClient
+import co.chainring.integrationtests.utils.ExchangeContractManager
 import co.chainring.integrationtests.utils.ExpectedBalance
 import co.chainring.integrationtests.utils.Faucet
 import co.chainring.integrationtests.utils.TestApiClient
@@ -471,9 +471,9 @@ class OrderRoutesApiTest {
 
     @Test
     fun `order execution`() {
-        val exchangeClient = ExchangeClient()
+        val exchangeContractManager = ExchangeContractManager()
 
-        val initialFeeAccountEthBalance = exchangeClient.getFeeBalance("ETH")
+        val initialFeeAccountEthBalance = exchangeContractManager.getFeeBalance("ETH")
 
         val (takerApiClient, takerWallet, takerWsClient) =
             setupTrader(btcEthMarketId, "0.5", null, "ETH", "2")
@@ -1085,7 +1085,7 @@ class OrderRoutesApiTest {
         // verify that fees have settled correctly on chain
         assertEquals(
             makerFee + takerFee + makerFee2 + takerFee2,
-            exchangeClient.getFeeBalance("ETH") - initialFeeAccountEthBalance,
+            exchangeContractManager.getFeeBalance("ETH") - initialFeeAccountEthBalance,
         )
     }
 

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/exchange/DepositTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/exchange/DepositTest.kt
@@ -1,14 +1,11 @@
 package co.chainring.integrationtests.exchange
 
-import co.chainring.core.blockchain.BlockchainClient
-import co.chainring.core.blockchain.ContractType
 import co.chainring.core.utils.toFundamentalUnits
 import co.chainring.core.utils.toHexBytes
 import co.chainring.integrationtests.testutils.AppUnderTestRunner
 import co.chainring.integrationtests.utils.TestApiClient
 import co.chainring.integrationtests.utils.Wallet
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.extension.ExtendWith
 import org.web3j.crypto.ECKeyPair
 import org.web3j.utils.Numeric
@@ -19,23 +16,6 @@ import kotlin.test.Test
 class DepositTest {
 
     private val walletPrivateKeyHex = "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97"
-
-    @Test
-    fun testConfiguration() {
-        val apiClient = TestApiClient()
-        val config = apiClient.getConfiguration().chains.first()
-        assertEquals(config.contracts.size, 1)
-        assertEquals(config.contracts[0].name, ContractType.Exchange.name)
-        val client = BlockchainClient().loadExchangeContract(config.contracts[0].address)
-        assertEquals(client.version.send().toInt(), 1)
-
-        assertNotNull(config.symbols.firstOrNull { it.name == "ETH" })
-        assertNotNull(config.symbols.firstOrNull { it.name == "USDC" })
-
-        val nativeToken = config.symbols.first { it.contractAddress == null }
-        assertEquals("BTC", nativeToken.name)
-        assertEquals(18.toUByte(), nativeToken.decimals)
-    }
 
     @Test
     fun testERC20Deposits() {

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/testutils/AppUnderTestRunner.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/testutils/AppUnderTestRunner.kt
@@ -137,10 +137,7 @@ class AppUnderTestRunner : BeforeAllCallback, BeforeEachCallback {
             .getStore(ExtensionContext.Namespace.GLOBAL)
             .get("fixtures", Fixtures::class.java)
 
-        TestApiClient.setFeeRatesInSequencer(
-            maker = fixtures.makerFeeRateInBps,
-            taker = fixtures.takerFeeRateInBps,
-        )
+        TestApiClient.setFeeRatesInSequencer(fixtures.feeRates)
 
         fixtures.markets.forEach { market ->
             val baseSymbol = fixtures.symbols.first { it.id == market.baseSymbol }

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/Main.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/Main.kt
@@ -1,8 +1,8 @@
 package co.chainring.sequencer
 
 import co.chainring.sequencer.apps.GatewayApp
-import co.chainring.sequencer.apps.QueueProcessorApp
 import co.chainring.sequencer.apps.SequencerApp
+import co.chainring.sequencer.apps.SequencerResponseProcessorApp
 import co.chainring.sequencer.core.queueHome
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.nio.file.Path
@@ -22,11 +22,11 @@ fun main(args: Array<String>) {
             },
         )
         sequencer.start()
-        val queueProcessorApp = QueueProcessorApp(
+        val sequencerResponseProcessorApp = SequencerResponseProcessorApp(
             sequencer.inputQueue,
             sequencer.outputQueue,
         )
-        queueProcessorApp.start()
+        sequencerResponseProcessorApp.start()
         try {
             val gateway = GatewayApp()
             gateway.start()
@@ -36,7 +36,7 @@ fun main(args: Array<String>) {
             logger.error(e) { "Failed, stopping sequencer and exiting" }
         } finally {
             sequencer.stop()
-            queueProcessorApp.stop()
+            sequencerResponseProcessorApp.stop()
         }
     } catch (e: Throwable) {
         logger.error(e) { "Failed to start" }

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/apps/SequencerApp.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/apps/SequencerApp.kt
@@ -7,6 +7,7 @@ import co.chainring.sequencer.core.MarketId
 import co.chainring.sequencer.core.SequencerState
 import co.chainring.sequencer.core.WalletAddress
 import co.chainring.sequencer.core.notional
+import co.chainring.sequencer.core.notionalPlusFee
 import co.chainring.sequencer.core.sumBigIntegers
 import co.chainring.sequencer.core.toAsset
 import co.chainring.sequencer.core.toBigDecimal
@@ -84,6 +85,25 @@ class SequencerApp(
                     }
                 }
             }
+            SequencerRequest.Type.SetFeeRates -> {
+                var error: SequencerError? = null
+
+                val feeRates = request.feeRates
+                if (feeRates == null || feeRates.maker < 0 || feeRates.maker > 10000 || feeRates.taker < 0 || feeRates.taker > 10000) {
+                    error = SequencerError.InvalidFeeRate
+                } else {
+                    state.feeRatesInBps = feeRates
+                }
+
+                sequencerResponse {
+                    this.guid = request.guid
+                    this.sequence = sequence
+                    this.processingTime = System.nanoTime() - startTime
+                    error?.let { this.error = it } ?: run {
+                        this.feeRatesSet = feeRates
+                    }
+                }
+            }
             SequencerRequest.Type.ApplyOrderBatch -> {
                 var ordersChanged: List<OrderChanged> = emptyList()
                 var ordersChangeRejected: List<OrderChangeRejected> = emptyList()
@@ -99,7 +119,7 @@ class SequencerApp(
                 } else {
                     error = checkLimits(market, orderBatch)
                     if (error == null) {
-                        val result = market.applyOrderBatch(orderBatch)
+                        val result = market.applyOrderBatch(orderBatch, state.feeRatesInBps)
                         ordersChanged = result.ordersChanged
                         ordersChangeRejected = result.ordersChangeRejected
                         trades = result.createdTrades
@@ -180,20 +200,28 @@ class SequencerApp(
                         val baseAsset = market.id.baseAsset()
                         val quoteAsset = market.id.quoteAsset()
                         val baseAmount = failedSettlement.trade.amount.toBigInteger()
-                        val negatedBaseAmount = baseAmount.negate()
                         val price = failedSettlement.trade.price.toBigDecimal()
                         val notional = notional(baseAmount, price, market.baseDecimals, market.quoteDecimals)
-                        val negatedNotional = notional.negate()
-                        val buyWallet = failedSettlement.buyWallet.toWalletAddress()
+
                         val sellWallet = failedSettlement.sellWallet.toWalletAddress()
-                        state.balances.getOrPut(sellWallet) { mutableMapOf() }.merge(baseAsset, baseAmount, ::sumBigIntegers)
-                        balancesChanged.merge(Pair(sellWallet, baseAsset), baseAmount, ::sumBigIntegers)
-                        state.balances.getOrPut(sellWallet) { mutableMapOf() }.merge(quoteAsset, negatedNotional, ::sumBigIntegers)
-                        balancesChanged.merge(Pair(sellWallet, quoteAsset), negatedNotional, ::sumBigIntegers)
-                        state.balances.getOrPut(buyWallet) { mutableMapOf() }.merge(baseAsset, negatedBaseAmount, ::sumBigIntegers)
-                        balancesChanged.merge(Pair(buyWallet, baseAsset), negatedBaseAmount, ::sumBigIntegers)
-                        state.balances.getOrPut(buyWallet) { mutableMapOf() }.merge(quoteAsset, notional, ::sumBigIntegers)
-                        balancesChanged.merge(Pair(buyWallet, quoteAsset), notional, ::sumBigIntegers)
+                        val sellerBaseRefund = baseAmount
+                        val sellerQuoteRefund = (notional - failedSettlement.trade.sellerFee.toBigInteger()).negate()
+
+                        val buyWallet = failedSettlement.buyWallet.toWalletAddress()
+                        val buyerBaseRefund = baseAmount.negate()
+                        val buyerQuoteRefund = notional + failedSettlement.trade.buyerFee.toBigInteger()
+
+                        state.balances.getOrPut(sellWallet) { mutableMapOf() }.merge(baseAsset, sellerBaseRefund, ::sumBigIntegers)
+                        balancesChanged.merge(Pair(sellWallet, baseAsset), sellerBaseRefund, ::sumBigIntegers)
+
+                        state.balances.getOrPut(sellWallet) { mutableMapOf() }.merge(quoteAsset, sellerQuoteRefund, ::sumBigIntegers)
+                        balancesChanged.merge(Pair(sellWallet, quoteAsset), sellerQuoteRefund, ::sumBigIntegers)
+
+                        state.balances.getOrPut(buyWallet) { mutableMapOf() }.merge(baseAsset, buyerBaseRefund, ::sumBigIntegers)
+                        balancesChanged.merge(Pair(buyWallet, baseAsset), buyerBaseRefund, ::sumBigIntegers)
+
+                        state.balances.getOrPut(buyWallet) { mutableMapOf() }.merge(quoteAsset, buyerQuoteRefund, ::sumBigIntegers)
+                        balancesChanged.merge(Pair(buyWallet, quoteAsset), buyerQuoteRefund, ::sumBigIntegers)
                     }
                 }
 
@@ -286,14 +314,13 @@ class SequencerApp(
                     baseAssetsRequired.merge(orderBatch.wallet.toWalletAddress(), order.amount.toBigInteger(), ::sumBigIntegers)
                 }
                 Order.Type.LimitBuy -> {
-                    val notional = calculateLimitBuyOrderNotional(order, market)
-
-                    quoteAssetsRequired.merge(orderBatch.wallet.toWalletAddress(), notional, ::sumBigIntegers)
+                    val notionalAndFee = calculateLimitBuyOrderNotionalPlusFee(order, market)
+                    quoteAssetsRequired.merge(orderBatch.wallet.toWalletAddress(), notionalAndFee, ::sumBigIntegers)
                 }
                 Order.Type.MarketBuy -> {
                     // the quote assets required for a market buy depends on what the clearing price would be
-                    val(clearingPrice, availableQuantity) = market.clearingPriceAndQuantityForMarketBuy(order.amount.toBigInteger())
-                    quoteAssetsRequired.merge(orderBatch.wallet.toWalletAddress(), notional(availableQuantity, clearingPrice, market.baseDecimals, market.quoteDecimals), ::sumBigIntegers)
+                    val (clearingPrice, availableQuantity) = market.clearingPriceAndQuantityForMarketBuy(order.amount.toBigInteger())
+                    quoteAssetsRequired.merge(orderBatch.wallet.toWalletAddress(), notionalPlusFee(availableQuantity, clearingPrice, market.baseDecimals, market.quoteDecimals, state.feeRatesInBps.taker), ::sumBigIntegers)
                 }
                 else -> {}
             }
@@ -309,10 +336,9 @@ class SequencerApp(
                     )
                 }
                 if (oldQuoteAssets > BigInteger.ZERO) { // LimitBuy
-                    val previousNotional = notional(order.quantity, market.levels[order.levelIx].price, market.baseDecimals, market.quoteDecimals)
-                    val notional = calculateLimitBuyOrderNotional(orderChange, market)
-
-                    quoteAssetsRequired.merge(order.wallet, notional - previousNotional, ::sumBigIntegers)
+                    val previousNotionalAndFee = notionalPlusFee(order.quantity, market.levels[order.levelIx].price, market.baseDecimals, market.quoteDecimals, state.feeRatesInBps.maker)
+                    val notionalAndFee = calculateLimitBuyOrderNotionalPlusFee(orderChange, market)
+                    quoteAssetsRequired.merge(order.wallet, notionalAndFee - previousNotionalAndFee, ::sumBigIntegers)
                 }
             }
         }
@@ -329,23 +355,19 @@ class SequencerApp(
         }
 
         baseAssetsRequired.forEach { (wallet, required) ->
-            if (required + market.baseAssetsRequired(wallet) > (
-                    state.balances[wallet]?.get(market.id.baseAsset())
-                        ?: BigInteger.ZERO
-                    )
-            ) {
-                logger.debug { "Wallet $wallet requires $required + ${market.baseAssetsRequired(wallet)} = ${required + market.baseAssetsRequired(wallet)} but only has ${state.balances[wallet]?.get(market.id.baseAsset())}" }
+            val baseRequired = market.baseAssetsRequired(wallet)
+            val baseBalance = state.balances[wallet]?.get(market.id.baseAsset()) ?: BigInteger.ZERO
+            if (required + baseRequired > baseBalance) {
+                logger.debug { "Wallet $wallet requires $required + $baseRequired = ${required + baseRequired} but only has $baseBalance" }
                 return SequencerError.ExceedsLimit
             }
         }
 
         quoteAssetsRequired.forEach { (wallet, required) ->
-            if (required + market.quoteAssetsRequired(wallet) > (
-                    state.balances[wallet]?.get(market.id.quoteAsset())
-                        ?: BigInteger.ZERO
-                    )
-            ) {
-                logger.debug { "Wallet $wallet requires $required + ${market.quoteAssetsRequired(wallet)} = ${required + market.quoteAssetsRequired(wallet)} but only has ${state.balances[wallet]?.get(market.id.quoteAsset())}" }
+            val quoteRequired = market.quoteAssetsRequired(wallet)
+            val quoteBalance = state.balances[wallet]?.get(market.id.quoteAsset()) ?: BigInteger.ZERO
+            if (required + quoteRequired > quoteBalance) {
+                logger.debug { "Wallet $wallet requires $required + $quoteRequired = ${required + quoteRequired} but only has $quoteBalance" }
                 return SequencerError.ExceedsLimit
             }
         }
@@ -353,7 +375,7 @@ class SequencerApp(
         return null
     }
 
-    private fun calculateLimitBuyOrderNotional(order: Order, market: Market): BigInteger {
+    private fun calculateLimitBuyOrderNotionalPlusFee(order: Order, market: Market): BigInteger {
         return if (order.price.toBigDecimal() >= market.bestOffer) {
             // limit order crosses the market
             val orderPrice = order.price.toBigDecimal()
@@ -362,12 +384,12 @@ class SequencerApp(
             val (clearingPrice, availableQuantity) = market.clearingPriceAndQuantityForMarketBuy(order.amount.toBigInteger(), stopAtLevelIx = levelIx)
             val remainingQuantity = order.amount.toBigInteger() - availableQuantity
 
-            val marketChunkNotional = notional(availableQuantity, clearingPrice, market.baseDecimals, market.quoteDecimals)
-            val limitChunkNotional = notional(remainingQuantity, orderPrice, market.baseDecimals, market.quoteDecimals)
+            val marketChunkNotional = notionalPlusFee(availableQuantity, clearingPrice, market.baseDecimals, market.quoteDecimals, state.feeRatesInBps.taker)
+            val limitChunkNotional = notionalPlusFee(remainingQuantity, orderPrice, market.baseDecimals, market.quoteDecimals, state.feeRatesInBps.maker)
 
             marketChunkNotional + limitChunkNotional
         } else {
-            notional(order.amount, order.price, market.baseDecimals, market.quoteDecimals)
+            notionalPlusFee(order.amount, order.price, market.baseDecimals, market.quoteDecimals, state.feeRatesInBps.maker)
         }
     }
 

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/apps/services/SequencerResponseProcessorService.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/apps/services/SequencerResponseProcessorService.kt
@@ -52,29 +52,17 @@ import co.chainring.sequencer.proto.SequencerResponse
 import co.chainring.sequencer.proto.newQuantityOrNull
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.datetime.Clock
-import org.jetbrains.exposed.sql.transactions.transaction
-import java.math.BigInteger
 import java.math.RoundingMode
 import kotlin.time.Duration.Companion.hours
 
 object SequencerResponseProcessorService {
-
     private val logger = KotlinLogging.logger {}
 
     private val symbolMap = mutableMapOf<String, SymbolEntity>()
     private val marketMap = mutableMapOf<MarketId, MarketEntity>()
     private val chainId by lazy { ChainEntity.all().first().id.value }
-    private val keyName = "LastProcessedOutputIndex"
 
-    fun getLastProcessedIndex() = transaction {
-        KeyValueStore.getLong(keyName)
-    }
-
-    fun updateLastProcessedIndex(lastProcessedIndex: Long) = transaction {
-        KeyValueStore.setLong(keyName, lastProcessedIndex)
-    }
-
-    fun onSequencerResponseReceived(response: SequencerResponse, request: SequencerRequest) {
+    fun processResponse(response: SequencerResponse, request: SequencerRequest) {
         when (request.type) {
             SequencerRequest.Type.ApplyBalanceBatch -> {
                 request.balanceBatch!!.withdrawalsList.forEach { withdrawal ->
@@ -118,6 +106,13 @@ object SequencerResponseProcessorService {
                             cancelAll = request.orderBatch.cancelAll,
                         )
                     }
+                }
+            }
+
+            SequencerRequest.Type.SetFeeRates -> {
+                if (response.error == SequencerError.None) {
+                    KeyValueStore.setInt("MakerFeeRateInBps", response.feeRatesSet.maker)
+                    KeyValueStore.setInt("TakerFeeRateInBps", response.feeRatesSet.taker)
                 }
             }
 
@@ -180,17 +175,17 @@ object SequencerResponseProcessorService {
         val orderIdsInRequest: List<Long> = (request.orderBatch.ordersToAddList + request.orderBatch.ordersToChangeList).map { it.guid }
 
         // handle trades
-        val tradesWithTakerOrder: List<Pair<TradeEntity, OrderEntity>> = response.tradesCreatedList.mapNotNull {
-            logger.debug { "Trade Created ${it.buyGuid}, ${it.sellGuid}, ${it.amount.toBigInteger()} ${it.price.toBigDecimal()} " }
-            val buyOrder = OrderEntity.findBySequencerOrderId(it.buyGuid)
-            val sellOrder = OrderEntity.findBySequencerOrderId(it.sellGuid)
+        val tradesWithTakerOrder: List<Pair<TradeEntity, OrderEntity>> = response.tradesCreatedList.mapNotNull { trade ->
+            logger.debug { "Trade Created: buyOrderGuid=${trade.buyOrderGuid}, sellOrderGuid=${trade.sellOrderGuid}, amount=${trade.amount.toBigInteger()} price=${trade.price.toBigDecimal()}, buyerFee=${trade.buyerFee.toBigInteger()}, sellerFee=${trade.sellerFee.toBigInteger()}" }
+            val buyOrder = OrderEntity.findBySequencerOrderId(trade.buyOrderGuid)
+            val sellOrder = OrderEntity.findBySequencerOrderId(trade.sellOrderGuid)
 
             if (buyOrder != null && sellOrder != null) {
                 val tradeEntity = TradeEntity.create(
                     timestamp = timestamp,
                     market = buyOrder.market,
-                    amount = it.amount.toBigInteger(),
-                    price = it.price.toBigDecimal(),
+                    amount = trade.amount.toBigInteger(),
+                    price = trade.price.toBigDecimal(),
                 )
 
                 // create executions for both
@@ -199,8 +194,16 @@ object SequencerResponseProcessorService {
                         timestamp = timestamp,
                         orderEntity = order,
                         tradeEntity = tradeEntity,
-                        role = if (orderIdsInRequest.contains(order.sequencerOrderId?.value)) ExecutionRole.Taker else ExecutionRole.Maker,
-                        feeAmount = BigInteger.ZERO,
+                        role = if (orderIdsInRequest.contains(order.sequencerOrderId?.value)) {
+                            ExecutionRole.Taker
+                        } else {
+                            ExecutionRole.Maker
+                        },
+                        feeAmount = if (order == buyOrder) {
+                            trade.buyerFee.toBigInteger()
+                        } else {
+                            trade.sellerFee.toBigInteger()
+                        },
                         feeSymbol = Symbol(order.market.quoteSymbol.name),
                     )
 

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/apps/services/SequencerResponseProcessorService.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/apps/services/SequencerResponseProcessorService.kt
@@ -5,6 +5,7 @@ import co.chainring.apps.api.model.websocket.OrderUpdated
 import co.chainring.apps.api.model.websocket.Orders
 import co.chainring.apps.api.model.websocket.TradeCreated
 import co.chainring.core.evm.EIP712Transaction
+import co.chainring.core.model.FeeRate
 import co.chainring.core.model.SequencerWalletId
 import co.chainring.core.model.Symbol
 import co.chainring.core.model.db.BalanceChange
@@ -17,7 +18,7 @@ import co.chainring.core.model.db.DepositEntity
 import co.chainring.core.model.db.DepositStatus
 import co.chainring.core.model.db.ExchangeTransactionEntity
 import co.chainring.core.model.db.ExecutionRole
-import co.chainring.core.model.db.KeyValueStore
+import co.chainring.core.model.db.FeeRates
 import co.chainring.core.model.db.MarketEntity
 import co.chainring.core.model.db.MarketId
 import co.chainring.core.model.db.OHLCDuration
@@ -111,8 +112,10 @@ object SequencerResponseProcessorService {
 
             SequencerRequest.Type.SetFeeRates -> {
                 if (response.error == SequencerError.None) {
-                    KeyValueStore.setInt("MakerFeeRateInBps", response.feeRatesSet.maker)
-                    KeyValueStore.setInt("TakerFeeRateInBps", response.feeRatesSet.taker)
+                    FeeRates(
+                        maker = FeeRate(response.feeRatesSet.maker),
+                        taker = FeeRate(response.feeRatesSet.taker),
+                    ).persist()
                 }
             }
 

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/core/SequencerState.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/core/SequencerState.kt
@@ -3,9 +3,13 @@ package co.chainring.sequencer.core
 import co.chainring.sequencer.proto.BalancesCheckpoint
 import co.chainring.sequencer.proto.BalancesCheckpointKt.BalanceKt.consumption
 import co.chainring.sequencer.proto.BalancesCheckpointKt.balance
+import co.chainring.sequencer.proto.FeeRatesInBps
 import co.chainring.sequencer.proto.MarketCheckpoint
+import co.chainring.sequencer.proto.MetaInfoCheckpoint
 import co.chainring.sequencer.proto.StateDump
 import co.chainring.sequencer.proto.balancesCheckpoint
+import co.chainring.sequencer.proto.feeRatesInBps
+import co.chainring.sequencer.proto.metaInfoCheckpoint
 import co.chainring.sequencer.proto.stateDump
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.FileInputStream
@@ -22,6 +26,7 @@ data class SequencerState(
     val markets: MutableMap<MarketId, Market> = mutableMapOf(),
     val balances: MutableMap<WalletAddress, BalanceByAsset> = mutableMapOf(),
     val consumed: MutableMap<WalletAddress, ConsumedByAsset> = mutableMapOf(),
+    var feeRatesInBps: FeeRatesInBps = FeeRatesInBps.getDefaultInstance(),
 ) {
     private val logger = KotlinLogging.logger {}
 
@@ -29,6 +34,7 @@ data class SequencerState(
         balances.clear()
         markets.clear()
         consumed.clear()
+        feeRatesInBps = FeeRatesInBps.getDefaultInstance()
     }
 
     fun load(sourceDir: Path) {
@@ -53,15 +59,16 @@ data class SequencerState(
         }
 
         measureNanoTime {
-            val marketIds = FileInputStream(Path.of(sourceDir.toString(), "markets").toFile()).use { inputStream ->
-                String(inputStream.readAllBytes()).let {
-                    if (it.isEmpty()) {
-                        emptyList()
-                    } else {
-                        it.split(",").map(::MarketId)
-                    }
-                }
+            val metaInfoCheckpoint = FileInputStream(Path.of(sourceDir.toString(), "metainfo").toFile()).use { inputStream ->
+                MetaInfoCheckpoint.parseFrom(inputStream)
             }
+
+            this.feeRatesInBps = feeRatesInBps {
+                this.maker = metaInfoCheckpoint.makerFeeRate
+                this.taker = metaInfoCheckpoint.takerFeeRate
+            }
+
+            val marketIds = metaInfoCheckpoint.marketsList.map(::MarketId)
 
             marketIds.forEach { marketId ->
                 val marketCheckpointFileName = "market_${marketId.baseAsset()}_${marketId.quoteAsset()}"
@@ -81,9 +88,13 @@ data class SequencerState(
 
         // we are writing a list of markets into a separate file first so that
         // when loading we could be sure that checkpoint files for all markets are present
-        FileOutputStream(Path.of(destinationDir.toString(), "markets").toFile()).use { outputStream ->
-            val marketIds = this.markets.keys.map { it.value }.sorted().joinToString(",")
-            outputStream.write(marketIds.toByteArray())
+        FileOutputStream(Path.of(destinationDir.toString(), "metainfo").toFile()).use { outputStream ->
+            val marketIds = this.markets.keys.map { it.value }.sorted()
+            metaInfoCheckpoint {
+                this.markets.addAll(marketIds)
+                this.makerFeeRate = feeRatesInBps.maker
+                this.takerFeeRate = feeRatesInBps.taker
+            }.writeTo(outputStream)
         }
 
         measureNanoTime {
@@ -114,6 +125,7 @@ data class SequencerState(
             marketsMap.forEach { (_, market) ->
                 this.markets.add(market.toCheckpoint())
             }
+            this.feeRates = feeRatesInBps
         }
     }
 

--- a/sequencer/src/test/kotlin/co/chainring/TestOrderBookLevel.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestOrderBookLevel.kt
@@ -1,6 +1,7 @@
 package co.chainring
 
 import co.chainring.sequencer.core.BookSide
+import co.chainring.sequencer.core.FeeRate
 import co.chainring.sequencer.core.OrderBookLevel
 import co.chainring.sequencer.core.toDecimalValue
 import co.chainring.sequencer.core.toIntegerValue
@@ -21,7 +22,7 @@ class TestOrderBookLevel {
     fun test() {
         val obl = OrderBookLevel(300, BookSide.Buy, BigDecimal.ONE, 1000)
         (0 until 100).forEach { _ ->
-            assertEquals(obl.addOrder(0L, getNextOrder(), feeRateInBps = 0).first, OrderDisposition.Accepted, "failed at $nextOrderId")
+            assertEquals(obl.addOrder(0L, getNextOrder(), feeRate = FeeRate.zero).first, OrderDisposition.Accepted, "failed at $nextOrderId")
         }
         assertEquals(obl.orderHead, 0)
         assertEquals(obl.orderTail, 100)
@@ -39,10 +40,10 @@ class TestOrderBookLevel {
 
         // fill up to max orders which is obl.maxOrderCount - 1
         (0 until obl.maxOrderCount - 100 + 7).forEach { _ ->
-            assertEquals(obl.addOrder(0L, getNextOrder(), feeRateInBps = 0).first, OrderDisposition.Accepted, "failed at $nextOrderId")
+            assertEquals(obl.addOrder(0L, getNextOrder(), feeRate = FeeRate.zero).first, OrderDisposition.Accepted, "failed at $nextOrderId")
         }
         // make sure we fail if we hit the max
-        assertEquals(obl.addOrder(0L, getNextOrder(false), feeRateInBps = 0).first, OrderDisposition.Rejected)
+        assertEquals(obl.addOrder(0L, getNextOrder(false), feeRate = FeeRate.zero).first, OrderDisposition.Rejected)
         assertEquals(expectedOrderIdSet.size, obl.maxOrderCount - 1)
         assertEquals(5, obl.orderTail)
         assertEquals(6, obl.orderHead)

--- a/sequencer/src/test/kotlin/co/chainring/TestOrderBookLevel.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestOrderBookLevel.kt
@@ -21,7 +21,7 @@ class TestOrderBookLevel {
     fun test() {
         val obl = OrderBookLevel(300, BookSide.Buy, BigDecimal.ONE, 1000)
         (0 until 100).forEach { _ ->
-            assertEquals(obl.addOrder(0L, getNextOrder()).first, OrderDisposition.Accepted, "failed at $nextOrderId")
+            assertEquals(obl.addOrder(0L, getNextOrder(), feeRateInBps = 0).first, OrderDisposition.Accepted, "failed at $nextOrderId")
         }
         assertEquals(obl.orderHead, 0)
         assertEquals(obl.orderTail, 100)
@@ -39,10 +39,10 @@ class TestOrderBookLevel {
 
         // fill up to max orders which is obl.maxOrderCount - 1
         (0 until obl.maxOrderCount - 100 + 7).forEach { _ ->
-            assertEquals(obl.addOrder(0L, getNextOrder()).first, OrderDisposition.Accepted, "failed at $nextOrderId")
+            assertEquals(obl.addOrder(0L, getNextOrder(), feeRateInBps = 0).first, OrderDisposition.Accepted, "failed at $nextOrderId")
         }
         // make sure we fail if we hit the max
-        assertEquals(obl.addOrder(0L, getNextOrder(false)).first, OrderDisposition.Rejected)
+        assertEquals(obl.addOrder(0L, getNextOrder(false), feeRateInBps = 0).first, OrderDisposition.Rejected)
         assertEquals(expectedOrderIdSet.size, obl.maxOrderCount - 1)
         assertEquals(5, obl.orderTail)
         assertEquals(6, obl.orderHead)

--- a/sequencer/src/test/kotlin/co/chainring/TestSequencer.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestSequencer.kt
@@ -1,5 +1,6 @@
 package co.chainring
 
+import co.chainring.core.model.db.FeeRates
 import co.chainring.sequencer.core.MarketId
 import co.chainring.sequencer.core.WalletAddress
 import co.chainring.sequencer.core.toAsset
@@ -33,7 +34,7 @@ class TestSequencer {
         val sequencer = SequencerClient()
         val marketId = MarketId("BTC1/ETH1")
         sequencer.createMarket(marketId)
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
 
         val maker = 123456789L.toWalletAddress()
         val taker = 555111555L.toWalletAddress()
@@ -121,7 +122,7 @@ class TestSequencer {
         val sequencer = SequencerClient()
         val marketId = MarketId("BTC2/ETH2")
         sequencer.createMarket(marketId)
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
 
         val lp1 = 123457689L.toWalletAddress()
         val lp2 = 987654321L.toWalletAddress()
@@ -240,7 +241,7 @@ class TestSequencer {
     @Test
     fun `test limit checking on orders`() {
         val sequencer = SequencerClient()
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
         val marketId1 = MarketId("BTC3/ETH3")
         sequencer.createMarket(marketId1)
 
@@ -296,7 +297,7 @@ class TestSequencer {
     @Test
     fun `test LimitBuy order can cross the market`() {
         val sequencer = SequencerClient()
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
         val marketId = MarketId("BTC8/ETH8")
         sequencer.createMarket(marketId)
 
@@ -366,7 +367,7 @@ class TestSequencer {
     @Test
     fun `test LimitBuy order can cross the market filling LimitSell orders at multiple levels until limit price`() {
         val sequencer = SequencerClient()
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
         val marketId = MarketId("BTC9/ETH9")
         sequencer.createMarket(marketId)
 
@@ -445,7 +446,7 @@ class TestSequencer {
     @Test
     fun `test LimitSell order can cross the market`() {
         val sequencer = SequencerClient()
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
         val marketId = MarketId("BTC10/ETH10")
         sequencer.createMarket(marketId)
 
@@ -517,7 +518,7 @@ class TestSequencer {
     @Test
     fun `test LimitSell order can cross the market filling LimitBuy orders at multiple levels until limit price`() {
         val sequencer = SequencerClient()
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
         val marketId = MarketId("BTC11/ETH11")
         sequencer.createMarket(marketId)
 
@@ -585,7 +586,7 @@ class TestSequencer {
     @Test
     fun `test order cancel`() {
         val sequencer = SequencerClient()
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
         val marketId = MarketId("BTC4/ETH4")
         sequencer.createMarket(marketId)
 
@@ -625,7 +626,7 @@ class TestSequencer {
     @Test
     fun `test order change`() {
         val sequencer = SequencerClient()
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
         val marketId = MarketId("BTC5/ETH5")
         sequencer.createMarket(marketId)
 
@@ -708,7 +709,7 @@ class TestSequencer {
     @Test
     fun `test order change when new price crosses the market`() {
         val sequencer = SequencerClient()
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
         val marketId = MarketId("BTC12/ETH12")
         sequencer.createMarket(marketId)
 
@@ -798,7 +799,7 @@ class TestSequencer {
     @Test
     fun `test auto-reduce from trades`() {
         val sequencer = SequencerClient()
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
 
         val marketId1 = MarketId("BTC6/ETH6")
         sequencer.createMarket(marketId1, tickSize = BigDecimal.ONE, marketPrice = BigDecimal.valueOf(10.5), baseDecimals = 8, quoteDecimals = 18)
@@ -848,7 +849,7 @@ class TestSequencer {
     @Test
     fun `test auto-reduce from withdrawals`() {
         val sequencer = SequencerClient()
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
         val marketId = MarketId("BTC7/ETH7")
         sequencer.createMarket(marketId)
 
@@ -877,7 +878,7 @@ class TestSequencer {
     fun `fee rate change does not affect existing orders in the book`() {
         val sequencer = SequencerClient()
         // set maker fee rate to 1% and taker fee rate to 2%
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
         val marketId = MarketId("BTC8/ETH8")
         sequencer.createMarket(marketId)
 
@@ -894,8 +895,8 @@ class TestSequencer {
             response.ordersChangedList.first().guid
         }
 
-        // increase maker fee rate to 2% and taker fee rate to 4%
-        sequencer.setFeeRates(makerFeeRatInBps = 200, takerFeeRateInBps = 400)
+        // increase fee rates
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 2.0, taker = 4.0))
 
         val sellOrder2Guid = sequencer.addOrder(marketId, BigDecimal(5).inSats(), "10.00", maker, Order.Type.LimitSell).let { response ->
             assertEquals(OrderDisposition.Accepted, response.ordersChangedList.first().disposition)
@@ -933,7 +934,7 @@ class TestSequencer {
     @Test
     fun `test failed withdrawals`() {
         val sequencer = SequencerClient()
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
 
         val rnd = Random(0)
         val walletAddress = rnd.nextLong().toWalletAddress()
@@ -959,7 +960,7 @@ class TestSequencer {
     @Test
     fun `Test failed settlements`() {
         val sequencer = SequencerClient()
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
 
         val marketId = MarketId("BTC8/ETH8")
         sequencer.createMarket(marketId)
@@ -1032,7 +1033,7 @@ class TestSequencer {
     @Test
     fun `Test autoreduce on failed settlements`() {
         val sequencer = SequencerClient()
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
 
         val marketId = MarketId("BTC9/ETH9")
         sequencer.createMarket(marketId)
@@ -1110,7 +1111,7 @@ class TestSequencer {
     @Test
     fun `Test failed settlements - balances can go negative`() {
         val sequencer = SequencerClient()
-        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
 
         val marketId = MarketId("BTC10/ETH10")
         sequencer.createMarket(marketId)

--- a/sequencer/src/test/kotlin/co/chainring/TestSequencer.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestSequencer.kt
@@ -31,9 +31,10 @@ class TestSequencer {
     @Test
     fun `Test basic order matching`() {
         val sequencer = SequencerClient()
-
         val marketId = MarketId("BTC1/ETH1")
         sequencer.createMarket(marketId)
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+
         val maker = 123456789L.toWalletAddress()
         val taker = 555111555L.toWalletAddress()
         // maker deposits some of both assets -- 1 BTC, 1 ETH
@@ -59,8 +60,10 @@ class TestSequencer {
         val trade = response3.tradesCreatedList.first()
         assertEquals("17.550".toBigDecimal().toDecimalValue(), trade.price)
         assertEquals(BigDecimal("0.00043210").inSats().toIntegerValue(), trade.amount)
-        assertEquals(makerOrder.guid, trade.sellGuid)
-        assertEquals(takerOrder.guid, trade.buyGuid)
+        assertEquals(makerOrder.guid, trade.sellOrderGuid)
+        assertEquals(takerOrder.guid, trade.buyOrderGuid)
+        assertEquals(BigDecimal("0.00015166710").inWei(), trade.buyerFee.toBigInteger())
+        assertEquals(BigDecimal("0.00007583355").inWei(), trade.sellerFee.toBigInteger())
 
         // each of the maker and taker should have two balance changed messages, one for each asset
         assertEquals(4, response3.balancesChangedCount)
@@ -71,17 +74,17 @@ class TestSequencer {
         val makerBaseBalanceChange = makerBalanceChanges.find { it.asset == marketId.baseAsset().value }!!
         val makerQuoteBalanceChange = makerBalanceChanges.find { it.asset == marketId.quoteAsset().value }!!
         assertEquals(-BigDecimal("0.00043210").inSats(), makerBaseBalanceChange.delta.toBigInteger())
-        assertEquals(BigDecimal("0.007583355").inWei(), makerQuoteBalanceChange.delta.toBigInteger())
+        assertEquals(BigDecimal("0.00750752145").inWei(), makerQuoteBalanceChange.delta.toBigInteger())
 
         val takerBaseBalanceChange = takerBalanceChanges.find { it.asset == marketId.baseAsset().value }!!
         val takerQuoteBalanceChange = takerBalanceChanges.find { it.asset == marketId.quoteAsset().value }!!
         assertEquals(BigDecimal("0.00043210").inSats(), takerBaseBalanceChange.delta.toBigInteger())
-        assertEquals(-BigDecimal("0.007583355").inWei(), takerQuoteBalanceChange.delta.toBigInteger())
+        assertEquals(-BigDecimal("0.0077350221").inWei(), takerQuoteBalanceChange.delta.toBigInteger())
         // balances now should be:
         //   maker BTC1 = 1 - 0.00043210 = 0.99956790
-        //         ETH1 = 1 + .007583355 = 1.007583355
+        //         ETH1 = 1 + .00750752145 = 1.00750752145
         //   taker BTC1 = 0.00043210
-        //         ETH1 = 1 - .007583355 = 0.992416645
+        //         ETH1 = 1 - .0077350221 = 0.9922649779
 
         // now try a market sell which can only be partially filled and see that it gets executed
         val response4 = sequencer.addOrder(marketId, BigDecimal("0.00012346").inSats(), null, taker, Order.Type.MarketSell)
@@ -93,20 +96,22 @@ class TestSequencer {
         val trade2 = response4.tradesCreatedList.first()
         assertEquals("17.500".toBigDecimal().toDecimalValue(), trade2.price)
         assertEquals(BigDecimal("0.00012345").inSats().toIntegerValue(), trade2.amount)
-        assertEquals(makerOrder2.guid, trade2.buyGuid)
-        assertEquals(takerOrder2.guid, trade2.sellGuid)
+        assertEquals(makerOrder2.guid, trade2.buyOrderGuid)
+        assertEquals(takerOrder2.guid, trade2.sellOrderGuid)
+        assertEquals(BigDecimal("0.00002160375").inWei(), trade2.buyerFee.toBigInteger())
+        assertEquals(BigDecimal("0.00004320750").inWei(), trade2.sellerFee.toBigInteger())
         // verify the remaining balances for maker and taker (withdraw a large amount - returned balance change will
         // indicate what the balance was)
         // expected balances:
         //
         //   maker BTC1 = 0.00956790 + .00012345 = 0.99969135
-        //         ETH1 = 1.007583355 - 0.002160375 = 1.00542298
+        //         ETH1 = 1.00750752145 - 0.00218197875 = 1.0053255427
         //   taker BTC1 = 0.00043210 - 0.00012345 = 0.00030865
-        //         ETH1 = 0.992416645 + 0.002160375 = 0.99457702
+        //         ETH1 = 0.9922649779 + 0.0021171675 = 0.9943821454
         sequencer.withdrawal(maker, marketId.baseAsset(), BigDecimal.TEN.inSats(), BigDecimal("0.99969135").inSats())
-        sequencer.withdrawal(maker, marketId.quoteAsset(), BigDecimal.TEN.inWei(), BigDecimal("1.00542298").inWei())
+        sequencer.withdrawal(maker, marketId.quoteAsset(), BigDecimal.TEN.inWei(), BigDecimal("1.0053255427").inWei())
         sequencer.withdrawal(taker, marketId.baseAsset(), BigDecimal.TEN.inSats(), BigDecimal("0.00030865").inSats())
-        sequencer.withdrawal(taker, marketId.quoteAsset(), BigDecimal.TEN.inWei(), BigDecimal("0.99457702").inWei())
+        sequencer.withdrawal(taker, marketId.quoteAsset(), BigDecimal.TEN.inWei(), BigDecimal("0.9943821454").inWei())
     }
 
     private fun SequencerResponse.orderGuid() = this.ordersChangedList.first().guid
@@ -114,9 +119,10 @@ class TestSequencer {
     @Test
     fun `Test a market order that executes against multiple orders at multiple levels`() {
         val sequencer = SequencerClient()
-
         val marketId = MarketId("BTC2/ETH2")
         sequencer.createMarket(marketId)
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+
         val lp1 = 123457689L.toWalletAddress()
         val lp2 = 987654321L.toWalletAddress()
         val tkr = 555555555L.toWalletAddress()
@@ -129,8 +135,8 @@ class TestSequencer {
         val sell5 = sequencer.addOrder(marketId, BigInteger.valueOf(20000), "17.700", lp1, Order.Type.LimitSell)
         val sell6 = sequencer.addOrder(marketId, BigInteger.valueOf(20000), "17.700", lp2, Order.Type.LimitSell)
         // clearing price would be (2000 * 17.55 + 15000 * 17.6) / 17000 = 17.594
-        // notional is 17000 * 17.594 * 10^10
-        sequencer.deposit(tkr, marketId.quoteAsset(), BigInteger("2990980000000000"))
+        // notional is 17000 * 17.594 * 10^10 = 2990980000000000, fee would be notional * 0,02 = 59819600000000
+        sequencer.deposit(tkr, marketId.quoteAsset(), BigInteger("2990980000000000") + BigInteger("59819600000000"))
         val response = sequencer.addOrder(marketId, BigInteger.valueOf(17000), null, tkr, Order.Type.MarketBuy)
         assertEquals(5, response.ordersChangedCount)
         assertEquals(OrderDisposition.Filled, response.ordersChangedList[0].disposition)
@@ -141,40 +147,70 @@ class TestSequencer {
             assertEquals(OrderDisposition.PartiallyFilled, disposition)
             assertEquals(BigInteger.valueOf(5000), this.newQuantityOrNull?.toBigInteger())
         }
-        assertEquals(
-            listOf(sell1.orderGuid(), sell2.orderGuid(), sell3.orderGuid(), sell4.orderGuid()),
-            response.tradesCreatedList.map { it.sellGuid },
-        )
-        assertEquals(
-            listOf(1000, 1000, 10000, 5000),
-            response.tradesCreatedList.map { it.amount.toBigInteger().toInt() },
-        )
-        assertEquals(
-            listOf("17.550", "17.550", "17.600", "17.600"),
-            response.tradesCreatedList.map { it.price.toBigDecimal().toString() },
-        )
+
+        assertEquals(4, response.tradesCreatedList.size)
+        response.tradesCreatedList[0].apply {
+            assertEquals(sell1.orderGuid(), this.sellOrderGuid)
+            assertEquals(1000, this.amount.toBigInteger().toInt())
+            assertEquals("17.550", this.price.toBigDecimal().toString())
+            assertEquals(BigDecimal("0.000003510").inWei(), this.buyerFee.toBigInteger())
+            assertEquals(BigDecimal("0.000001755").inWei(), this.sellerFee.toBigInteger())
+        }
+        response.tradesCreatedList[1].apply {
+            assertEquals(sell2.orderGuid(), this.sellOrderGuid)
+            assertEquals(1000, this.amount.toBigInteger().toInt())
+            assertEquals("17.550", this.price.toBigDecimal().toString())
+            assertEquals(BigDecimal("0.000003510").inWei(), this.buyerFee.toBigInteger())
+            assertEquals(BigDecimal("0.000001755").inWei(), this.sellerFee.toBigInteger())
+        }
+        response.tradesCreatedList[2].apply {
+            assertEquals(sell3.orderGuid(), this.sellOrderGuid)
+            assertEquals(10000, this.amount.toBigInteger().toInt())
+            assertEquals("17.600", this.price.toBigDecimal().toString())
+            assertEquals(BigDecimal("0.0000352").inWei(), this.buyerFee.toBigInteger())
+            assertEquals(BigDecimal("0.0000176").inWei(), this.sellerFee.toBigInteger())
+        }
+        response.tradesCreatedList[3].apply {
+            assertEquals(sell4.orderGuid(), this.sellOrderGuid)
+            assertEquals(5000, this.amount.toBigInteger().toInt())
+            assertEquals("17.600", this.price.toBigDecimal().toString())
+            assertEquals(BigDecimal("0.0000176").inWei(), this.buyerFee.toBigInteger())
+            assertEquals(BigDecimal("0.0000088").inWei(), this.sellerFee.toBigInteger())
+        }
+
         // place another market order to exhaust remaining limit orders
         // clearing price would be (5000 * 17.6 + 40000 * 17.7) / 45000 = 17.689
-        // notional is 45000 * 17.689 * 10^10
-        sequencer.deposit(tkr, marketId.quoteAsset(), BigInteger("7960050000000000"))
+        // notional is 45000 * 17.689 * 10^10, fee would be notional * 0,02 = 159201000000000
+        sequencer.deposit(tkr, marketId.quoteAsset(), BigInteger("7960050000000000") + BigInteger("159201000000000"))
         val response2 = sequencer.addOrder(marketId, BigInteger.valueOf(45000), null, tkr, Order.Type.MarketBuy)
         assertEquals(4, response2.ordersChangedCount)
         assertEquals(OrderDisposition.Filled, response2.ordersChangedList[0].disposition)
         assertEquals(OrderDisposition.Filled, response2.ordersChangedList[1].disposition)
         assertEquals(OrderDisposition.Filled, response2.ordersChangedList[2].disposition)
         assertEquals(OrderDisposition.Filled, response2.ordersChangedList[3].disposition)
-        assertEquals(
-            listOf(sell4.orderGuid(), sell5.orderGuid(), sell6.orderGuid()),
-            response2.tradesCreatedList.map { it.sellGuid },
-        )
-        assertEquals(
-            listOf(5000, 20000, 20000),
-            response2.tradesCreatedList.map { it.amount.toBigInteger().toInt() },
-        )
-        assertEquals(
-            listOf("17.600", "17.700", "17.700"),
-            response2.tradesCreatedList.map { it.price.toBigDecimal().toString() },
-        )
+
+        assertEquals(3, response2.tradesCreatedList.size)
+        response2.tradesCreatedList[0].apply {
+            assertEquals(sell4.orderGuid(), this.sellOrderGuid)
+            assertEquals(5000, this.amount.toBigInteger().toInt())
+            assertEquals("17.600", this.price.toBigDecimal().toString())
+            assertEquals(BigDecimal("0.0000176").inWei(), this.buyerFee.toBigInteger())
+            assertEquals(BigDecimal("0.0000088").inWei(), this.sellerFee.toBigInteger())
+        }
+        response2.tradesCreatedList[1].apply {
+            assertEquals(sell5.orderGuid(), this.sellOrderGuid)
+            assertEquals(20000, this.amount.toBigInteger().toInt())
+            assertEquals("17.700", this.price.toBigDecimal().toString())
+            assertEquals(BigDecimal("0.0000708").inWei(), this.buyerFee.toBigInteger())
+            assertEquals(BigDecimal("0.0000354").inWei(), this.sellerFee.toBigInteger())
+        }
+        response2.tradesCreatedList[2].apply {
+            assertEquals(sell6.orderGuid(), this.sellOrderGuid)
+            assertEquals(20000, this.amount.toBigInteger().toInt())
+            assertEquals("17.700", this.price.toBigDecimal().toString())
+            assertEquals(BigDecimal("0.0000708").inWei(), this.buyerFee.toBigInteger())
+            assertEquals(BigDecimal("0.0000354").inWei(), this.sellerFee.toBigInteger())
+        }
     }
 
     @Test
@@ -204,10 +240,13 @@ class TestSequencer {
     @Test
     fun `test limit checking on orders`() {
         val sequencer = SequencerClient()
-        val rnd = Random(0)
-        val maker = rnd.nextLong().toWalletAddress()
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
         val marketId1 = MarketId("BTC3/ETH3")
         sequencer.createMarket(marketId1)
+
+        val rnd = Random(0)
+
+        val maker = rnd.nextLong().toWalletAddress()
         // cannot place a buy or sell limit order without any deposits
         assertEquals(SequencerError.ExceedsLimit, sequencer.addOrder(marketId1, BigInteger.valueOf(1000), "17.55", maker, Order.Type.LimitSell).error)
         assertEquals(SequencerError.ExceedsLimit, sequencer.addOrder(marketId1, BigInteger.valueOf(1000), "17.50", maker, Order.Type.LimitBuy).error)
@@ -217,8 +256,12 @@ class TestSequencer {
         val response = sequencer.addOrder(marketId1, BigInteger.valueOf(1000), "17.55", maker, Order.Type.LimitSell)
         assertEquals(OrderDisposition.Accepted, response.ordersChangedList.first().disposition)
 
-        // deposit some quote and can buy
+        // deposit some quote, but still can't buy because of the fee
         sequencer.deposit(maker, marketId1.quoteAsset(), BigDecimal.valueOf(17.50 * 1000 * 10.0.pow(10)).toBigInteger())
+        assertEquals(SequencerError.ExceedsLimit, sequencer.addOrder(marketId1, BigInteger.valueOf(1000), "17.50", maker, Order.Type.LimitBuy).error)
+
+        // can buy after depositing more quote to cover the fee
+        sequencer.deposit(maker, marketId1.quoteAsset(), BigDecimal.valueOf(17.50 * 10 * 10.0.pow(10)).toBigInteger())
         val response2 = sequencer.addOrder(marketId1, BigInteger.valueOf(1000), "17.50", maker, Order.Type.LimitBuy)
         assertEquals(OrderDisposition.Accepted, response2.ordersChangedList.first().disposition)
 
@@ -253,11 +296,13 @@ class TestSequencer {
     @Test
     fun `test LimitBuy order can cross the market`() {
         val sequencer = SequencerClient()
-        val rnd = Random(0)
-        val maker = rnd.nextLong().toWalletAddress()
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
         val marketId = MarketId("BTC8/ETH8")
         sequencer.createMarket(marketId)
 
+        val rnd = Random(0)
+
+        val maker = rnd.nextLong().toWalletAddress()
         // deposit and prepare liquidity
         sequencer.deposit(maker, marketId.baseAsset(), BigInteger.valueOf(2000))
         val response = sequencer.addOrder(marketId, BigInteger.valueOf(2000), "17.55", maker, Order.Type.LimitSell)
@@ -266,6 +311,8 @@ class TestSequencer {
         // prepare second maker
         val crossingTheMarketMaker = rnd.nextLong().toWalletAddress()
         sequencer.deposit(crossingTheMarketMaker, marketId.quoteAsset(), BigDecimal.valueOf(18.00 * 3000 * 10.0.pow(10)).toBigInteger())
+        // deposit extra for the fees
+        sequencer.deposit(crossingTheMarketMaker, marketId.quoteAsset(), (BigDecimal("0.000003510") * BigDecimal(2)).inWei())
 
         // limit order can cross the market and be filled immediately
         val response2 = sequencer.addOrder(marketId, BigInteger.valueOf(1000), "18.00", crossingTheMarketMaker, Order.Type.LimitBuy)
@@ -276,15 +323,19 @@ class TestSequencer {
         assertEquals(OrderDisposition.PartiallyFilled, r2MakerOrder.disposition)
         assertEquals("17.550".toBigDecimal().toDecimalValue(), r2trade.price)
         assertEquals(BigDecimal("0.00001").inSats().toIntegerValue(), r2trade.amount)
-        assertEquals(r2MakerOrder.guid, r2trade.sellGuid)
-        assertEquals(r2TakerOrder.guid, r2trade.buyGuid)
+        assertEquals(r2MakerOrder.guid, r2trade.sellOrderGuid)
+        assertEquals(BigDecimal("0.000001755").inWei(), r2trade.sellerFee.toBigInteger())
+        assertEquals(r2TakerOrder.guid, r2trade.buyOrderGuid)
+        assertEquals(BigDecimal("0.000003510").inWei(), r2trade.buyerFee.toBigInteger())
         verifyBalanceChanges(
             marketId = marketId,
             balancesChangedList = response2.balancesChangedList,
             makerWallet = maker,
             takerWallet = crossingTheMarketMaker,
+            expectedMakerBaseBalanceChange = -BigDecimal("0.00001").inSats(),
+            expectedMakerQuoteBalanceChange = BigDecimal("0.000173745").inWei(),
             expectedTakerBaseBalanceChange = BigDecimal("0.00001").inSats(),
-            expectedTakerQuoteBalanceChange = -BigDecimal("0.0001755").inWei(),
+            expectedTakerQuoteBalanceChange = -BigDecimal("0.00017901").inWei(),
         )
 
         // or filled partially with remaining limit amount stays on the book
@@ -296,26 +347,32 @@ class TestSequencer {
         val r3trade = response3.tradesCreatedList.first()
         assertEquals("17.550".toBigDecimal().toDecimalValue(), r3trade.price)
         assertEquals(BigDecimal("0.00001").inSats().toIntegerValue(), r3trade.amount)
-        assertEquals(r3MakerOrder.guid, r3trade.sellGuid)
-        assertEquals(r3TakerOrder.guid, r3trade.buyGuid)
+        assertEquals(r3MakerOrder.guid, r3trade.sellOrderGuid)
+        assertEquals(BigDecimal("0.000001755").inWei(), r3trade.sellerFee.toBigInteger())
+        assertEquals(r3TakerOrder.guid, r3trade.buyOrderGuid)
+        assertEquals(BigDecimal("0.000003510").inWei(), r3trade.buyerFee.toBigInteger())
         verifyBalanceChanges(
             marketId = marketId,
             balancesChangedList = response2.balancesChangedList,
             makerWallet = maker,
             takerWallet = crossingTheMarketMaker,
+            expectedMakerBaseBalanceChange = -BigDecimal("0.00001").inSats(),
+            expectedMakerQuoteBalanceChange = BigDecimal("0.000173745").inWei(),
             expectedTakerBaseBalanceChange = BigDecimal("0.00001").inSats(),
-            expectedTakerQuoteBalanceChange = -BigDecimal("0.0001755").inWei(),
+            expectedTakerQuoteBalanceChange = -BigDecimal("0.00017901").inWei(),
         )
     }
 
     @Test
     fun `test LimitBuy order can cross the market filling LimitSell orders at multiple levels until limit price`() {
         val sequencer = SequencerClient()
-        val rnd = Random(0)
-        val maker = rnd.nextLong().toWalletAddress()
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
         val marketId = MarketId("BTC9/ETH9")
         sequencer.createMarket(marketId)
 
+        val rnd = Random(0)
+
+        val maker = rnd.nextLong().toWalletAddress()
         // deposit and prepare liquidity
         sequencer.deposit(maker, marketId.baseAsset(), BigInteger.valueOf(2000))
         val sell1 = sequencer.addOrder(marketId, BigInteger.valueOf(100), "17.55", maker, Order.Type.LimitSell)
@@ -328,8 +385,16 @@ class TestSequencer {
         val crossingTheMarketMaker = rnd.nextLong().toWalletAddress()
         sequencer.deposit(crossingTheMarketMaker, marketId.quoteAsset(), BigDecimal.valueOf(18.2101 * 500 * 10.0.pow(10)).toBigInteger())
         assertEquals(SequencerError.ExceedsLimit, sequencer.addOrder(marketId, BigInteger.valueOf(500), "18.50", crossingTheMarketMaker, Order.Type.LimitBuy).error)
+
+        val expectedBuyerFeesForFilledAmount = (BigDecimal("0.0000003510") + BigDecimal("0.00000036") + BigDecimal("0.000000370")).inWei()
+        val expectedBuyerFeesForRemainingAmount = BigDecimal.valueOf(19.00 * 200 * 10.0.pow(10)).toBigInteger()
+
         // limit check passes on lower deposited amount due to partial filling by market price
-        sequencer.deposit(crossingTheMarketMaker, marketId.quoteAsset(), BigDecimal.valueOf(0.0001 * 500 * 10.0.pow(10)).toBigInteger())
+        sequencer.deposit(
+            crossingTheMarketMaker,
+            marketId.quoteAsset(),
+            BigDecimal.valueOf(0.0001 * 500 * 10.0.pow(10)).toBigInteger() + expectedBuyerFeesForFilledAmount + expectedBuyerFeesForRemainingAmount,
+        )
 
         // limit order is partially filled until limit price is reached
         val response2 = sequencer.addOrder(marketId, BigInteger.valueOf(500), "18.50", crossingTheMarketMaker, Order.Type.LimitBuy)
@@ -338,42 +403,59 @@ class TestSequencer {
         assertEquals(OrderDisposition.Filled, response2.ordersChangedList[1].disposition)
         assertEquals(OrderDisposition.Filled, response2.ordersChangedList[2].disposition)
         assertEquals(OrderDisposition.Filled, response2.ordersChangedList[3].disposition)
-        assertEquals(
-            listOf(sell1.orderGuid(), sell2.orderGuid(), sell3.orderGuid()),
-            response2.tradesCreatedList.map { it.sellGuid },
-        )
-        assertEquals(
-            listOf(response2.orderGuid()),
-            response2.tradesCreatedList.map { it.buyGuid }.distinct(),
-        )
-        assertEquals(
-            listOf(100, 100, 100),
-            response2.tradesCreatedList.map { it.amount.toBigInteger().toInt() },
-        )
-        assertEquals(
-            listOf("17.550", "18.000", "18.500"),
-            response2.tradesCreatedList.map { it.price.toBigDecimal().toString() },
-        )
+
+        assertEquals(3, response2.tradesCreatedList.size)
+        response2.tradesCreatedList[0].apply {
+            assertEquals(sell1.orderGuid(), this.sellOrderGuid)
+            assertEquals(response2.orderGuid(), this.buyOrderGuid)
+            assertEquals(100, this.amount.toBigInteger().toInt())
+            assertEquals("17.550", this.price.toBigDecimal().toString())
+            assertEquals(BigDecimal("0.0000001755").inWei(), this.sellerFee.toBigInteger())
+            assertEquals(BigDecimal("0.0000003510").inWei(), this.buyerFee.toBigInteger())
+        }
+        response2.tradesCreatedList[1].apply {
+            assertEquals(sell2.orderGuid(), this.sellOrderGuid)
+            assertEquals(response2.orderGuid(), this.buyOrderGuid)
+            assertEquals(100, this.amount.toBigInteger().toInt())
+            assertEquals("18.000", this.price.toBigDecimal().toString())
+            assertEquals(BigDecimal("0.00000018").inWei(), this.sellerFee.toBigInteger())
+            assertEquals(BigDecimal("0.00000036").inWei(), this.buyerFee.toBigInteger())
+        }
+        response2.tradesCreatedList[2].apply {
+            assertEquals(sell3.orderGuid(), this.sellOrderGuid)
+            assertEquals(response2.orderGuid(), this.buyOrderGuid)
+            assertEquals(100, this.amount.toBigInteger().toInt())
+            assertEquals("18.500", this.price.toBigDecimal().toString())
+            assertEquals(BigDecimal("0.000000185").inWei(), this.sellerFee.toBigInteger())
+            assertEquals(BigDecimal("0.000000370").inWei(), this.buyerFee.toBigInteger())
+        }
+
         verifyBalanceChanges(
             marketId = marketId,
             balancesChangedList = response2.balancesChangedList,
             makerWallet = maker,
             takerWallet = crossingTheMarketMaker,
+            expectedMakerBaseBalanceChange = -BigDecimal("0.000003").inSats(),
+            expectedMakerQuoteBalanceChange = BigDecimal("0.0000535095").inWei(),
             expectedTakerBaseBalanceChange = BigDecimal("0.000003").inSats(),
-            expectedTakerQuoteBalanceChange = -BigDecimal("0.00005405").inWei(),
+            expectedTakerQuoteBalanceChange = -(BigDecimal("0.00005405").inWei() + expectedBuyerFeesForFilledAmount),
         )
     }
 
     @Test
     fun `test LimitSell order can cross the market`() {
         val sequencer = SequencerClient()
-        val rnd = Random(0)
-        val maker = rnd.nextLong().toWalletAddress()
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
         val marketId = MarketId("BTC10/ETH10")
         sequencer.createMarket(marketId)
 
+        val rnd = Random(0)
+
+        val maker = rnd.nextLong().toWalletAddress()
         // deposit and prepare liquidity
         sequencer.deposit(maker, marketId.quoteAsset(), BigDecimal.valueOf(17.50 * 2000 * 10.0.pow(10)).toBigInteger())
+        // deposit extra for the fees
+        sequencer.deposit(maker, marketId.quoteAsset(), (BigDecimal("0.00001750") * BigDecimal(2)).inWei())
         val response1 = sequencer.addOrder(marketId, BigInteger.valueOf(2000), "17.50", maker, Order.Type.LimitBuy)
         assertEquals(OrderDisposition.Accepted, response1.ordersChangedList.first().disposition)
 
@@ -383,6 +465,7 @@ class TestSequencer {
 
         // limit order can cross the market and be filled immediately
         val response2 = sequencer.addOrder(marketId, BigInteger.valueOf(1000), "17.00", crossingTheMarketMaker, Order.Type.LimitSell)
+        assertEquals(2, response2.ordersChangedList.size)
         val r2TakerOrder = response2.ordersChangedList.first()
         val r2MakerOrder = response2.ordersChangedList.last()
         val r2trade = response2.tradesCreatedList.first()
@@ -390,19 +473,24 @@ class TestSequencer {
         assertEquals(OrderDisposition.PartiallyFilled, r2MakerOrder.disposition)
         assertEquals("17.500".toBigDecimal().toDecimalValue(), r2trade.price)
         assertEquals(BigDecimal("0.00001").inSats().toIntegerValue(), r2trade.amount)
-        assertEquals(r2MakerOrder.guid, r2trade.buyGuid)
-        assertEquals(r2TakerOrder.guid, r2trade.sellGuid)
+        assertEquals(r2MakerOrder.guid, r2trade.buyOrderGuid)
+        assertEquals(BigDecimal("0.000001750").inWei(), r2trade.buyerFee.toBigInteger())
+        assertEquals(r2TakerOrder.guid, r2trade.sellOrderGuid)
+        assertEquals(BigDecimal("0.000003500").inWei(), r2trade.sellerFee.toBigInteger())
         verifyBalanceChanges(
             marketId = marketId,
             balancesChangedList = response2.balancesChangedList,
             makerWallet = maker,
             takerWallet = crossingTheMarketMaker,
+            expectedMakerBaseBalanceChange = BigDecimal("0.00001").inSats(),
+            expectedMakerQuoteBalanceChange = -BigDecimal("0.00017675").inWei(),
             expectedTakerBaseBalanceChange = -BigDecimal("0.00001").inSats(),
-            expectedTakerQuoteBalanceChange = BigDecimal("0.000175").inWei(),
+            expectedTakerQuoteBalanceChange = BigDecimal("0.000171500").inWei(),
         )
 
         // or filled partially with remaining limit amount stays on the book
         val response3 = sequencer.addOrder(marketId, BigInteger.valueOf(2000), "17.00", crossingTheMarketMaker, Order.Type.LimitSell)
+        assertEquals(2, response3.ordersChangedList.size)
         val r3TakerOrder = response3.ordersChangedList.first()
         val r3MakerOrder = response3.ordersChangedList.last()
         assertEquals(OrderDisposition.PartiallyFilled, r3TakerOrder.disposition)
@@ -410,26 +498,32 @@ class TestSequencer {
         val r3trade = response3.tradesCreatedList.first()
         assertEquals("17.500".toBigDecimal().toDecimalValue(), r3trade.price)
         assertEquals(BigDecimal("0.00001").inSats().toIntegerValue(), r3trade.amount)
-        assertEquals(r3MakerOrder.guid, r3trade.buyGuid)
-        assertEquals(r3TakerOrder.guid, r3trade.sellGuid)
+        assertEquals(r3MakerOrder.guid, r3trade.buyOrderGuid)
+        assertEquals(BigDecimal("0.000001750").inWei(), r3trade.buyerFee.toBigInteger())
+        assertEquals(r3TakerOrder.guid, r3trade.sellOrderGuid)
+        assertEquals(BigDecimal("0.000003500").inWei(), r3trade.sellerFee.toBigInteger())
         verifyBalanceChanges(
             marketId = marketId,
             balancesChangedList = response2.balancesChangedList,
             makerWallet = maker,
             takerWallet = crossingTheMarketMaker,
+            expectedMakerBaseBalanceChange = BigDecimal("0.00001").inSats(),
+            expectedMakerQuoteBalanceChange = -BigDecimal("0.00017675").inWei(),
             expectedTakerBaseBalanceChange = -BigDecimal("0.00001").inSats(),
-            expectedTakerQuoteBalanceChange = BigDecimal("0.000175").inWei(),
+            expectedTakerQuoteBalanceChange = BigDecimal("0.000171500").inWei(),
         )
     }
 
     @Test
     fun `test LimitSell order can cross the market filling LimitBuy orders at multiple levels until limit price`() {
         val sequencer = SequencerClient()
-        val rnd = Random(0)
-        val maker = rnd.nextLong().toWalletAddress()
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
         val marketId = MarketId("BTC11/ETH11")
         sequencer.createMarket(marketId)
 
+        val rnd = Random(0)
+
+        val maker = rnd.nextLong().toWalletAddress()
         // deposit and prepare liquidity
         sequencer.deposit(maker, marketId.quoteAsset(), BigDecimal.valueOf(17.50 * 2000 * 10.0.pow(10)).toBigInteger())
         val buy1 = sequencer.addOrder(marketId, BigInteger.valueOf(100), "17.50", maker, Order.Type.LimitBuy)
@@ -449,39 +543,55 @@ class TestSequencer {
         assertEquals(OrderDisposition.Filled, response2.ordersChangedList[1].disposition)
         assertEquals(OrderDisposition.Filled, response2.ordersChangedList[2].disposition)
         assertEquals(OrderDisposition.Filled, response2.ordersChangedList[3].disposition)
-        assertEquals(
-            listOf(buy1.orderGuid(), buy2.orderGuid(), buy3.orderGuid()),
-            response2.tradesCreatedList.map { it.buyGuid },
-        )
-        assertEquals(
-            listOf(response2.orderGuid()),
-            response2.tradesCreatedList.map { it.sellGuid }.distinct(),
-        )
-        assertEquals(
-            listOf(100, 100, 100),
-            response2.tradesCreatedList.map { it.amount.toBigInteger().toInt() },
-        )
-        assertEquals(
-            listOf("17.500", "17.000", "16.500"),
-            response2.tradesCreatedList.map { it.price.toBigDecimal().toString() },
-        )
+
+        assertEquals(3, response2.tradesCreatedList.size)
+        response2.tradesCreatedList[0].apply {
+            assertEquals(buy1.orderGuid(), this.buyOrderGuid)
+            assertEquals(response2.orderGuid(), this.sellOrderGuid)
+            assertEquals(100, this.amount.toBigInteger().toInt())
+            assertEquals("17.500", this.price.toBigDecimal().toString())
+            assertEquals(BigDecimal("0.0000003500").inWei(), this.sellerFee.toBigInteger())
+            assertEquals(BigDecimal("0.0000001750").inWei(), this.buyerFee.toBigInteger())
+        }
+        response2.tradesCreatedList[1].apply {
+            assertEquals(buy2.orderGuid(), this.buyOrderGuid)
+            assertEquals(response2.orderGuid(), this.sellOrderGuid)
+            assertEquals(100, this.amount.toBigInteger().toInt())
+            assertEquals("17.000", this.price.toBigDecimal().toString())
+            assertEquals(BigDecimal("0.0000003400").inWei(), this.sellerFee.toBigInteger())
+            assertEquals(BigDecimal("0.0000001700").inWei(), this.buyerFee.toBigInteger())
+        }
+        response2.tradesCreatedList[2].apply {
+            assertEquals(buy3.orderGuid(), this.buyOrderGuid)
+            assertEquals(response2.orderGuid(), this.sellOrderGuid)
+            assertEquals(100, this.amount.toBigInteger().toInt())
+            assertEquals("16.500", this.price.toBigDecimal().toString())
+            assertEquals(BigDecimal("0.0000003300").inWei(), this.sellerFee.toBigInteger())
+            assertEquals(BigDecimal("0.0000001650").inWei(), this.buyerFee.toBigInteger())
+        }
+
         verifyBalanceChanges(
             marketId = marketId,
             balancesChangedList = response2.balancesChangedList,
             makerWallet = maker,
             takerWallet = crossingTheMarketMaker,
+            expectedMakerBaseBalanceChange = BigDecimal("0.000003").inSats(),
+            expectedMakerQuoteBalanceChange = -BigDecimal("0.00005151").inWei(),
             expectedTakerBaseBalanceChange = -BigDecimal("0.000003").inSats(),
-            expectedTakerQuoteBalanceChange = BigDecimal("0.000051").inWei(),
+            expectedTakerQuoteBalanceChange = BigDecimal("0.000049980").inWei(),
         )
     }
 
     @Test
     fun `test order cancel`() {
         val sequencer = SequencerClient()
-        val rnd = Random(0)
-        val maker = rnd.nextLong().toWalletAddress()
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
         val marketId = MarketId("BTC4/ETH4")
         sequencer.createMarket(marketId)
+
+        val rnd = Random(0)
+
+        val maker = rnd.nextLong().toWalletAddress()
         sequencer.deposit(maker, marketId.baseAsset(), BigInteger.valueOf(1000))
         val response = sequencer.addOrder(marketId, BigInteger.valueOf(1000), "17.55", maker, Order.Type.LimitSell)
         assertEquals(OrderDisposition.Accepted, response.ordersChangedList.first().disposition)
@@ -515,10 +625,13 @@ class TestSequencer {
     @Test
     fun `test order change`() {
         val sequencer = SequencerClient()
-        val rnd = Random(0)
-        val maker = rnd.nextLong().toWalletAddress()
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
         val marketId = MarketId("BTC5/ETH5")
         sequencer.createMarket(marketId)
+
+        val rnd = Random(0)
+
+        val maker = rnd.nextLong().toWalletAddress()
         sequencer.deposit(maker, marketId.baseAsset(), BigInteger.valueOf(1000))
         val response = sequencer.addOrder(marketId, BigInteger.valueOf(1000), "17.55", maker, Order.Type.LimitSell)
         assertEquals(OrderDisposition.Accepted, response.ordersChangedList.first().disposition)
@@ -543,7 +656,7 @@ class TestSequencer {
         assertEquals(OrderDisposition.Accepted, response5.ordersChangedList.first().disposition)
 
         // check for a limit buy
-        sequencer.deposit(maker, marketId.quoteAsset(), BigDecimal.TEN.inWei())
+        sequencer.deposit(maker, marketId.quoteAsset(), BigDecimal("10.1").inWei())
         val response6 = sequencer.addOrder(marketId, BigDecimal.ONE.inSats(), "10.00", maker, Order.Type.LimitBuy)
         assertEquals(OrderDisposition.Accepted, response6.ordersChangedList.first().disposition)
 
@@ -595,14 +708,18 @@ class TestSequencer {
     @Test
     fun `test order change when new price crosses the market`() {
         val sequencer = SequencerClient()
-        val rnd = Random(0)
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
         val marketId = MarketId("BTC12/ETH12")
         sequencer.createMarket(marketId)
+
+        val rnd = Random(0)
 
         // onboard maker and prepare market
         val maker = rnd.nextLong().toWalletAddress()
         sequencer.deposit(maker, marketId.baseAsset(), BigInteger.valueOf(2000))
         sequencer.deposit(maker, marketId.quoteAsset(), BigDecimal.valueOf(17.50 * 2000 * 10.0.pow(10)).toBigInteger())
+        // deposit extra for the fees
+        sequencer.deposit(maker, marketId.quoteAsset(), (BigDecimal("0.000001750") + BigDecimal("0.000001755")).inWei())
         val m1sell2 = sequencer.addOrder(marketId, BigInteger.valueOf(1000), "18.00", maker, Order.Type.LimitSell)
         val m1sell1 = sequencer.addOrder(marketId, BigInteger.valueOf(1000), "17.55", maker, Order.Type.LimitSell)
         val m1buy1 = sequencer.addOrder(marketId, BigInteger.valueOf(1000), "17.50", maker, Order.Type.LimitBuy)
@@ -612,6 +729,8 @@ class TestSequencer {
         val anotherMaker = rnd.nextLong().toWalletAddress()
         sequencer.deposit(anotherMaker, marketId.baseAsset(), BigInteger.valueOf(2000))
         sequencer.deposit(anotherMaker, marketId.quoteAsset(), BigDecimal.valueOf(17.7 * 2000 * 10.0.pow(10)).toBigInteger())
+        // deposit extra for the fees
+        sequencer.deposit(maker, marketId.quoteAsset(), (BigDecimal("0.000003500") + BigDecimal("0.000003510")).inWei())
         val m2sell1 = sequencer.addOrder(marketId, BigInteger.valueOf(2000), "18.00", anotherMaker, Order.Type.LimitSell)
         val m2buy1 = sequencer.addOrder(marketId, BigInteger.valueOf(2000), "17.00", anotherMaker, Order.Type.LimitBuy)
 
@@ -627,17 +746,24 @@ class TestSequencer {
         assertEquals(OrderDisposition.PartiallyFilled, m2sell1ChangeResponse.ordersChangedList[0].disposition)
         assertEquals(OrderDisposition.Filled, m2sell1ChangeResponse.ordersChangedList[1].disposition)
         assertEquals(1, m2sell1ChangeResponse.tradesCreatedCount)
-        assertEquals(m1buy1.orderGuid(), m2sell1ChangeResponse.tradesCreatedList.first().buyGuid)
-        assertEquals(m2sell1ChangeResponse.orderGuid(), m2sell1ChangeResponse.tradesCreatedList.first().sellGuid)
-        assertEquals(1000, m2sell1ChangeResponse.tradesCreatedList.first().amount.toBigInteger().toInt())
-        assertEquals("17.500", m2sell1ChangeResponse.tradesCreatedList.first().price.toBigDecimal().toString())
+
+        m2sell1ChangeResponse.tradesCreatedList[0].apply {
+            assertEquals(m1buy1.orderGuid(), this.buyOrderGuid)
+            assertEquals(m2sell1ChangeResponse.orderGuid(), this.sellOrderGuid)
+            assertEquals(1000, this.amount.toBigInteger().toInt())
+            assertEquals("17.500", this.price.toBigDecimal().toString())
+            assertEquals(BigDecimal("0.000003500").inWei(), this.sellerFee.toBigInteger())
+            assertEquals(BigDecimal("0.000001750").inWei(), this.buyerFee.toBigInteger())
+        }
         verifyBalanceChanges(
             marketId = marketId,
             balancesChangedList = m2sell1ChangeResponse.balancesChangedList,
             makerWallet = maker,
             takerWallet = anotherMaker,
+            expectedMakerBaseBalanceChange = BigDecimal("0.00001").inSats(),
+            expectedMakerQuoteBalanceChange = -BigDecimal("0.00017675").inWei(),
             expectedTakerBaseBalanceChange = -BigDecimal("0.00001").inSats(),
-            expectedTakerQuoteBalanceChange = BigDecimal("0.0001750").inWei(),
+            expectedTakerQuoteBalanceChange = BigDecimal("0.000171500").inWei(),
         )
 
         // now cancel own order (limit sell 17.30) to avoid matching
@@ -649,45 +775,60 @@ class TestSequencer {
         assertEquals(OrderDisposition.PartiallyFilled, m2buy1ChangeResponse.ordersChangedList[0].disposition)
         assertEquals(OrderDisposition.Filled, m2buy1ChangeResponse.ordersChangedList[1].disposition)
         assertEquals(1, m2buy1ChangeResponse.tradesCreatedCount)
-        assertEquals(m1sell1.orderGuid(), m2buy1ChangeResponse.tradesCreatedList.first().sellGuid)
-        assertEquals(m2buy1ChangeResponse.orderGuid(), m2buy1ChangeResponse.tradesCreatedList.first().buyGuid)
-        assertEquals(1000, m2buy1ChangeResponse.tradesCreatedList.first().amount.toBigInteger().toInt())
-        assertEquals("17.550", m2buy1ChangeResponse.tradesCreatedList.first().price.toBigDecimal().toString())
+        m2buy1ChangeResponse.tradesCreatedList[0].apply {
+            assertEquals(m1sell1.orderGuid(), this.sellOrderGuid)
+            assertEquals(m2buy1ChangeResponse.orderGuid(), this.buyOrderGuid)
+            assertEquals(1000, this.amount.toBigInteger().toInt())
+            assertEquals("17.550", this.price.toBigDecimal().toString())
+            assertEquals(BigDecimal("0.000001755").inWei(), this.sellerFee.toBigInteger())
+            assertEquals(BigDecimal("0.000003510").inWei(), this.buyerFee.toBigInteger())
+        }
         verifyBalanceChanges(
             marketId = marketId,
             balancesChangedList = m2buy1ChangeResponse.balancesChangedList,
             makerWallet = maker,
             takerWallet = anotherMaker,
+            expectedMakerBaseBalanceChange = -BigDecimal("0.00001").inSats(),
+            expectedMakerQuoteBalanceChange = BigDecimal("0.000173745").inWei(),
             expectedTakerBaseBalanceChange = BigDecimal("0.00001").inSats(),
-            expectedTakerQuoteBalanceChange = -BigDecimal("0.0001755").inWei(),
+            expectedTakerQuoteBalanceChange = -BigDecimal("0.00017901").inWei(),
         )
     }
 
     @Test
     fun `test auto-reduce from trades`() {
         val sequencer = SequencerClient()
-        val rnd = Random(0)
-        val maker = rnd.nextLong().toWalletAddress()
-        // create two markets
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+
         val marketId1 = MarketId("BTC6/ETH6")
-        val marketId2 = MarketId("ETH6/USDC6")
-        val marketId3 = MarketId("XXX6/ETH6")
         sequencer.createMarket(marketId1, tickSize = BigDecimal.ONE, marketPrice = BigDecimal.valueOf(10.5), baseDecimals = 8, quoteDecimals = 18)
+
+        val marketId2 = MarketId("ETH6/USDC6")
         sequencer.createMarket(marketId2, tickSize = BigDecimal.ONE, marketPrice = BigDecimal.valueOf(9.5), baseDecimals = 18, quoteDecimals = 6)
+
+        val marketId3 = MarketId("XXX6/ETH6")
         sequencer.createMarket(marketId3, tickSize = BigDecimal.ONE, marketPrice = BigDecimal.valueOf(20.5), baseDecimals = 1, quoteDecimals = 18)
-        // maker deposits 10 ETH
-        sequencer.deposit(maker, marketId1.quoteAsset(), BigDecimal.TEN.inWei())
-        // maker adds a bid in market1 using all 10 eth
+
+        val rnd = Random(0)
+
+        val maker = rnd.nextLong().toWalletAddress()
+
+        // maker deposits 10.1 ETH
+        sequencer.deposit(maker, marketId1.quoteAsset(), BigDecimal("10.1").inWei())
+
+        // maker adds a bid in market1 using all 10.1 eth
         val response1 = sequencer.addOrder(marketId1, BigDecimal.ONE.inSats(), "10", maker, Order.Type.LimitBuy)
         assertEquals(OrderDisposition.Accepted, response1.ordersChangedList.first().disposition)
-        // maker adds an offer in market2 using all 10 eth
+
+        // maker adds an offer in market2 using all 10.1 eth
         val response2 = sequencer.addOrder(marketId2, BigDecimal.TEN.inWei(), "10", maker, Order.Type.LimitSell)
         assertEquals(OrderDisposition.Accepted, response2.ordersChangedList.first().disposition)
-        // maker also adds a bid in market3 using all 10 eth
+
+        // maker also adds a bid in market3 using all 10.1 eth
         val response3 = sequencer.addOrder(marketId3, BigInteger.valueOf(5), "20", maker, Order.Type.LimitBuy)
         assertEquals(OrderDisposition.Accepted, response3.ordersChangedList.first().disposition)
 
-        // now add a taker who will hit the market1 bid selling 0.6 BTC
+        // now add a taker who will hit the market1 bid selling 0.6 BTC, this would consume 6 ETH + 0,06 ETH fee from maker
         val taker = rnd.nextLong().toWalletAddress()
         sequencer.deposit(taker, marketId1.baseAsset(), BigDecimal.valueOf(0.6).inSats())
         val response4 = sequencer.addOrder(marketId1, BigDecimal.valueOf(0.6).inSats(), null, taker, Order.Type.MarketSell)
@@ -696,7 +837,7 @@ class TestSequencer {
         // the maker's offer in market2 should be auto-reduced
         val reducedOffer = response4.ordersChangedList.find { it.guid == response2.orderGuid() }!!
         assertEquals(OrderDisposition.AutoReduced, reducedOffer.disposition)
-        assertEquals(BigDecimal.valueOf(4).inWei(), reducedOffer.newQuantity.toBigInteger())
+        assertEquals(BigDecimal("4.04").inWei(), reducedOffer.newQuantity.toBigInteger())
 
         // also the maker's bid in market3 should be auto-reduced
         val reducedBid = response4.ordersChangedList.find { it.guid == response3.orderGuid() }!!
@@ -707,10 +848,13 @@ class TestSequencer {
     @Test
     fun `test auto-reduce from withdrawals`() {
         val sequencer = SequencerClient()
-        val rnd = Random(0)
-        val maker = rnd.nextLong().toWalletAddress()
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
         val marketId = MarketId("BTC7/ETH7")
         sequencer.createMarket(marketId)
+
+        val rnd = Random(0)
+
+        val maker = rnd.nextLong().toWalletAddress()
         // maker deposits 10 BTC
         sequencer.deposit(maker, marketId.baseAsset(), BigDecimal.TEN.inSats())
         // maker adds two offers combined which use all 10 BTC
@@ -730,14 +874,75 @@ class TestSequencer {
     }
 
     @Test
+    fun `fee rate change does not affect existing orders in the book`() {
+        val sequencer = SequencerClient()
+        // set maker fee rate to 1% and taker fee rate to 2%
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+        val marketId = MarketId("BTC8/ETH8")
+        sequencer.createMarket(marketId)
+
+        val rnd = Random(0)
+
+        val maker = rnd.nextLong().toWalletAddress()
+        val taker = rnd.nextLong().toWalletAddress()
+
+        sequencer.deposit(maker, marketId.baseAsset(), BigDecimal("10").inSats())
+        sequencer.deposit(taker, marketId.quoteAsset(), BigDecimal("200").inWei())
+
+        val sellOrder1Guid = sequencer.addOrder(marketId, BigDecimal(5).inSats(), "10.00", maker, Order.Type.LimitSell).let { response ->
+            assertEquals(OrderDisposition.Accepted, response.ordersChangedList.first().disposition)
+            response.ordersChangedList.first().guid
+        }
+
+        // increase maker fee rate to 2% and taker fee rate to 4%
+        sequencer.setFeeRates(makerFeeRatInBps = 200, takerFeeRateInBps = 400)
+
+        val sellOrder2Guid = sequencer.addOrder(marketId, BigDecimal(5).inSats(), "10.00", maker, Order.Type.LimitSell).let { response ->
+            assertEquals(OrderDisposition.Accepted, response.ordersChangedList.first().disposition)
+            response.ordersChangedList.first().guid
+        }
+
+        sequencer.addOrder(marketId, BigDecimal(10).inSats(), null, taker, Order.Type.MarketBuy).apply {
+            assertEquals(3, this.ordersChangedList.size)
+            assertEquals(OrderDisposition.Filled, this.ordersChangedList[0].disposition)
+            assertEquals(OrderDisposition.Filled, this.ordersChangedList[1].disposition)
+            assertEquals(OrderDisposition.Filled, this.ordersChangedList[2].disposition)
+
+            assertEquals(2, this.tradesCreatedList.size)
+            this.tradesCreatedList[0].apply {
+                assertEquals(sellOrder1Guid, this.sellOrderGuid)
+                assertEquals(BigDecimal(5).inSats(), this.amount.toBigInteger())
+                assertEquals("10.000", this.price.toBigDecimal().toString())
+                // maker's fee is 1% since first order was created before fee rate increase
+                assertEquals(BigDecimal("0.5").inWei(), this.sellerFee.toBigInteger())
+                // taker's fee is 4%
+                assertEquals(BigDecimal("2.0").inWei(), this.buyerFee.toBigInteger())
+            }
+            this.tradesCreatedList[1].apply {
+                assertEquals(sellOrder2Guid, this.sellOrderGuid)
+                assertEquals(BigDecimal(5).inSats(), this.amount.toBigInteger())
+                assertEquals("10.000", this.price.toBigDecimal().toString())
+                // maker's fee is 2% since second order was created after fee rate increase
+                assertEquals(BigDecimal("1.0").inWei(), this.sellerFee.toBigInteger())
+                // taker's fee is 4%
+                assertEquals(BigDecimal("2.0").inWei(), this.buyerFee.toBigInteger())
+            }
+        }
+    }
+
+    @Test
     fun `test failed withdrawals`() {
         val sequencer = SequencerClient()
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
+
         val rnd = Random(0)
         val walletAddress = rnd.nextLong().toWalletAddress()
         val asset = "ETH".toAsset()
         val amount = BigInteger.valueOf(1000)
+
         // do a deposit
         sequencer.deposit(walletAddress, asset, amount)
+
         // withdraw half
         sequencer.withdrawal(walletAddress, asset, amount / BigInteger.TWO)
 
@@ -754,16 +959,20 @@ class TestSequencer {
     @Test
     fun `Test failed settlements`() {
         val sequencer = SequencerClient()
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
 
         val marketId = MarketId("BTC8/ETH8")
         sequencer.createMarket(marketId)
+
         val maker = 123456789L.toWalletAddress()
         val taker = 555111555L.toWalletAddress()
+
         // maker deposits some of both assets -- 2 BTC, 2 ETH
         val makerBaseBalance = BigDecimal("2").inSats()
         val makerQuoteBalance = BigDecimal("2").inWei()
         sequencer.deposit(maker, marketId.baseAsset(), makerBaseBalance)
         sequencer.deposit(maker, marketId.quoteAsset(), makerQuoteBalance)
+
         // place an order and see that it gets accepted
         val response = sequencer.addOrder(marketId, BigDecimal("0.00012345").inSats(), "17.500", maker, Order.Type.LimitBuy)
         assertEquals(OrderDisposition.Accepted, response.ordersChangedList.first().disposition)
@@ -786,8 +995,8 @@ class TestSequencer {
         val trade = response3.tradesCreatedList.first()
         assertEquals("17.550".toBigDecimal().toDecimalValue(), trade.price)
         assertEquals(BigDecimal("0.00043210").inSats().toIntegerValue(), trade.amount)
-        assertEquals(makerOrder.guid, trade.sellGuid)
-        assertEquals(takerOrder.guid, trade.buyGuid)
+        assertEquals(makerOrder.guid, trade.sellOrderGuid)
+        assertEquals(takerOrder.guid, trade.buyOrderGuid)
 
         // each of the maker and taker should have two balance changed messages, one for each asset
         verifyBalanceChanges(
@@ -795,8 +1004,10 @@ class TestSequencer {
             balancesChangedList = response3.balancesChangedList,
             makerWallet = maker,
             takerWallet = taker,
+            expectedMakerBaseBalanceChange = -BigDecimal("0.00043210").inSats(),
+            expectedMakerQuoteBalanceChange = BigDecimal("0.00750752145").inWei(),
             expectedTakerBaseBalanceChange = BigDecimal("0.00043210").inSats(),
-            expectedTakerQuoteBalanceChange = -BigDecimal("0.007583355").inWei(),
+            expectedTakerQuoteBalanceChange = -BigDecimal("0.0077350221").inWei(),
         )
 
         // now rollback the settlement - all the balances should be back to their original values
@@ -806,8 +1017,10 @@ class TestSequencer {
             balancesChangedList = failedSettlementResponse.balancesChangedList,
             makerWallet = maker,
             takerWallet = taker,
+            expectedMakerBaseBalanceChange = BigDecimal("0.00043210").inSats(),
+            expectedMakerQuoteBalanceChange = -BigDecimal("0.00750752145").inWei(),
             expectedTakerBaseBalanceChange = -BigDecimal("0.00043210").inSats(),
-            expectedTakerQuoteBalanceChange = BigDecimal("0.007583355").inWei(),
+            expectedTakerQuoteBalanceChange = BigDecimal("0.007735022100").inWei(),
         )
         // all balances should be back to original values
         sequencer.withdrawal(maker, marketId.baseAsset(), BigDecimal.TEN.inSats(), makerBaseBalance)
@@ -819,11 +1032,14 @@ class TestSequencer {
     @Test
     fun `Test autoreduce on failed settlements`() {
         val sequencer = SequencerClient()
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
 
         val marketId = MarketId("BTC9/ETH9")
         sequencer.createMarket(marketId)
+
         val maker = 123456789L.toWalletAddress()
         val taker = 555111555L.toWalletAddress()
+
         // maker deposits some of both assets -- 2 BTC, 2 ETH
         val makerBaseBalance = BigDecimal("2").inSats()
         val makerQuoteBalance = BigDecimal("10").inWei()
@@ -848,8 +1064,8 @@ class TestSequencer {
         val trade = response2.tradesCreatedList.first()
         assertEquals("17.550".toBigDecimal().toDecimalValue(), trade.price)
         assertEquals(BigDecimal("1").inSats().toIntegerValue(), trade.amount)
-        assertEquals(makerOrder.guid, trade.sellGuid)
-        assertEquals(takerOrder.guid, trade.buyGuid)
+        assertEquals(makerOrder.guid, trade.sellOrderGuid)
+        assertEquals(takerOrder.guid, trade.buyOrderGuid)
 
         // each of the maker and taker should have two balance changed messages, one for each asset
         verifyBalanceChanges(
@@ -857,8 +1073,10 @@ class TestSequencer {
             balancesChangedList = response2.balancesChangedList,
             makerWallet = maker,
             takerWallet = taker,
+            expectedMakerBaseBalanceChange = -BigDecimal("1").inSats(),
+            expectedMakerQuoteBalanceChange = BigDecimal("17.3745").inWei(),
             expectedTakerBaseBalanceChange = BigDecimal("1").inSats(),
-            expectedTakerQuoteBalanceChange = -BigDecimal("17.55").inWei(),
+            expectedTakerQuoteBalanceChange = -BigDecimal("17.901").inWei(),
         )
 
         // place an order for taker to sell 2 BTC - they started with 1 and just bought 1, so they have 2 total
@@ -872,8 +1090,10 @@ class TestSequencer {
             balancesChangedList = failedSettlementResponse.balancesChangedList,
             makerWallet = maker,
             takerWallet = taker,
+            expectedMakerBaseBalanceChange = BigDecimal("1").inSats(),
+            expectedMakerQuoteBalanceChange = -BigDecimal("17.3745").inWei(),
             expectedTakerBaseBalanceChange = -BigDecimal("1").inSats(),
-            expectedTakerQuoteBalanceChange = BigDecimal("17.55").inWei(),
+            expectedTakerQuoteBalanceChange = BigDecimal("17.901").inWei(),
         )
         assertEquals(failedSettlementResponse.ordersChangedList.size, 1)
         val reducedBid = failedSettlementResponse.ordersChangedList.find { it.guid == response3.orderGuid() }!!
@@ -890,11 +1110,14 @@ class TestSequencer {
     @Test
     fun `Test failed settlements - balances can go negative`() {
         val sequencer = SequencerClient()
+        sequencer.setFeeRates(makerFeeRatInBps = 100, takerFeeRateInBps = 200)
 
         val marketId = MarketId("BTC10/ETH10")
         sequencer.createMarket(marketId)
+
         val maker = 123456789L.toWalletAddress()
         val taker = 555111555L.toWalletAddress()
+
         // maker deposits some of both assets -- 2 BTC, 2 ETH
         val makerBaseBalance = BigDecimal("2").inSats()
         val makerQuoteBalance = BigDecimal("2").inWei()
@@ -923,28 +1146,30 @@ class TestSequencer {
         val trade = response3.tradesCreatedList.first()
         assertEquals("17.550".toBigDecimal().toDecimalValue(), trade.price)
         assertEquals(BigDecimal("0.00043210").inSats().toIntegerValue(), trade.amount)
-        assertEquals(makerOrder.guid, trade.sellGuid)
-        assertEquals(takerOrder.guid, trade.buyGuid)
+        assertEquals(makerOrder.guid, trade.sellOrderGuid)
+        assertEquals(takerOrder.guid, trade.buyOrderGuid)
 
         verifyBalanceChanges(
             marketId = marketId,
             balancesChangedList = response3.balancesChangedList,
             makerWallet = maker,
             takerWallet = taker,
+            expectedMakerBaseBalanceChange = -BigDecimal("0.00043210").inSats(),
+            expectedMakerQuoteBalanceChange = BigDecimal("0.00750752145").inWei(),
             expectedTakerBaseBalanceChange = BigDecimal("0.00043210").inSats(),
-            expectedTakerQuoteBalanceChange = -BigDecimal("0.007583355").inWei(),
+            expectedTakerQuoteBalanceChange = -BigDecimal("0.0077350221").inWei(),
         )
 
         // balances now should be:
         //   maker BTC1 = 2 - 0.00043210 = 1.99956790
-        //         ETH1 = 2 + .007583355 = 2.007583355
+        //         ETH1 = 2 + .00750752145 = 2.00750752145
         //   taker BTC1 = 0.00043210
-        //         ETH1 = 1 - .007583355 = 0.992416645
+        //         ETH1 = 1 - .0077350221 = 0.9922649779
         // withdraw everything
         sequencer.withdrawal(maker, marketId.baseAsset(), BigDecimal.TEN.inSats(), BigDecimal("1.999567905").inSats())
-        sequencer.withdrawal(maker, marketId.quoteAsset(), BigDecimal.TEN.inWei(), BigDecimal("2.007583355").inWei())
+        sequencer.withdrawal(maker, marketId.quoteAsset(), BigDecimal.TEN.inWei(), BigDecimal("2.00750752145").inWei())
         sequencer.withdrawal(taker, marketId.baseAsset(), BigDecimal.TEN.inSats(), BigDecimal("1.00043210").inSats())
-        sequencer.withdrawal(taker, marketId.quoteAsset(), BigDecimal.TEN.inWei(), BigDecimal("0.992416645").inWei())
+        sequencer.withdrawal(taker, marketId.quoteAsset(), BigDecimal.TEN.inWei(), BigDecimal("0.9922649779").inWei())
 
         // now rollback the settlement - some balances go negative (takers base balance, and makers quote balance
         val failedSettlementResponse = sequencer.failedSettlement(taker, maker, marketId, trade)
@@ -953,11 +1178,13 @@ class TestSequencer {
             balancesChangedList = failedSettlementResponse.balancesChangedList,
             makerWallet = maker,
             takerWallet = taker,
+            expectedMakerBaseBalanceChange = BigDecimal("0.00043210").inSats(),
+            expectedMakerQuoteBalanceChange = -BigDecimal("0.00750752145").inWei(),
             expectedTakerBaseBalanceChange = -BigDecimal("0.00043210").inSats(),
-            expectedTakerQuoteBalanceChange = BigDecimal("0.007583355").inWei(),
+            expectedTakerQuoteBalanceChange = BigDecimal("0.0077350221").inWei(),
         )
         sequencer.withdrawal(maker, marketId.baseAsset(), BigDecimal.TEN.inSats(), BigDecimal("0.00043210").inSats())
-        sequencer.withdrawal(taker, marketId.quoteAsset(), BigDecimal.TEN.inWei(), BigDecimal("0.007583355").inWei())
+        sequencer.withdrawal(taker, marketId.quoteAsset(), BigDecimal.TEN.inWei(), BigDecimal("0.0077350221").inWei())
         // no balance change for these two since they went negative
         sequencer.withdrawal(maker, marketId.quoteAsset(), BigDecimal.TEN.inWei(), null)
         sequencer.withdrawal(taker, marketId.baseAsset(), BigDecimal.TEN.inSats(), null)
@@ -966,7 +1193,7 @@ class TestSequencer {
         sequencer.deposit(maker, marketId.quoteAsset(), BigDecimal.ONE.inWei())
         sequencer.deposit(taker, marketId.baseAsset(), BigDecimal.ONE.inSats())
 
-        sequencer.withdrawal(maker, marketId.quoteAsset(), BigDecimal.TEN.inWei(), BigDecimal("0.992416645").inWei())
+        sequencer.withdrawal(maker, marketId.quoteAsset(), BigDecimal.TEN.inWei(), BigDecimal("0.99249247855").inWei())
         sequencer.withdrawal(taker, marketId.baseAsset(), BigDecimal.TEN.inSats(), BigDecimal("0.999567905").inSats())
     }
 
@@ -975,6 +1202,8 @@ class TestSequencer {
         balancesChangedList: MutableList<BalanceChange>,
         makerWallet: WalletAddress,
         takerWallet: WalletAddress,
+        expectedMakerBaseBalanceChange: BigInteger,
+        expectedMakerQuoteBalanceChange: BigInteger,
         expectedTakerBaseBalanceChange: BigInteger,
         expectedTakerQuoteBalanceChange: BigInteger,
     ) {
@@ -987,12 +1216,12 @@ class TestSequencer {
 
         val makerBaseBalanceChange = makerBalanceChanges.find { it.asset == marketId.baseAsset().value }!!
         val makerQuoteBalanceChange = makerBalanceChanges.find { it.asset == marketId.quoteAsset().value }!!
-        assertEquals(-expectedTakerBaseBalanceChange, makerBaseBalanceChange.delta.toBigInteger())
-        assertEquals(-expectedTakerQuoteBalanceChange, makerQuoteBalanceChange.delta.toBigInteger())
+        assertEquals(expectedMakerBaseBalanceChange, makerBaseBalanceChange.delta.toBigInteger(), "Maker base balance change did not match")
+        assertEquals(expectedMakerQuoteBalanceChange, makerQuoteBalanceChange.delta.toBigInteger(), "Maker quote balance change did not match")
 
         val takerBaseBalanceChange = takerBalanceChanges.find { it.asset == marketId.baseAsset().value }!!
         val takerQuoteBalanceChange = takerBalanceChanges.find { it.asset == marketId.quoteAsset().value }!!
-        assertEquals(expectedTakerBaseBalanceChange, takerBaseBalanceChange.delta.toBigInteger())
-        assertEquals(expectedTakerQuoteBalanceChange, takerQuoteBalanceChange.delta.toBigInteger())
+        assertEquals(expectedTakerBaseBalanceChange, takerBaseBalanceChange.delta.toBigInteger(), "Taker base balance change did not match")
+        assertEquals(expectedTakerQuoteBalanceChange, takerQuoteBalanceChange.delta.toBigInteger(), "Taker base balance change did not match")
     }
 }

--- a/sequencer/src/test/kotlin/co/chainring/TestSequencerCheckpoints.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestSequencerCheckpoints.kt
@@ -4,6 +4,8 @@ import co.chainring.sequencer.apps.GatewayApp
 import co.chainring.sequencer.apps.GatewayConfig
 import co.chainring.sequencer.apps.SequencerApp
 import co.chainring.sequencer.core.Asset
+import co.chainring.sequencer.core.FeeRate
+import co.chainring.sequencer.core.FeeRates
 import co.chainring.sequencer.core.LevelOrder
 import co.chainring.sequencer.core.Market
 import co.chainring.sequencer.core.MarketId
@@ -25,7 +27,7 @@ import co.chainring.sequencer.proto.OrderDisposition
 import co.chainring.sequencer.proto.SequencerResponse
 import co.chainring.sequencer.proto.balanceBatch
 import co.chainring.sequencer.proto.deposit
-import co.chainring.sequencer.proto.feeRatesInBps
+import co.chainring.sequencer.proto.feeRates
 import co.chainring.sequencer.proto.market
 import co.chainring.sequencer.proto.order
 import co.chainring.sequencer.proto.orderBatch
@@ -128,7 +130,7 @@ class TestSequencerCheckpoints {
                 gateway.setFeeRates(
                     setFeeRatesRequest {
                         this.guid = UUID.randomUUID().toString()
-                        this.feeRates = feeRatesInBps {
+                        this.feeRates = feeRates {
                             this.maker = 100
                             this.taker = 200
                         }
@@ -408,10 +410,7 @@ class TestSequencerCheckpoints {
     fun `test state storing and loading - single empty market`() {
         verifySerialization(
             SequencerState(
-                feeRatesInBps = feeRatesInBps {
-                    this.maker = 100
-                    this.taker = 200
-                },
+                feeRates = FeeRates.fromPercents(maker = 1.0, taker = 2.0),
                 balances = mutableMapOf(
                     wallet1 to mutableMapOf(
                         btc to BigDecimal("1").inSats(),
@@ -440,10 +439,7 @@ class TestSequencerCheckpoints {
     fun `test state storing and loading - market with no buy orders`() {
         verifySerialization(
             SequencerState(
-                feeRatesInBps = feeRatesInBps {
-                    this.maker = 100
-                    this.taker = 200
-                },
+                feeRates = FeeRates.fromPercents(maker = 1.0, taker = 2.0),
                 balances = mutableMapOf(
                     wallet1 to mutableMapOf(
                         btc to BigDecimal("1").inSats(),
@@ -486,10 +482,7 @@ class TestSequencerCheckpoints {
                             market.addOrder(
                                 wallet1.value,
                                 order,
-                                feeRatesInBps {
-                                    this.maker = 10
-                                    this.taker = 20
-                                },
+                                FeeRates.fromPercents(maker = 1.0, taker = 2.0),
                             )
                         }
                     },
@@ -502,10 +495,7 @@ class TestSequencerCheckpoints {
     fun `test state storing and loading - market with no sell orders`() {
         verifySerialization(
             SequencerState(
-                feeRatesInBps = feeRatesInBps {
-                    this.maker = 100
-                    this.taker = 200
-                },
+                feeRates = FeeRates.fromPercents(maker = 1.0, taker = 2.0),
                 balances = mutableMapOf(
                     wallet1 to mutableMapOf(
                         btc to BigDecimal("1").inSats(),
@@ -548,10 +538,7 @@ class TestSequencerCheckpoints {
                             market.addOrder(
                                 wallet1.value,
                                 order,
-                                feeRatesInBps {
-                                    this.maker = 10
-                                    this.taker = 20
-                                },
+                                FeeRates.fromPercents(maker = 1.0, taker = 2.0),
                             )
                         }
                     },
@@ -564,10 +551,7 @@ class TestSequencerCheckpoints {
     fun `test state storing and loading - markets buy and sell orders`() {
         verifySerialization(
             SequencerState(
-                feeRatesInBps = feeRatesInBps {
-                    this.maker = 100
-                    this.taker = 200
-                },
+                feeRates = FeeRates.fromPercents(maker = 1.0, taker = 2.0),
                 balances = mutableMapOf(
                     wallet1 to mutableMapOf(
                         btc to BigDecimal("1").inSats(),
@@ -630,10 +614,7 @@ class TestSequencerCheckpoints {
                             market.addOrder(
                                 wallet1.value,
                                 order,
-                                feeRatesInBps {
-                                    this.maker = 10
-                                    this.taker = 20
-                                },
+                                FeeRates.fromPercents(maker = 1.0, taker = 2.0),
                             )
                         }
                     },
@@ -687,10 +668,7 @@ class TestSequencerCheckpoints {
                             market.addOrder(
                                 wallet1.value,
                                 order,
-                                feeRatesInBps {
-                                    this.maker = 10
-                                    this.taker = 20
-                                },
+                                FeeRates.fromPercents(maker = 1.0, taker = 2.0),
                             )
                         }
                     },
@@ -761,7 +739,7 @@ class TestSequencerCheckpoints {
                                 OrderGuid(it.guid),
                                 WalletAddress(it.wallet),
                                 it.quantity.toBigInteger(),
-                                it.feeRateInBps,
+                                FeeRate(it.feeRate),
                                 it.levelIx,
                                 it.originalQuantity.toBigInteger(),
                             )

--- a/sequencer/src/test/kotlin/co/chainring/TestSequencerCheckpoints.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestSequencerCheckpoints.kt
@@ -19,14 +19,17 @@ import co.chainring.sequencer.core.toMarketId
 import co.chainring.sequencer.core.toWalletAddress
 import co.chainring.sequencer.proto.GatewayGrpcKt
 import co.chainring.sequencer.proto.MarketCheckpoint
+import co.chainring.sequencer.proto.MetaInfoCheckpoint
 import co.chainring.sequencer.proto.Order
 import co.chainring.sequencer.proto.OrderDisposition
 import co.chainring.sequencer.proto.SequencerResponse
 import co.chainring.sequencer.proto.balanceBatch
 import co.chainring.sequencer.proto.deposit
+import co.chainring.sequencer.proto.feeRatesInBps
 import co.chainring.sequencer.proto.market
 import co.chainring.sequencer.proto.order
 import co.chainring.sequencer.proto.orderBatch
+import co.chainring.sequencer.proto.setFeeRatesRequest
 import co.chainring.testutils.inSats
 import co.chainring.testutils.inWei
 import io.grpc.ManagedChannelBuilder
@@ -42,6 +45,7 @@ import org.junit.jupiter.api.Test
 import java.io.FileInputStream
 import java.lang.System.getenv
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.UUID
@@ -116,6 +120,18 @@ class TestSequencerCheckpoints {
                         this.marketPrice = "17.525".toBigDecimal().toDecimalValue()
                         this.baseDecimals = 18
                         this.quoteDecimals = 18
+                    },
+                ).success,
+            )
+
+            assertTrue(
+                gateway.setFeeRates(
+                    setFeeRatesRequest {
+                        this.guid = UUID.randomUUID().toString()
+                        this.feeRates = feeRatesInBps {
+                            this.maker = 100
+                            this.taker = 200
+                        }
                     },
                 ).success,
             )
@@ -248,11 +264,17 @@ class TestSequencerCheckpoints {
                 it.sequencerResponse.ordersChangedList[3].also { limitSellOrder3 ->
                     assertEquals(OrderDisposition.PartiallyFilled, limitSellOrder3.disposition)
                 }
+
+                assertEquals(3, it.sequencerResponse.tradesCreatedCount)
+                it.sequencerResponse.tradesCreatedList.forEach { trade ->
+                    assertTrue(trade.buyerFee.toBigInteger() > BigInteger.ZERO)
+                    assertTrue(trade.sellerFee.toBigInteger() > BigInteger.ZERO)
+                }
             }
 
             assertQueueFilesCount(inputQueue, 2)
             assertCheckpointsCount(checkpointsPath, 1)
-            assertOutputQueueContainsNoDuplicates(outputQueue, expectedMessagesCount = 6)
+            assertOutputQueueContainsNoDuplicates(outputQueue, expectedMessagesCount = 7)
 
             currentTime.addAndGet(60.seconds.inWholeMilliseconds)
 
@@ -302,7 +324,7 @@ class TestSequencerCheckpoints {
             }
 
             assertCheckpointsCount(checkpointsPath, 2)
-            assertOutputQueueContainsNoDuplicates(outputQueue, expectedMessagesCount = 8)
+            assertOutputQueueContainsNoDuplicates(outputQueue, expectedMessagesCount = 9)
         } finally {
             gatewayApp.stop()
             sequencerApp.stop()
@@ -386,6 +408,10 @@ class TestSequencerCheckpoints {
     fun `test state storing and loading - single empty market`() {
         verifySerialization(
             SequencerState(
+                feeRatesInBps = feeRatesInBps {
+                    this.maker = 100
+                    this.taker = 200
+                },
                 balances = mutableMapOf(
                     wallet1 to mutableMapOf(
                         btc to BigDecimal("1").inSats(),
@@ -414,6 +440,10 @@ class TestSequencerCheckpoints {
     fun `test state storing and loading - market with no buy orders`() {
         verifySerialization(
             SequencerState(
+                feeRatesInBps = feeRatesInBps {
+                    this.maker = 100
+                    this.taker = 200
+                },
                 balances = mutableMapOf(
                     wallet1 to mutableMapOf(
                         btc to BigDecimal("1").inSats(),
@@ -452,8 +482,15 @@ class TestSequencerCheckpoints {
                                 this.price = BigDecimal("17.600").toDecimalValue()
                                 this.type = Order.Type.LimitSell
                             },
-                        ).forEach {
-                            market.addOrder(wallet1.value, it)
+                        ).forEach { order ->
+                            market.addOrder(
+                                wallet1.value,
+                                order,
+                                feeRatesInBps {
+                                    this.maker = 10
+                                    this.taker = 20
+                                },
+                            )
                         }
                     },
                 ),
@@ -465,6 +502,10 @@ class TestSequencerCheckpoints {
     fun `test state storing and loading - market with no sell orders`() {
         verifySerialization(
             SequencerState(
+                feeRatesInBps = feeRatesInBps {
+                    this.maker = 100
+                    this.taker = 200
+                },
                 balances = mutableMapOf(
                     wallet1 to mutableMapOf(
                         btc to BigDecimal("1").inSats(),
@@ -503,8 +544,15 @@ class TestSequencerCheckpoints {
                                 this.price = BigDecimal("17.5").toDecimalValue()
                                 this.type = Order.Type.LimitBuy
                             },
-                        ).forEach {
-                            market.addOrder(wallet1.value, it)
+                        ).forEach { order ->
+                            market.addOrder(
+                                wallet1.value,
+                                order,
+                                feeRatesInBps {
+                                    this.maker = 10
+                                    this.taker = 20
+                                },
+                            )
                         }
                     },
                 ),
@@ -516,6 +564,10 @@ class TestSequencerCheckpoints {
     fun `test state storing and loading - markets buy and sell orders`() {
         verifySerialization(
             SequencerState(
+                feeRatesInBps = feeRatesInBps {
+                    this.maker = 100
+                    this.taker = 200
+                },
                 balances = mutableMapOf(
                     wallet1 to mutableMapOf(
                         btc to BigDecimal("1").inSats(),
@@ -574,8 +626,15 @@ class TestSequencerCheckpoints {
                                 this.price = BigDecimal("17.600").toDecimalValue()
                                 this.type = Order.Type.LimitSell
                             },
-                        ).forEach {
-                            market.addOrder(wallet1.value, it)
+                        ).forEach { order ->
+                            market.addOrder(
+                                wallet1.value,
+                                order,
+                                feeRatesInBps {
+                                    this.maker = 10
+                                    this.taker = 20
+                                },
+                            )
                         }
                     },
                     btcUsdcMarketId to Market(
@@ -624,8 +683,15 @@ class TestSequencerCheckpoints {
                                 this.price = BigDecimal("70003").toDecimalValue()
                                 this.type = Order.Type.LimitSell
                             },
-                        ).forEach {
-                            market.addOrder(wallet1.value, it)
+                        ).forEach { order ->
+                            market.addOrder(
+                                wallet1.value,
+                                order,
+                                feeRatesInBps {
+                                    this.maker = 10
+                                    this.taker = 20
+                                },
+                            )
                         }
                     },
                 ),
@@ -668,14 +734,8 @@ class TestSequencerCheckpoints {
     }
 
     private fun verifySerializedOrdersContent(initialState: SequencerState, checkpointPath: Path) {
-        val marketIds = FileInputStream(Path.of(checkpointPath.toString(), "markets").toFile()).use { inputStream ->
-            String(inputStream.readAllBytes()).let {
-                if (it.isEmpty()) {
-                    emptyList()
-                } else {
-                    it.split(",").map(::MarketId)
-                }
-            }
+        val marketIds = FileInputStream(Path.of(checkpointPath.toString(), "metainfo").toFile()).use { inputStream ->
+            MetaInfoCheckpoint.parseFrom(inputStream).marketsList.map(::MarketId)
         }
         assertEquals(initialState.markets.keys, marketIds.toSet())
 
@@ -701,6 +761,7 @@ class TestSequencerCheckpoints {
                                 OrderGuid(it.guid),
                                 WalletAddress(it.wallet),
                                 it.quantity.toBigInteger(),
+                                it.feeRateInBps,
                                 it.levelIx,
                                 it.originalQuantity.toBigInteger(),
                             )

--- a/sequencer/src/test/kotlin/co/chainring/testutils/SequencerClient.kt
+++ b/sequencer/src/test/kotlin/co/chainring/testutils/SequencerClient.kt
@@ -1,5 +1,6 @@
 package co.chainring.testutils
 
+import co.chainring.core.model.db.FeeRates
 import co.chainring.sequencer.apps.SequencerApp
 import co.chainring.sequencer.core.Asset
 import co.chainring.sequencer.core.MarketId
@@ -15,7 +16,7 @@ import co.chainring.sequencer.proto.SequencerRequest
 import co.chainring.sequencer.proto.SequencerResponse
 import co.chainring.sequencer.proto.TradeCreated
 import co.chainring.sequencer.proto.balanceBatch
-import co.chainring.sequencer.proto.feeRatesInBps
+import co.chainring.sequencer.proto.feeRates
 import co.chainring.sequencer.proto.market
 import co.chainring.sequencer.proto.order
 import co.chainring.sequencer.proto.orderBatch
@@ -121,21 +122,21 @@ class SequencerClient {
         assertEquals(tickSize, createdMarket.tickSize.toBigDecimal())
     }
 
-    fun setFeeRates(makerFeeRatInBps: Int, takerFeeRateInBps: Int) {
+    fun setFeeRates(feeRates: FeeRates) {
         val response = sequencer.processRequest(
             sequencerRequest {
                 this.guid = UUID.randomUUID().toString()
                 this.type = SequencerRequest.Type.SetFeeRates
-                this.feeRates = feeRatesInBps {
-                    this.maker = makerFeeRatInBps
-                    this.taker = takerFeeRateInBps
+                this.feeRates = feeRates {
+                    this.maker = feeRates.maker.value
+                    this.taker = feeRates.taker.value
                 }
             },
         )
         val feeRatesSet = response.feeRatesSet
         assertNotNull(feeRatesSet)
-        assertEquals(makerFeeRatInBps, feeRatesSet.maker)
-        assertEquals(takerFeeRateInBps, feeRatesSet.taker)
+        assertEquals(feeRates.maker.value, feeRatesSet.maker)
+        assertEquals(feeRates.taker.value, feeRatesSet.taker)
     }
 
     private fun List<BigInteger>.sum() = this.reduce { a, b -> a + b }

--- a/sequencercommon/src/main/kotlin/co/chainring/sequencer/core/Utils.kt
+++ b/sequencercommon/src/main/kotlin/co/chainring/sequencer/core/Utils.kt
@@ -30,8 +30,18 @@ fun IntegerValue.toBigInteger(): BigInteger = BigInteger(
 
 fun sumBigIntegers(a: BigInteger, b: BigInteger): BigInteger = a + b
 
+fun Iterable<BigInteger>.sum(): BigInteger = reduce(::sumBigIntegers)
+
 fun notional(amount: BigInteger, price: BigDecimal, baseDecimals: Int, quoteDecimals: Int): BigInteger =
     (amount.toBigDecimal() * price).movePointRight(quoteDecimals - baseDecimals).toBigInteger()
 
-fun notional(amount: IntegerValue, price: DecimalValue, baseDecimals: Int, quoteDecimals: Int): BigInteger =
-    notional(amount.toBigInteger(), price.toBigDecimal(), baseDecimals, quoteDecimals)
+fun notionalFee(notional: BigInteger, feeRateInBps: Int): BigInteger =
+    notional * feeRateInBps.toBigInteger() / 10000.toBigInteger()
+
+fun notionalPlusFee(amount: BigInteger, price: BigDecimal, baseDecimals: Int, quoteDecimals: Int, feeRateInBps: Int): BigInteger =
+    (amount.toBigDecimal() * price).movePointRight(quoteDecimals - baseDecimals).toBigInteger().let { notional ->
+        notional + notionalFee(notional, feeRateInBps)
+    }
+
+fun notionalPlusFee(amount: IntegerValue, price: DecimalValue, baseDecimals: Int, quoteDecimals: Int, feeRateInBps: Int): BigInteger =
+    notionalPlusFee(amount.toBigInteger(), price.toBigDecimal(), baseDecimals, quoteDecimals, feeRateInBps)

--- a/sequencercommon/src/main/kotlin/co/chainring/sequencer/core/Utils.kt
+++ b/sequencercommon/src/main/kotlin/co/chainring/sequencer/core/Utils.kt
@@ -35,13 +35,13 @@ fun Iterable<BigInteger>.sum(): BigInteger = reduce(::sumBigIntegers)
 fun notional(amount: BigInteger, price: BigDecimal, baseDecimals: Int, quoteDecimals: Int): BigInteger =
     (amount.toBigDecimal() * price).movePointRight(quoteDecimals - baseDecimals).toBigInteger()
 
-fun notionalFee(notional: BigInteger, feeRateInBps: Int): BigInteger =
-    notional * feeRateInBps.toBigInteger() / 10000.toBigInteger()
+fun notionalFee(notional: BigInteger, feeRate: FeeRate): BigInteger =
+    notional * feeRate.value.toBigInteger() / FeeRate.MAX_VALUE.toBigInteger()
 
-fun notionalPlusFee(amount: BigInteger, price: BigDecimal, baseDecimals: Int, quoteDecimals: Int, feeRateInBps: Int): BigInteger =
+fun notionalPlusFee(amount: BigInteger, price: BigDecimal, baseDecimals: Int, quoteDecimals: Int, feeRate: FeeRate): BigInteger =
     (amount.toBigDecimal() * price).movePointRight(quoteDecimals - baseDecimals).toBigInteger().let { notional ->
-        notional + notionalFee(notional, feeRateInBps)
+        notional + notionalFee(notional, feeRate)
     }
 
-fun notionalPlusFee(amount: IntegerValue, price: DecimalValue, baseDecimals: Int, quoteDecimals: Int, feeRateInBps: Int): BigInteger =
-    notionalPlusFee(amount.toBigInteger(), price.toBigDecimal(), baseDecimals, quoteDecimals, feeRateInBps)
+fun notionalPlusFee(amount: IntegerValue, price: DecimalValue, baseDecimals: Int, quoteDecimals: Int, feeRate: FeeRate): BigInteger =
+    notionalPlusFee(amount.toBigInteger(), price.toBigDecimal(), baseDecimals, quoteDecimals, feeRate)

--- a/sequencercommon/src/main/kotlin/co/chainring/sequencer/core/ValueClasses.kt
+++ b/sequencercommon/src/main/kotlin/co/chainring/sequencer/core/ValueClasses.kt
@@ -1,5 +1,7 @@
 package co.chainring.sequencer.core
 
+import java.math.BigDecimal
+
 @JvmInline
 value class WalletAddress(val value: Long) {
     override fun toString(): String = value.toString()
@@ -42,3 +44,23 @@ value class Asset(val value: String) {
 }
 
 fun String.toAsset() = Asset(this)
+
+@JvmInline
+value class FeeRate(val value: Long) {
+    init {
+        require(isValid(value)) { "Invalid fee rate" }
+    }
+
+    companion object {
+        const val MIN_VALUE = 0L
+        const val MAX_VALUE = 1000000L
+
+        fun isValid(value: Long): Boolean =
+            value in MIN_VALUE..MAX_VALUE
+
+        val zero = FeeRate(0)
+
+        fun fromPercents(percents: Double): FeeRate =
+            FeeRate((BigDecimal(percents) * BigDecimal(MAX_VALUE) / BigDecimal(100)).toLong())
+    }
+}

--- a/sequencercommon/src/main/proto/checkpoint.proto
+++ b/sequencercommon/src/main/proto/checkpoint.proto
@@ -9,8 +9,8 @@ option java_outer_classname = "CheckpointSchema";
 
 message MetaInfoCheckpoint {
   repeated string markets = 1;
-  uint32 makerFeeRate = 2;
-  uint32 takerFeeRate = 3;
+  uint64 makerFeeRate = 2;
+  uint64 takerFeeRate = 3;
 }
 
 message BalancesCheckpoint {
@@ -65,6 +65,6 @@ message MarketCheckpoint {
     IntegerValue quantity = 3;
     uint32 levelIx = 4;
     IntegerValue originalQuantity = 5;
-    uint32 feeRateInBps = 6;
+    uint64 feeRate = 6;
   }
 }

--- a/sequencercommon/src/main/proto/checkpoint.proto
+++ b/sequencercommon/src/main/proto/checkpoint.proto
@@ -7,6 +7,12 @@ option java_multiple_files = true;
 option java_package = "co.chainring.sequencer.proto";
 option java_outer_classname = "CheckpointSchema";
 
+message MetaInfoCheckpoint {
+  repeated string markets = 1;
+  uint32 makerFeeRate = 2;
+  uint32 takerFeeRate = 3;
+}
+
 message BalancesCheckpoint {
   repeated Balance balances = 1;
 
@@ -59,5 +65,6 @@ message MarketCheckpoint {
     IntegerValue quantity = 3;
     uint32 levelIx = 4;
     IntegerValue originalQuantity = 5;
+    uint32 feeRateInBps = 6;
   }
 }

--- a/sequencercommon/src/main/proto/gateway.proto
+++ b/sequencercommon/src/main/proto/gateway.proto
@@ -25,7 +25,7 @@ message GetStateRequest {
 
 message SetFeeRatesRequest {
   string guid = 1;
-  FeeRatesInBps feeRates = 2;
+  FeeRates feeRates = 2;
 }
 
 service Gateway {

--- a/sequencercommon/src/main/proto/gateway.proto
+++ b/sequencercommon/src/main/proto/gateway.proto
@@ -23,8 +23,14 @@ message GetStateRequest {
   string guid = 1;
 }
 
+message SetFeeRatesRequest {
+  string guid = 1;
+  FeeRatesInBps feeRates = 2;
+}
+
 service Gateway {
   rpc AddMarket (Market) returns (GatewayResponse);
+  rpc SetFeeRates (SetFeeRatesRequest) returns (GatewayResponse);
   rpc ApplyBalanceBatch (BalanceBatch) returns (GatewayResponse);
   rpc ApplyOrderBatch (OrderBatch) returns (GatewayResponse);
   rpc Reset (ResetRequest) returns (GatewayResponse);

--- a/sequencercommon/src/main/proto/sequencer.proto
+++ b/sequencercommon/src/main/proto/sequencer.proto
@@ -38,6 +38,11 @@ message MarketCreated {
   DecimalValue tickSize = 2;
 }
 
+message FeeRatesInBps {
+  uint32 maker = 1;
+  uint32 taker = 2;
+}
+
 message SequencerRequest {
   enum Type {
     AddMarket = 0;
@@ -45,12 +50,14 @@ message SequencerRequest {
     ApplyBalanceBatch = 2;
     Reset = 3;
     GetState = 4;
+    SetFeeRates = 5;
   }
   string guid = 1;
   Type type = 2;
   optional Market addMarket = 3;
   optional OrderBatch orderBatch = 4;
   optional BalanceBatch balanceBatch = 5;
+  optional FeeRatesInBps feeRates = 6;
 }
 
 enum SequencerError {
@@ -59,11 +66,13 @@ enum SequencerError {
   MarketExists = 2;
   UnknownMarket = 3;
   ExceedsLimit = 4;
+  InvalidFeeRate = 5;
 }
 
 message StateDump {
   repeated BalancesCheckpoint.Balance balances = 1;
   repeated MarketCheckpoint markets = 2;
+  FeeRatesInBps feeRates = 3;
 }
 
 message SequencerResponse {
@@ -77,6 +86,7 @@ message SequencerResponse {
   repeated MarketCreated marketsCreated = 8;
   repeated OrderChangeRejected ordersChangeRejected = 9;
   optional StateDump stateDump = 10;
+  optional FeeRatesInBps feeRatesSet = 11;
 }
 
 message Sequenced {

--- a/sequencercommon/src/main/proto/sequencer.proto
+++ b/sequencercommon/src/main/proto/sequencer.proto
@@ -38,9 +38,9 @@ message MarketCreated {
   DecimalValue tickSize = 2;
 }
 
-message FeeRatesInBps {
-  uint32 maker = 1;
-  uint32 taker = 2;
+message FeeRates {
+  uint64 maker = 1;
+  uint64 taker = 2;
 }
 
 message SequencerRequest {
@@ -57,7 +57,7 @@ message SequencerRequest {
   optional Market addMarket = 3;
   optional OrderBatch orderBatch = 4;
   optional BalanceBatch balanceBatch = 5;
-  optional FeeRatesInBps feeRates = 6;
+  optional FeeRates feeRates = 6;
 }
 
 enum SequencerError {
@@ -72,7 +72,7 @@ enum SequencerError {
 message StateDump {
   repeated BalancesCheckpoint.Balance balances = 1;
   repeated MarketCheckpoint markets = 2;
-  FeeRatesInBps feeRates = 3;
+  FeeRates feeRates = 3;
 }
 
 message SequencerResponse {
@@ -86,7 +86,7 @@ message SequencerResponse {
   repeated MarketCreated marketsCreated = 8;
   repeated OrderChangeRejected ordersChangeRejected = 9;
   optional StateDump stateDump = 10;
-  optional FeeRatesInBps feeRatesSet = 11;
+  optional FeeRates feeRatesSet = 11;
 }
 
 message Sequenced {

--- a/sequencercommon/src/main/proto/trade.proto
+++ b/sequencercommon/src/main/proto/trade.proto
@@ -7,8 +7,10 @@ option java_package = "co.chainring.sequencer.proto";
 option java_outer_classname = "TradeSchema";
 
 message TradeCreated {
-  uint64 buyGuid = 1;
-  uint64 sellGuid = 2;
+  uint64 buyOrderGuid = 1;
+  uint64 sellOrderGuid = 2;
   IntegerValue amount = 3;
   DecimalValue price = 4;
+  IntegerValue buyerFee = 5;
+  IntegerValue sellerFee = 6;
 }

--- a/src/main/kotlin/co/chainring/tasks/SeedDatabase.kt
+++ b/src/main/kotlin/co/chainring/tasks/SeedDatabase.kt
@@ -4,6 +4,7 @@ import co.chainring.core.db.DbConfig
 import co.chainring.core.db.connect
 import co.chainring.core.model.db.BlockchainNonceEntity
 import co.chainring.core.model.db.ChainEntity
+import co.chainring.core.model.db.KeyValueStore
 import co.chainring.core.model.db.MarketEntity
 import co.chainring.core.model.db.MarketId
 import co.chainring.core.model.db.OHLCEntity
@@ -22,6 +23,9 @@ fun seedDatabase(fixtures: Fixtures, symbolContractAddresses: List<SymbolContrac
     TransactionManager.defaultDatabase = db
 
     transaction {
+        KeyValueStore.setInt("MakerFeeRateInBps", fixtures.makerFeeRateInBps)
+        KeyValueStore.setInt("TakerFeeRateInBps", fixtures.takerFeeRateInBps)
+
         fixtures.chains.forEach { chain ->
             if (ChainEntity.findById(chain.id) == null) {
                 ChainEntity.create(chain.id, chain.name).flush()

--- a/src/main/kotlin/co/chainring/tasks/SeedDatabase.kt
+++ b/src/main/kotlin/co/chainring/tasks/SeedDatabase.kt
@@ -23,8 +23,7 @@ fun seedDatabase(fixtures: Fixtures, symbolContractAddresses: List<SymbolContrac
     TransactionManager.defaultDatabase = db
 
     transaction {
-        KeyValueStore.setInt("MakerFeeRateInBps", fixtures.makerFeeRateInBps)
-        KeyValueStore.setInt("TakerFeeRateInBps", fixtures.takerFeeRateInBps)
+        fixtures.feeRates.persist()
 
         fixtures.chains.forEach { chain ->
             if (ChainEntity.findById(chain.id) == null) {

--- a/src/main/kotlin/co/chainring/tasks/SeedSequencer.kt
+++ b/src/main/kotlin/co/chainring/tasks/SeedSequencer.kt
@@ -8,20 +8,29 @@ val sequencerClient = SequencerClient()
 
 fun seedSequencer(fixtures: Fixtures) {
     runBlocking {
+        sequencerClient.setFeeRates(
+            maker = fixtures.makerFeeRateInBps,
+            taker = fixtures.takerFeeRateInBps
+        ).also { response ->
+            if (response.hasError()) {
+                throw RuntimeException("Failed to set fee rates in sequencer: ${response.error}")
+            }
+        }
+
         fixtures.markets.forEach { market ->
             val baseSymbol = fixtures.symbols.first { it.id == market.baseSymbol }
             val quoteSymbol = fixtures.symbols.first { it.id == market.quoteSymbol }
 
-            val response = sequencerClient.createMarket(
+            sequencerClient.createMarket(
                 marketId = "${baseSymbol.name}/${quoteSymbol.name}",
                 tickSize = market.tickSize,
                 marketPrice = market.marketPrice,
                 quoteDecimals = quoteSymbol.decimals,
                 baseDecimals = baseSymbol.decimals,
-            )
-
-            if (response.hasError()) {
-                throw RuntimeException("Failed to create market in sequencer: ${response.error}")
+            ).also { response ->
+                if (response.hasError()) {
+                    throw RuntimeException("Failed to create market in sequencer: ${response.error}")
+                }
             }
         }
     }

--- a/src/main/kotlin/co/chainring/tasks/SeedSequencer.kt
+++ b/src/main/kotlin/co/chainring/tasks/SeedSequencer.kt
@@ -8,10 +8,7 @@ val sequencerClient = SequencerClient()
 
 fun seedSequencer(fixtures: Fixtures) {
     runBlocking {
-        sequencerClient.setFeeRates(
-            maker = fixtures.makerFeeRateInBps,
-            taker = fixtures.takerFeeRateInBps
-        ).also { response ->
+        sequencerClient.setFeeRates(fixtures.feeRates).also { response ->
             if (response.hasError()) {
                 throw RuntimeException("Failed to set fee rates in sequencer: ${response.error}")
             }

--- a/src/main/kotlin/co/chainring/tasks/fixtures/Fixtures.kt
+++ b/src/main/kotlin/co/chainring/tasks/fixtures/Fixtures.kt
@@ -7,6 +7,8 @@ import java.math.BigDecimal
 import java.math.BigInteger
 
 data class Fixtures(
+    val makerFeeRateInBps: Int,
+    val takerFeeRateInBps: Int,
     val chains: List<Chain>,
     val symbols: List<Symbol>,
     val markets: List<Market>,
@@ -42,6 +44,8 @@ data class Fixtures(
 }
 
 fun getFixtures(chainringChainId: ChainId) = Fixtures(
+    makerFeeRateInBps = 100,
+    takerFeeRateInBps = 200,
     chains = listOf(
         Fixtures.Chain(chainringChainId, "chainring-dev", Address("0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"))
     ),

--- a/src/main/kotlin/co/chainring/tasks/fixtures/Fixtures.kt
+++ b/src/main/kotlin/co/chainring/tasks/fixtures/Fixtures.kt
@@ -1,14 +1,15 @@
 package co.chainring.tasks.fixtures
 
 import co.chainring.core.model.Address
+import co.chainring.core.model.FeeRate
 import co.chainring.core.model.db.ChainId
+import co.chainring.core.model.db.FeeRates
 import co.chainring.core.model.db.SymbolId
 import java.math.BigDecimal
 import java.math.BigInteger
 
 data class Fixtures(
-    val makerFeeRateInBps: Int,
-    val takerFeeRateInBps: Int,
+    val feeRates: FeeRates,
     val chains: List<Chain>,
     val symbols: List<Symbol>,
     val markets: List<Market>,
@@ -44,8 +45,7 @@ data class Fixtures(
 }
 
 fun getFixtures(chainringChainId: ChainId) = Fixtures(
-    makerFeeRateInBps = 100,
-    takerFeeRateInBps = 200,
+    feeRates = FeeRates.fromPercents(maker = 1.0, taker = 2.0),
     chains = listOf(
         Fixtures.Chain(chainringChainId, "chainring-dev", Address("0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"))
     ),

--- a/web-ui/src/apiClient.ts
+++ b/web-ui/src/apiClient.ts
@@ -59,9 +59,16 @@ const MarketSchema = z.object({
 })
 export type Market = z.infer<typeof MarketSchema>
 
+const FeeRatesInBpsSchema = z.object({
+  maker: z.coerce.bigint(),
+  taker: z.coerce.bigint()
+})
+export type FeeRatesInBps = z.infer<typeof FeeRatesInBpsSchema>
+
 const ConfigurationApiResponseSchema = z.object({
   chains: z.array(ChainSchema),
-  markets: z.array(MarketSchema)
+  markets: z.array(MarketSchema),
+  feeRatesInBps: FeeRatesInBpsSchema
 })
 export type ConfigurationApiResponse = z.infer<
   typeof ConfigurationApiResponseSchema

--- a/web-ui/src/apiClient.ts
+++ b/web-ui/src/apiClient.ts
@@ -59,16 +59,16 @@ const MarketSchema = z.object({
 })
 export type Market = z.infer<typeof MarketSchema>
 
-const FeeRatesInBpsSchema = z.object({
+const FeeRatesSchema = z.object({
   maker: z.coerce.bigint(),
   taker: z.coerce.bigint()
 })
-export type FeeRatesInBps = z.infer<typeof FeeRatesInBpsSchema>
+export type FeeRates = z.infer<typeof FeeRatesSchema>
 
 const ConfigurationApiResponseSchema = z.object({
   chains: z.array(ChainSchema),
   markets: z.array(MarketSchema),
-  feeRatesInBps: FeeRatesInBpsSchema
+  feeRates: FeeRatesSchema
 })
 export type ConfigurationApiResponse = z.infer<
   typeof ConfigurationApiResponseSchema

--- a/web-ui/src/components/Screens/HomeScreen.tsx
+++ b/web-ui/src/components/Screens/HomeScreen.tsx
@@ -23,7 +23,7 @@ export default function HomeScreen() {
 
   const [selectedMarket, setSelectedMarket] = useState<Market | null>(null)
 
-  const { exchangeContract, markets, symbols } = useMemo(() => {
+  const { exchangeContract, markets, symbols, feeRatesInBps } = useMemo(() => {
     const config = configQuery.data
     const chainConfig = config?.chains.find(
       (chain) => chain.id === (wallet.chainId || config.chains[0]?.id)
@@ -37,10 +37,13 @@ export default function HomeScreen() {
     const markets =
       config && symbols ? new Markets(config.markets, symbols) : null
 
+    const feeRatesInBps = config && config.feeRatesInBps
+
     return {
       exchangeContract,
       markets,
-      symbols
+      symbols,
+      feeRatesInBps
     }
   }, [configQuery.data, wallet.chainId])
 
@@ -52,7 +55,7 @@ export default function HomeScreen() {
 
   return (
     <WebsocketProvider wallet={wallet}>
-      {markets && selectedMarket ? (
+      {markets && feeRatesInBps && selectedMarket ? (
         <div className="min-h-screen bg-darkBluishGray10">
           <Header
             markets={markets}
@@ -78,6 +81,7 @@ export default function HomeScreen() {
                     market={selectedMarket}
                     walletAddress={wallet.address}
                     exchangeContractAddress={exchangeContract?.address}
+                    feeRatesInBps={feeRatesInBps}
                   />
                   <OrderBookWidget marketId={selectedMarket.id} />
                 </div>

--- a/web-ui/src/components/Screens/HomeScreen.tsx
+++ b/web-ui/src/components/Screens/HomeScreen.tsx
@@ -23,7 +23,7 @@ export default function HomeScreen() {
 
   const [selectedMarket, setSelectedMarket] = useState<Market | null>(null)
 
-  const { exchangeContract, markets, symbols, feeRatesInBps } = useMemo(() => {
+  const { exchangeContract, markets, symbols, feeRates } = useMemo(() => {
     const config = configQuery.data
     const chainConfig = config?.chains.find(
       (chain) => chain.id === (wallet.chainId || config.chains[0]?.id)
@@ -37,13 +37,13 @@ export default function HomeScreen() {
     const markets =
       config && symbols ? new Markets(config.markets, symbols) : null
 
-    const feeRatesInBps = config && config.feeRatesInBps
+    const feeRates = config && config.feeRates
 
     return {
       exchangeContract,
       markets,
       symbols,
-      feeRatesInBps
+      feeRates
     }
   }, [configQuery.data, wallet.chainId])
 
@@ -55,7 +55,7 @@ export default function HomeScreen() {
 
   return (
     <WebsocketProvider wallet={wallet}>
-      {markets && feeRatesInBps && selectedMarket ? (
+      {markets && feeRates && selectedMarket ? (
         <div className="min-h-screen bg-darkBluishGray10">
           <Header
             markets={markets}
@@ -81,7 +81,7 @@ export default function HomeScreen() {
                     market={selectedMarket}
                     walletAddress={wallet.address}
                     exchangeContractAddress={exchangeContract?.address}
-                    feeRatesInBps={feeRatesInBps}
+                    feeRates={feeRates}
                   />
                   <OrderBookWidget marketId={selectedMarket.id} />
                 </div>

--- a/web-ui/src/utils/index.ts
+++ b/web-ui/src/utils/index.ts
@@ -1,3 +1,5 @@
+import { TradingSymbol } from 'apiClient'
+
 export function classNames(...classes: unknown[]): string {
   return classes.filter(Boolean).join(' ')
 }
@@ -37,4 +39,16 @@ export function cleanAndFormatNumberInput(
       : '')
 
   return cleanedValue
+}
+
+export function calculateNotional(
+  price: bigint,
+  baseAmount: bigint,
+  baseSymbol: TradingSymbol
+): bigint {
+  return (price * baseAmount) / BigInt(Math.pow(10, baseSymbol.decimals))
+}
+
+export function calculateFee(notional: bigint, feeRate: bigint): bigint {
+  return (notional * feeRate) / 1000000n
 }


### PR DESCRIPTION
- Fee rates are set in basic points (1 BP = 0.01%)
- Fee rates for maker and taker can differ
- Fee rates are set in Sequencer via RPC
- Sequencer acts as a source of truth for fee rates, backend DB has a copy stored in `key-value` table for UI
- Change of fee rates does not affect the orders that are already in the book
- If existing order is changed, the latest fee rate is applied
- Fees are taken into account when calculating limits