### PR TITLE
CHAIN-277 prevent sequencer level side flip

### DIFF
--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/OrderRoutesApiTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/OrderRoutesApiTest.kt
@@ -1083,18 +1083,18 @@ class OrderRoutesApiTest : OrderBaseTest() {
                 assertEquals(
                     OHLC(
                         // initial ohlc in the BTC/USDC market
-                        // price is weighted across limit orders that have been filled within execution
+                        // price is a weighted price across all order execution of market order
                         start = OHLCDuration.P5M.durationStart(Clock.System.now()),
-                        open = 68400.3,
-                        high = 68400.3,
-                        low = 68400.3,
-                        close = 68400.3,
+                        open = 68400.8,
+                        high = 68400.8,
+                        low = 68400.8,
+                        close = 68400.8,
                         duration = OHLCDuration.P5M,
                     ),
                     msg.ohlc.last(),
                 )
             }
-            assertLimitsMessageReceived(market, base = BigDecimal("0.0018"), quote = BigDecimal("374.416988"))
+            assertLimitsMessageReceived(market, base = BigDecimal("0.0018"), quote = BigDecimal("374.416070"))
         }
 
         makerWsClient.apply {
@@ -1105,16 +1105,16 @@ class OrderRoutesApiTest : OrderBaseTest() {
                 assertEquals(
                     OHLC(
                         start = OHLCDuration.P5M.durationStart(Clock.System.now()),
-                        open = 68400.3,
-                        high = 68400.3,
-                        low = 68400.3,
-                        close = 68400.3,
+                        open = 68400.8,
+                        high = 68400.8,
+                        low = 68400.8,
+                        close = 68400.8,
                         duration = OHLCDuration.P5M,
                     ),
                     msg.ohlc.last(),
                 )
             }
-            assertLimitsMessageReceived(market, base = BigDecimal("0.1982"), quote = BigDecimal("621.889395"))
+            assertLimitsMessageReceived(market, base = BigDecimal("0.1982"), quote = BigDecimal("621.890285"))
         }
 
         val takerOrders = takerApiClient.listOrders(emptyList(), market.id).orders

--- a/scripts/envs/demo.yml
+++ b/scripts/envs/demo.yml
@@ -11,7 +11,7 @@ environment:
     SLACK_ERROR_REPORTING_CHANNEL_ID: C073ZA2VASW
   sequencer:
     QUEUE_HOME: "/data/queues/demo"
-    CHECKPOINTS_ENABLED: "false"
+    CHECKPOINTS_ENABLED: "true"
     SANDBOX_MODE: "true"
     STRICT_REPLAY_VALIDATION: "true"
     DB_HOST: demo-db-cluster.cluster-cpwwaa4iqa1s.us-east-2.rds.amazonaws.com

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/apps/SequencerApp.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/apps/SequencerApp.kt
@@ -35,6 +35,7 @@ import net.openhft.chronicle.queue.TailerDirection
 import net.openhft.chronicle.queue.TailerState
 import net.openhft.chronicle.queue.impl.RollingChronicleQueue
 import java.lang.Thread.UncaughtExceptionHandler
+import java.math.BigDecimal
 import java.math.BigInteger
 import java.nio.file.Path
 import kotlin.concurrent.thread
