### PR TITLE
CHAIN-321 apply d3 transitions only when page is visible

### DIFF
--- a/web-ui/src/hooks/usePageVisibility.ts
+++ b/web-ui/src/hooks/usePageVisibility.ts
@@ -1,0 +1,19 @@
+import { useState, useLayoutEffect } from 'react'
+
+function usePageVisibility() {
+  const [isPageVisible, setIsPageVisible] = useState(!document.hidden)
+
+  useLayoutEffect(() => {
+    const handleVisibility = () => {
+      setIsPageVisible(!document.hidden)
+    }
+    document.addEventListener('visibilitychange', handleVisibility)
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibility)
+    }
+  }, [])
+
+  return { isPageVisible }
+}
+
+export default usePageVisibility


### PR DESCRIPTION
Listening to `visibilitychange` event to determine if page is shown on the screen. Animated transitions are rendered only if page is shown to avoid building queue of pending animations.