### PR TITLE
Fix Sequencer upgrades

### DIFF
--- a/scripts/ecs-deploy.py
+++ b/scripts/ecs-deploy.py
@@ -100,6 +100,7 @@ class ChainringDeploymentManager:
 
             if restart_required:
                 self.update_instances_count([service_name], desired_count=0)
+                self.wait_for_stable_state(service_names)
 
             new_task_def = {key: task_def[key] for key in [
                 'family',


### PR DESCRIPTION
Turned out that after setting desired instances count to 0 we should wait for it to reach the stable state before upgrading and setting desired instances count back to 1, otherwise ECS gets confused and deployment times out