### PR TITLE
fix background for orders and trades scrolling

### DIFF
--- a/web-ui/src/components/Screens/HomeScreen/OrdersAndTradesWidget.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/OrdersAndTradesWidget.tsx
@@ -148,7 +148,7 @@ export default function OrdersAndTradesWidget({
       <>
         <div className="max-h-96 min-h-24 overflow-scroll">
           <table className="relative w-full text-left text-sm">
-            <thead className="sticky top-0 font-normal text-darkBluishGray2">
+            <thead className="sticky top-0 z-10 bg-darkBluishGray9 font-normal text-darkBluishGray2">
               <tr key="header">
                 <td className="pl-4">Date</td>
                 <td className="pl-4">Side</td>
@@ -252,7 +252,7 @@ export default function OrdersAndTradesWidget({
       <>
         <div className="max-h-96 min-h-24 overflow-scroll">
           <table className="relative w-full text-left text-sm">
-            <thead className="sticky top-0 font-normal text-darkBluishGray2">
+            <thead className="sticky top-0 z-10 bg-darkBluishGray9 font-normal text-darkBluishGray2">
               <tr key="header">
                 <td className="pl-4">Date</td>
                 <td className="pl-4">Side</td>


### PR DESCRIPTION
scroll orders and trades under table header

<img width="1716" alt="Screenshot 2024-05-28 at 5 00 17 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/c95f2890-3ea4-4f8e-8f8f-0708150fbfeb">

<img width="1705" alt="Screenshot 2024-05-28 at 4 59 26 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/bc327933-758e-48a1-83bf-0f8c31eba1c6">
