### PR TITLE
Improvements to deploy script

### DIFF
--- a/scripts/envs/demo.yml
+++ b/scripts/envs/demo.yml
@@ -41,6 +41,7 @@ services:
   api:
     image: 851725450525.dkr.ecr.us-east-2.amazonaws.com/backend
     count: 1
+    is_essential: "true"
     environment: api
     secrets:
       DB_CREDENTIALS: arn:aws:secretsmanager:us-east-2:851725450525:secret:rds!cluster-d567d2ec-6ebb-4c6d-b48a-529eb09febfb-KMOVrv
@@ -48,6 +49,7 @@ services:
   anvil:
     image: 851725450525.dkr.ecr.us-east-2.amazonaws.com/anvil
     count: 1
+    is_essential: "true"
   otterscan:
     image: otterscan/otterscan
     count: 1
@@ -55,6 +57,7 @@ services:
   anvil2:
     image: 851725450525.dkr.ecr.us-east-2.amazonaws.com/anvil
     count: 1
+    is_essential: "true"
     environment: anvil2
   otterscan2:
     image: otterscan/otterscan
@@ -63,6 +66,8 @@ services:
   sequencer:
     image: 851725450525.dkr.ecr.us-east-2.amazonaws.com/sequencer
     count: 1
+    is_essential: "true"
+    no_rolling_upgrade: "true"
     environment: sequencer
     secrets:
       DB_CREDENTIALS: arn:aws:secretsmanager:us-east-2:851725450525:secret:rds!cluster-d567d2ec-6ebb-4c6d-b48a-529eb09febfb-KMOVrv

--- a/scripts/envs/test.yml
+++ b/scripts/envs/test.yml
@@ -24,12 +24,14 @@ services:
   api:
     image: 851725450525.dkr.ecr.us-east-2.amazonaws.com/backend
     count: 1
+    is_essential: "true"
     environment: api
     secrets:
       DB_CREDENTIALS: arn:aws:secretsmanager:us-east-2:851725450525:secret:rds!cluster-19a608f6-1f4b-4e6a-849f-27831fcf40de-vkcDz2
   anvil:
     image: 851725450525.dkr.ecr.us-east-2.amazonaws.com/anvil
     count: 1
+    is_essential: "true"
   otterscan:
     image: otterscan/otterscan
     count: 1
@@ -37,6 +39,7 @@ services:
   anvil2:
     image: 851725450525.dkr.ecr.us-east-2.amazonaws.com/anvil
     count: 1
+    is_essential: "true"
     environment: anvil2
   otterscan2:
     image: otterscan/otterscan
@@ -45,6 +48,8 @@ services:
   sequencer:
     image: 851725450525.dkr.ecr.us-east-2.amazonaws.com/sequencer
     count: 1
+    is_essential: "true"
+    no_rolling_upgrade: "true"
     environment: sequencer
     secrets:
       DB_CREDENTIALS: arn:aws:secretsmanager:us-east-2:851725450525:secret:rds!cluster-19a608f6-1f4b-4e6a-849f-27831fcf40de-vkcDz2

--- a/scripts/envs/testnet.yml
+++ b/scripts/envs/testnet.yml
@@ -17,6 +17,7 @@ services:
   api:
     image: 851725450525.dkr.ecr.us-east-2.amazonaws.com/backend
     count: 1
+    is_essential: "true"
     environment: api
     secrets:
       DB_CREDENTIALS: arn:aws:secretsmanager:us-east-2:851725450525:secret:rds!cluster-45c44b9b-ac53-47ab-8997-6d5d799ce4bc-OY4iRs
@@ -26,6 +27,8 @@ services:
   sequencer:
     image: 851725450525.dkr.ecr.us-east-2.amazonaws.com/sequencer
     count: 1
+    is_essential: "true"
+    no_rolling_upgrade: "true"
     environment: sequencer
     secrets:
       DB_CREDENTIALS: arn:aws:secretsmanager:us-east-2:851725450525:secret:rds!cluster-45c44b9b-ac53-47ab-8997-6d5d799ce4bc-OY4iRs


### PR DESCRIPTION
- Prevent Sequencer from starting when doing upgrade of a stopped service
- Stopping non-essential services should not result in a holding page