@@ -64,16 +65,22 @@ class SequencerApp(
                     error = SequencerError.MarketExists
                 } else {
                     val tickSize = market.tickSize.toBigDecimal()
+                    val halfTick = tickSize.setScale(tickSize.scale() + 1) / BigDecimal.valueOf(2)
                     val marketPrice = market.marketPrice.toBigDecimal()
-                    state.markets[marketId] = Market(
-                        id = marketId,
-                        tickSize = tickSize,
-                        initialMarketPrice = marketPrice,
-                        maxLevels = market.maxLevels,
-                        maxOrdersPerLevel = market.maxOrdersPerLevel,
-                        baseDecimals = market.baseDecimals,
-                        quoteDecimals = market.quoteDecimals,
-                    )
+                    if (BigDecimal.ZERO.compareTo((marketPrice + halfTick).remainder(tickSize)) != 0) {
+                        // initial market price is not exactly in between of 2 ticks
+                        error = SequencerError.InvalidPrice
+                    } else {
+                        state.markets[marketId] = Market(
+                            id = marketId,
+                            tickSize = tickSize,
+                            initialMarketPrice = marketPrice,
+                            maxLevels = market.maxLevels,
+                            maxOrdersPerLevel = market.maxOrdersPerLevel,
+                            baseDecimals = market.baseDecimals,
+                            quoteDecimals = market.quoteDecimals,
+                        )
+                    }
                 }
                 sequencerResponse {
                     this.guid = market.guid

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/apps/SequencerApp.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/apps/SequencerApp.kt
@@ -68,7 +68,7 @@ class SequencerApp(
                     val halfTick = tickSize.setScale(tickSize.scale() + 1) / BigDecimal.valueOf(2)
                     val marketPrice = market.marketPrice.toBigDecimal()
                     if (BigDecimal.ZERO.compareTo((marketPrice + halfTick).remainder(tickSize)) != 0) {
-                        // initial market price is not exactly in between of 2 ticks
+                        // initial market price is not exactly between ticks
                         error = SequencerError.InvalidPrice
                     } else {
                         state.markets[marketId] = Market(
@@ -425,8 +425,6 @@ class SequencerApp(
 
             if (checkpointsPath != null) {
                 restoreFromLatestValidCheckpoint(inputTailer, checkpointsPath)
-            } else {
-                inputTailer.toStart()
             }
 
             val lastSequenceNumberProcessedBeforeRestart = getLastSequenceNumberInOutputQueue()

--- a/sequencer/src/test/kotlin/co/chainring/TestSequencer.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestSequencer.kt
@@ -1065,11 +1065,11 @@ class TestSequencer {
 
         // fail
         expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("17"))
-        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("17.005"))
-        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.0024"))
-        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.0026"))
-        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.00251"))
-        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.002500001"))
+        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("17.05"))
+        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.024"))
+        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.026"))
+        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.0251"))
+        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.02500001"))
         // succeed
         sequencerClient.createMarket(MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.05"), marketPrice = BigDecimal("60.025"))
     }

--- a/sequencer/src/test/kotlin/co/chainring/TestSequencer.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestSequencer.kt
@@ -1,15 +1,20 @@
 package co.chainring
 
 import co.chainring.core.model.db.FeeRates
+import co.chainring.sequencer.apps.SequencerApp
 import co.chainring.sequencer.core.MarketId
 import co.chainring.sequencer.core.WalletAddress
+import co.chainring.sequencer.core.toDecimalValue
 import co.chainring.sequencer.core.toOrderGuid
 import co.chainring.sequencer.core.toWalletAddress
 import co.chainring.sequencer.proto.Order
 import co.chainring.sequencer.proto.OrderChangeRejected
 import co.chainring.sequencer.proto.OrderDisposition
 import co.chainring.sequencer.proto.SequencerError
+import co.chainring.sequencer.proto.SequencerRequest
+import co.chainring.sequencer.proto.market
 import co.chainring.sequencer.proto.newQuantityOrNull
+import co.chainring.sequencer.proto.sequencerRequest
 import co.chainring.testutils.ExpectedTrade
 import co.chainring.testutils.SequencerClient
 import co.chainring.testutils.assertBalanceChanges
@@ -18,6 +23,7 @@ import co.chainring.testutils.fromFundamentalUnits
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
+import java.util.UUID
 import kotlin.random.Random
 
 class TestSequencer {
@@ -308,7 +314,7 @@ class TestSequencer {
     fun `test limit checking on orders`() {
         val sequencer = SequencerClient()
         sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
-        val market1 = sequencer.createMarket(MarketId("BTC3/ETH3"), marketPrice = BigDecimal("11.00"))
+        val market1 = sequencer.createMarket(MarketId("BTC3/ETH3"), marketPrice = BigDecimal("11.025"))
 
         val maker = generateWalletAddress()
         // cannot place a buy or sell limit order without any deposits
@@ -332,7 +338,7 @@ class TestSequencer {
         assertEquals(SequencerError.ExceedsLimit, sequencer.addOrder(market1, BigDecimal("0.001"), BigDecimal("11.00"), maker, Order.Type.LimitBuy).error)
 
         // but we can reuse the same liquidity in another market
-        val market2 = sequencer.createMarket(MarketId("ETH3/USDC3"), baseDecimals = 18, quoteDecimals = 6, marketPrice = BigDecimal("100"))
+        val market2 = sequencer.createMarket(MarketId("ETH3/USDC3"), baseDecimals = 18, quoteDecimals = 6, tickSize = BigDecimal("1"), marketPrice = BigDecimal("100.5"))
         sequencer.addOrderAndVerifyAccepted(market2, BigDecimal("1.111"), BigDecimal("100.00"), maker, Order.Type.LimitSell)
 
         // if we deposit some more we can add another order
@@ -1020,6 +1026,52 @@ class TestSequencer {
                 ),
             )
         }
+    }
+
+    @Test
+    fun `initial market price should exactly between ticks`() {
+        fun expectMarketCreationFail(sequencerApp: SequencerApp, marketId: MarketId, tickSize: BigDecimal, marketPrice: BigDecimal, baseDecimals: Int = 8, quoteDecimals: Int = 18) {
+            val createMarketResponse = sequencerApp.processRequest(
+                sequencerRequest {
+                    this.guid = UUID.randomUUID().toString()
+                    this.type = SequencerRequest.Type.AddMarket
+                    this.addMarket = market {
+                        this.guid = UUID.randomUUID().toString()
+                        this.marketId = marketId.value
+                        this.tickSize = tickSize.toDecimalValue()
+                        this.maxLevels = 1000
+                        this.maxOrdersPerLevel = 1000
+                        this.marketPrice = marketPrice.toDecimalValue()
+                        this.baseDecimals = baseDecimals
+                        this.quoteDecimals = quoteDecimals
+                    }
+                },
+            )
+            assertEquals(0, createMarketResponse.marketsCreatedCount)
+            assertEquals(0, createMarketResponse.marketsCreatedList.size)
+            assertEquals(SequencerError.InvalidPrice, createMarketResponse.error)
+        }
+
+        val sequencerApp = SequencerApp(checkpointsPath = null)
+        val sequencerClient = SequencerClient()
+
+        // fail
+        expectMarketCreationFail(sequencerApp, MarketId("BTC98/ETH98"), tickSize = BigDecimal("1"), marketPrice = BigDecimal("1"))
+        expectMarketCreationFail(sequencerApp, MarketId("BTC98/ETH98"), tickSize = BigDecimal("1"), marketPrice = BigDecimal("100"))
+        expectMarketCreationFail(sequencerApp, MarketId("BTC98/ETH98"), tickSize = BigDecimal("1"), marketPrice = BigDecimal("100.001"))
+        expectMarketCreationFail(sequencerApp, MarketId("BTC98/ETH98"), tickSize = BigDecimal("1"), marketPrice = BigDecimal("100.501"))
+        // succeed
+        sequencerClient.createMarket(MarketId("BTC98/ETH98"), tickSize = BigDecimal("1"), marketPrice = BigDecimal("100.50"))
+
+        // fail
+        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("17"))
+        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("17.005"))
+        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.0024"))
+        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.0026"))
+        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.00251"))
+        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.002500001"))
+        // succeed
+        sequencerClient.createMarket(MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.05"), marketPrice = BigDecimal("60.025"))
     }
 
     @Test

--- a/sequencercommon/src/main/proto/sequencer.proto
+++ b/sequencercommon/src/main/proto/sequencer.proto
@@ -76,6 +76,7 @@ enum SequencerError {
   UnknownMarket = 3;
   ExceedsLimit = 4;
   InvalidFeeRate = 5;
+  InvalidPrice = 6;
 }
 
 message StateDump {

--- a/src/main/kotlin/co/chainring/tasks/fixtures/Fixtures.kt
+++ b/src/main/kotlin/co/chainring/tasks/fixtures/Fixtures.kt
@@ -73,13 +73,13 @@ fun getFixtures(chainringChainClients: List<BlockchainClient>) = Fixtures(
                 baseSymbol = SymbolId(client.chainId, "USDC".toChainSymbol(index)),
                 quoteSymbol = SymbolId(client.chainId, "DAI".toChainSymbol(index)),
                 tickSize = "0.01".toBigDecimal(),
-                marketPrice = "2.05".toBigDecimal()
+                marketPrice = "2.005".toBigDecimal()
             ),
             Fixtures.Market(
                 baseSymbol = SymbolId(client.chainId, "BTC".toChainSymbol(index)),
                 quoteSymbol = SymbolId(client.chainId, "USDC".toChainSymbol(index)),
                 tickSize = "1.00".toBigDecimal(),
-                marketPrice = "68390.000".toBigDecimal()
+                marketPrice = "68390.500".toBigDecimal()
             ),
         )
     }.flatten() + if (chainringChainClients.size > 1) listOf(


### PR DESCRIPTION
Combination of multiple issues lead to replied response deviate from expected, restore from checkpoint just allowed for problem to manifest.

- problem 1: when creating limit order the bestBid/bestOffer are set to order price. When filling orders level price is used. As outcome bestBid/bestOffer deviate based on action. 
- problem 2: when checking for market cross order price is compared with bestBid/bestOffer and not the target level price. Same applied for update order when price changes.
- problem 3: filled orders are not reset and stay on the level 'logically' excluded

Sequence until deviation detected
```
85375359913419 - batch orders request (adding limit buy order 3582207263612507227 to level 187)
  - state USDC/DAI (tickSize = 0.01):
      bestBid = 0.015
      bestOffer = 1.99 - (problem 1, level price should be between ticks: 1.985 or 1.995)
      levels[0].price = 0.015
      levels[187].price = 1.885
  - create LIMIT BUY order
      orderPrice = 1.89
      levelIx = 187 <= (orderPrice - levels[0].price).divideToIntegralValue(tickSize).toInt() 


85375359913421 - batch orders request (adding limit sell to level 187)
  - state USDC/DAI (tickSize = 0.01):
      bestBid = 1.885
      bestOffer = 1.99
      levels[0].price = 0.015
      levels[187].price = 1.885
  - create LIMIT SELL order
      orderPrice = 1.89
      levelIx = 187 <= (orderPrice - levels[0].price).divideToIntegralValue(tickSize).toInt() 
  - orderPrice > bestBid => create new order, but on the same level
      => NON-EMPTY level 187 side is updated from BUY to SELL!


85375359913422 - batch orders request that cancels original buy order 3582207263612507227
  - level 187 side is wrong, therefore code tried to delete limit buy order from `sellOrdersByWallet`
  - results into `0` order on `buyOrdersByWallet` after order object has been reset
  - when cancelling the orderTail on level was moved back, important for next move


85375359913496 - some batch orders request
  - new order is added to the end of level 187. It is same reference as order '0' and results into 2x NON-ZERO same ref orders on `buyOrdersByWallet`.
  - `ordersByGuid` is a hash map. Therefore only 1 time on the list.


some sequence - creates a market order 
  - order from previous sequence is filled =>
      - removed from `level 187` and `ordersByGuid` and 1x from `ordersByGuid`
      - 1x NON-ZERO still stays on `buyOrdersByWallet` (we have a ticket for this, CHAIN-274 filled orders are not reset)


Checkpoint (85379654877184). Later server will restart and replay from here
  - 'buyOrdersByWallet' are not stored directly, but restored from levels. Therefore on checkpoint restoration ghost order is removed from `buyOrdersByWallet`


85379654881454 (4270 since checkpoint, 111607 since start) - a batch order from USDC/DAI MM
  - Actual response did not match expected
     expected: exceeds limit on batch
     actual: batch applied. 
   => ghost order was removed and does not hinder batch apply
```