### PR TITLE
Chain 161/fine tune pan/zoom behavior

### DIFF
--- a/backend/src/main/kotlin/co/chainring/core/websocket/Broadcaster.kt
+++ b/backend/src/main/kotlin/co/chainring/core/websocket/Broadcaster.kt
@@ -169,7 +169,8 @@ class Broadcaster(val db: Database) {
             null -> Prices(
                 market = topic.marketId,
                 duration = topic.duration,
-                ohlc = pricesByMarketAndPeriod[topic] ?: listOf(),
+                // 3360 is equivalent to 7 days of 5 minutes sticks
+                ohlc = pricesByMarketAndPeriod[topic]?.takeLast(3360) ?: listOf(),
                 full = true,
                 dailyChange = pricesDailyChangeByMarket[topic.marketId] ?: 0.0,
             )

--- a/web-ui/src/index.css
+++ b/web-ui/src/index.css
@@ -78,6 +78,15 @@
   stroke-dasharray: 2 2;
 }
 
+svg text {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  pointer-events: none;
+}
+
 @layer utilities {
   .bg-switch {
     background: url("assets/Switch.svg") no-repeat center;

--- a/web-ui/src/utils/dateUtils.ts
+++ b/web-ui/src/utils/dateUtils.ts
@@ -5,11 +5,3 @@ export function maxDate(a: Date, b: Date): Date {
     return b
   }
 }
-
-export function addDuration(date: Date, millis: number): Date {
-  return new Date(date.getTime() + millis)
-}
-
-export function subtractDuration(date: Date, millis: number): Date {
-  return new Date(date.getTime() - millis)
-}


### PR DESCRIPTION
 - panning
    - no future times on the graph
    - panning via click+horizontal drag
    - panned to mostright point (half of the last ohlc is visible) - graph follows new ohlcs
    - panned left - graph is static

 - zoom
    - zooming via click+vertical drag
    - mostright point is fixed
    - auto switch ohlc duration (less than 20 candles, more that 200 candles), otherwise limit max/min zoom

 - limit number of initial ohlcs provided by BE 