### PR TITLE
CHAIN-280: change limit price semantics (again)

### DIFF
--- a/web-ui/src/components/Screens/HomeScreen/OrdersAndTradesWidget.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/OrdersAndTradesWidget.tsx
@@ -252,7 +252,7 @@ export default function OrdersAndTradesWidget({
     side: OrderSide,
     market: Market
   ): string {
-    if (side === 'Buy') {
+    if (side === 'Sell') {
       return price.toFixed(market.quoteDecimalPlaces)
     } else {
       const invertedPrice = new Decimal(1).div(price)

--- a/web-ui/src/components/Screens/HomeScreen/swap/LimitModal.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/swap/LimitModal.tsx
@@ -191,18 +191,32 @@ export function LimitModal({
               </div>
               <div className="text-center">
                 <span className="whitespace-nowrap px-4 text-darkBluishGray1">
-                  Buy {sr.bottomSymbol.name} at a rate of
+                  Sell {sr.topSymbol.name} at
                 </span>
-                <input
-                  value={sr.limitPriceInputValue}
-                  disabled={sr.mutation.isPending}
-                  onChange={sr.handlePriceChange}
-                  className="w-36 rounded-xl border-darkBluishGray6 bg-darkBluishGray8 text-center text-white disabled:bg-darkBluishGray7"
-                />
+                <span className="relative">
+                  <input
+                    value={sr.sellLimitPriceInputValue}
+                    disabled={sr.mutation.isPending}
+                    onChange={(e) =>
+                      sr.handleSellLimitPriceChange(e.target.value)
+                    }
+                    className="w-36 rounded-xl border-darkBluishGray6 bg-darkBluishGray8 text-center text-white disabled:bg-darkBluishGray7"
+                  />
+                  {sr.percentOffMarket !== undefined && (
+                    <span
+                      className={classNames(
+                        'ml-2 text-xs absolute right-1 -top-2.5 text-darkBluishGray1'
+                      )}
+                    >
+                      {sr.percentOffMarket > 0 && '+'}
+                      {sr.percentOffMarket.toFixed(1)}%
+                    </span>
+                  )}
+                </span>
                 {[
                   ['Market', undefined],
-                  ['-1%', 100],
-                  ['-5%', 20]
+                  ['+1%', 100],
+                  ['+5%', 20]
                 ].map(([label, incrementDivisor]) => (
                   <button
                     key={label}
@@ -252,26 +266,76 @@ export function LimitModal({
                   {depositAmount(sr.bottomBalance, sr.bottomSymbol)}
                 </div>
               </div>
-              <div className="flex flex-row justify-between">
-                <AmountInput
-                  className="!focus:ring-0 !bg-darkBluishGray8 text-left text-xl !ring-0"
-                  value={sr.buyAmountInputValue}
-                  disabled={false}
-                  onChange={
-                    sr.side === 'Buy'
-                      ? sr.handleBaseAmountChange
-                      : sr.handleQuoteAmountChange
-                  }
-                />
-                <SymbolSelector
-                  markets={markets}
-                  selected={sr.bottomSymbol}
-                  onChange={sr.handleBottomSymbolChange}
-                />
+              <div>
+                <div className="flex flex-row justify-between">
+                  <AmountInput
+                    className="!focus:ring-0 !bg-darkBluishGray8 text-left text-xl !ring-0"
+                    value={sr.buyAmountInputValue}
+                    disabled={false}
+                    onChange={
+                      sr.side === 'Buy'
+                        ? sr.handleBaseAmountChange
+                        : sr.handleQuoteAmountChange
+                    }
+                  />
+                  <SymbolSelector
+                    markets={markets}
+                    selected={sr.bottomSymbol}
+                    onChange={sr.handleBottomSymbolChange}
+                  />
+                </div>
+                <div className="text-center">
+                  <span className="whitespace-nowrap px-4 text-darkBluishGray1">
+                    Buy {sr.bottomSymbol.name} at
+                  </span>
+                  <span className="relative">
+                    <input
+                      value={sr.buyLimitPriceInputValue}
+                      disabled={sr.mutation.isPending}
+                      onChange={(e) =>
+                        sr.handleBuyLimitPriceChange(e.target.value)
+                      }
+                      className="w-36 rounded-xl border-darkBluishGray6 bg-darkBluishGray8 text-center text-white disabled:bg-darkBluishGray7"
+                    />
+                    {sr.percentOffMarket !== undefined && (
+                      <span
+                        className={classNames(
+                          'ml-2 text-xs absolute right-1 -top-2.5 text-darkBluishGray1'
+                        )}
+                      >
+                        {sr.percentOffMarket < 0 && '+'}
+                        {(-sr.percentOffMarket).toFixed(1)}%
+                      </span>
+                    )}
+                  </span>
+                  {[
+                    ['Market', undefined],
+                    ['-1%', 100],
+                    ['-5%', 20]
+                  ].map(([label, incrementDivisor]) => (
+                    <button
+                      key={label}
+                      className={classNames(
+                        'rounded bg-darkBluishGray6 px-2 text-darkBluishGray2 ml-4',
+                        'hover:bg-blue5'
+                      )}
+                      disabled={false}
+                      onClick={() =>
+                        sr.setPriceFromMarketPrice(
+                          incrementDivisor
+                            ? BigInt(incrementDivisor as number)
+                            : undefined
+                        )
+                      }
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
               </div>
             </div>
             <div
-              className="mt-1 cursor-pointer pl-4 text-darkBluishGray1 hover:text-lightBluishGray5"
+              className="mt-1 cursor-pointer pl-4 text-darkBluishGray1 hover:text-statusOrange"
               onClick={() => setMarketPriceInverted(!marketPriceInverted)}
             >
               1 {marketPriceInverted ? sr.topSymbol.name : sr.bottomSymbol.name}{' '}

--- a/web-ui/src/components/Screens/HomeScreen/swap/SwapWidget.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/swap/SwapWidget.tsx
@@ -105,38 +105,33 @@ export function SwapWidget({
                   onChange={sr.handleTopSymbolChange}
                 />
               </div>
-              <div className="mt-2 text-center">
-                <input
-                  id="isLimitOrder"
-                  name="isLimitOrder"
-                  type="checkbox"
-                  checked={sr.isLimitOrder}
-                  disabled={sr.mutation.isPending}
-                  onChange={sr.handleMarketOrderFlagChange}
-                  className="!focus:border-0 size-5 rounded
-                         !border-0
-                         !bg-darkBluishGray6 text-darkBluishGray1
-                         !outline-0
-                         !ring-0"
-                />
-                <label
-                  htmlFor="isLimitOrder"
-                  className="whitespace-nowrap px-4 text-darkBluishGray1"
-                >
-                  Limit Order
-                </label>
-                <input
-                  value={sr.limitPriceInputValue}
-                  disabled={!sr.isLimitOrder || sr.mutation.isPending}
-                  onChange={sr.handlePriceChange}
-                  autoFocus={sr.isLimitOrder}
-                  className="w-36 rounded-xl border-darkBluishGray8 bg-darkBluishGray9 text-center text-white disabled:bg-darkBluishGray6"
-                />
-                <br />
+              <div className="mt-2 space-x-2 text-center text-white">
+                <span>Sell at</span>
+                <span className="relative">
+                  <input
+                    value={sr.sellLimitPriceInputValue}
+                    disabled={sr.mutation.isPending}
+                    onChange={(e) => {
+                      sr.handleMarketOrderFlagChange(e.target.value != '')
+                      sr.handleSellLimitPriceChange(e.target.value)
+                    }}
+                    className="w-36 rounded-xl border-darkBluishGray8 bg-darkBluishGray9 text-center text-white disabled:bg-darkBluishGray6"
+                  />
+                  {sr.percentOffMarket !== undefined && (
+                    <span
+                      className={classNames(
+                        'ml-2 text-xs absolute right-1 -top-2.5 text-darkBluishGray1'
+                      )}
+                    >
+                      {sr.percentOffMarket > 0 && '+'}
+                      {sr.percentOffMarket.toFixed(1)}%
+                    </span>
+                  )}
+                </span>
                 {[
                   ['Market', undefined],
-                  ['-1%', 100],
-                  ['-5%', 20]
+                  ['+1%', 100],
+                  ['+5%', 20]
                 ].map(([label, incrementDivisor]) => (
                   <button
                     key={label}
@@ -144,7 +139,7 @@ export function SwapWidget({
                       'rounded bg-darkBluishGray6 px-2 text-darkBluishGray2 ml-4 mt-2',
                       sr.isLimitOrder && 'hover:bg-blue5'
                     )}
-                    disabled={!sr.isLimitOrder}
+                    disabled={sr.mutation.isPending}
                     onClick={() =>
                       sr.setPriceFromMarketPrice(
                         incrementDivisor
@@ -195,6 +190,53 @@ export function SwapWidget({
                   selected={sr.bottomSymbol}
                   onChange={sr.handleBottomSymbolChange}
                 />
+              </div>
+              <div className="mt-2 space-x-2 text-center text-white">
+                <span>Buy at</span>
+                <span className="relative">
+                  <input
+                    value={sr.buyLimitPriceInputValue}
+                    disabled={sr.mutation.isPending}
+                    onChange={(e) => {
+                      sr.handleMarketOrderFlagChange(e.target.value != '')
+                      sr.handleBuyLimitPriceChange(e.target.value)
+                    }}
+                    className="w-36 rounded-xl border-darkBluishGray8 bg-darkBluishGray9 text-center text-white disabled:bg-darkBluishGray6"
+                  />
+                  {sr.percentOffMarket !== undefined && (
+                    <span
+                      className={classNames(
+                        'ml-2 text-xs absolute right-1 -top-2.5 text-darkBluishGray1'
+                      )}
+                    >
+                      {sr.percentOffMarket < 0 && '+'}
+                      {(-sr.percentOffMarket).toFixed(1)}%
+                    </span>
+                  )}
+                </span>
+                {[
+                  ['Market', undefined],
+                  ['-1%', 100],
+                  ['-5%', 20]
+                ].map(([label, incrementDivisor]) => (
+                  <button
+                    key={label}
+                    className={classNames(
+                      'rounded bg-darkBluishGray6 px-2 text-darkBluishGray2 ml-4 mt-2',
+                      sr.isLimitOrder && 'hover:bg-blue5'
+                    )}
+                    disabled={sr.mutation.isPending}
+                    onClick={() =>
+                      sr.setPriceFromMarketPrice(
+                        incrementDivisor
+                          ? BigInt(incrementDivisor as number)
+                          : undefined
+                      )
+                    }
+                  >
+                    {label}
+                  </button>
+                ))}
               </div>
             </div>
 


### PR DESCRIPTION
There are now two entry boxes for the limit price; one for the limit in terms of the sell token and one in terms of the buy token. Changing one automatically changes the other. Also, the %age off the market is shown.

<img width="1790" alt="Screenshot 2024-06-05 at 4 59 42 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/2530842/1e650d72-a727-4cdf-b1a9-a0e091f3684a">
<img width="1790" alt="Screenshot 2024-06-05 at 4 59 51 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/2530842/716b3a66-855f-470a-9fe9-91a6b22aeb8d">
<img width="1790" alt="Screenshot 2024-06-05 at 4 59 55 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/2530842/ab020307-95ed-4f88-b9e9-dfb8dd3ab635">
