### PR TITLE
ignore faucet response on FE

### DIFF
--- a/web-ui/src/apiClient.ts
+++ b/web-ui/src/apiClient.ts
@@ -453,7 +453,7 @@ export const apiClient = new Zodios(apiBaseUrl, [
         schema: FaucetRequestSchema
       }
     ],
-    response: z.undefined(),
+    response: z.any(),
     errors: [
       {
         status: 'default',


### PR DESCRIPTION
faucet api now returns data structure, ignoring it in FE otherwise error message is shown