### PR TITLE
calculate number of decimals for inverted price

### DIFF
--- a/web-ui/src/components/Screens/HomeScreen/OrderBookWidget.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/OrderBookWidget.tsx
@@ -110,9 +110,11 @@ export function OrderBookWidget({
 
   function invertPrices(entries: OrderBookEntry[]): OrderBookEntry[] {
     return entries.map((entry) => {
+      const price = parseFloat(entry.price)
+      const [integerPart] = entry.price.split('.')
       return {
-        price: (1.0 / parseFloat(entry.price)).toFixed(6),
-        size: entry.size * parseFloat(entry.price)
+        price: (1.0 / price).toFixed(4 + integerPart.length),
+        size: entry.size * price
       }
     })
   }


### PR DESCRIPTION
for btc/usdc inverted price 6 decimals are not enough to get unique values. Price is used as level is for svg

== prices ==
<img width="1008" alt="Screenshot 2024-06-07 at 2 21 54 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/e3216bcd-077d-4346-b09e-64f23146545d">

<img width="1001" alt="Screenshot 2024-06-07 at 2 22 07 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/8e6d0ac1-d9ce-43e7-aa3e-59212b1e23d3">

== order book ==
<img width="506" alt="Screenshot 2024-06-07 at 2 22 15 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/262eec58-46ef-4394-811e-9b45a8556dcb">

