### PR TITLE
use checkmark instead of 'Swapped' text after swap request has been sent

### DIFF
--- a/web-ui/src/components/Screens/HomeScreen/Swap.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/Swap.tsx
@@ -760,7 +760,7 @@ export function Swap({
                   if (mutation.isPending) {
                     return 'Submitting order...'
                   } else if (mutation.isSuccess) {
-                    return 'Swapped!'
+                    return <span className="text-xl">&#10003;</span>
                   } else {
                     return 'Swap'
                   }

--- a/web-ui/src/components/common/SubmitButton.tsx
+++ b/web-ui/src/components/common/SubmitButton.tsx
@@ -1,4 +1,5 @@
 import { classNames } from 'utils'
+import { JSX } from 'react'
 
 export type SubmitStatus = 'idle' | 'pending' | 'success' | 'error'
 
@@ -11,7 +12,7 @@ export default function SubmitButton({
 }: {
   disabled: boolean
   onClick: () => void
-  caption: () => string
+  caption: () => string | JSX.Element
   error: string | null | undefined
   status: SubmitStatus
 }) {


### PR DESCRIPTION
avoids 'Swaped' wording since result is not know yet

======
<img width="719" alt="Screenshot 2024-05-31 at 1 28 31 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/f869a954-c6fc-47d7-9e3c-88c5fbc07795">
