### PR TITLE
Fix Anvil image: previous tag was deleted from github

### DIFF
--- a/docker/anvil/Dockerfile
+++ b/docker/anvil/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 
 # Install Foundry
 RUN curl -L https://foundry.paradigm.xyz | bash
-RUN /root/.foundry/bin/foundryup -v nightly-c2e529786c07ee7069cefcd4fe2db41f0e46cef6
+RUN /root/.foundry/bin/foundryup -v nightly-5ac78a9cd4b94dc53d1fe5e0f42372b28b5a7559
 
 # initialize directory for efs mount
 RUN mkdir -p /data


### PR DESCRIPTION
Seems like using tags they create on 2-nd of every month is more reliable. This one is June 2, 2024