### PR TITLE
CHAIN-334 limit order price range

### DIFF
--- a/backend/src/main/kotlin/co/chainring/apps/api/ConfigRoutes.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/ConfigRoutes.kt
@@ -81,6 +81,8 @@ object ConfigRoutes {
                                 quoteDecimals = 6,
                                 tickSize = "0.01".toBigDecimal(),
                                 lastPrice = "0.995".toBigDecimal(),
+                                minAllowedBidPrice = "0.01".toBigDecimal(),
+                                maxAllowedOfferPrice = "3.49".toBigDecimal(),
                             ),
                         ),
                         feeRates = FeeRates(
@@ -126,6 +128,8 @@ object ConfigRoutes {
                                     quoteDecimals = market.quoteSymbol.decimals.toInt(),
                                     tickSize = market.tickSize,
                                     lastPrice = market.lastPrice,
+                                    minAllowedBidPrice = market.minAllowedBidPrice,
+                                    maxAllowedOfferPrice = market.maxAllowedOfferPrice,
                                 )
                             }.sortedWith(compareBy({ it.baseSymbol.value }, { it.quoteSymbol.value })),
                             feeRates = FeeRates.fetch(),

--- a/backend/src/main/kotlin/co/chainring/apps/api/model/Configuration.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/model/Configuration.kt
@@ -48,4 +48,6 @@ data class Market(
     val quoteDecimals: Int,
     val tickSize: BigDecimalJson,
     val lastPrice: BigDecimalJson,
+    val minAllowedBidPrice: BigDecimalJson,
+    val maxAllowedOfferPrice: BigDecimalJson,
 )

--- a/backend/src/main/kotlin/co/chainring/apps/api/services/ExchangeApiService.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/services/ExchangeApiService.kt
@@ -359,6 +359,8 @@ class ExchangeApiService(
                         quoteDecimals = it.quoteSymbol.decimals.toInt(),
                         tickSize = it.tickSize,
                         lastPrice = it.lastPrice,
+                        minAllowedBidPrice = it.minAllowedBidPrice,
+                        maxAllowedOfferPrice = it.maxAllowedOfferPrice,
                     )
                 }
             }

--- a/backend/src/main/kotlin/co/chainring/core/db/Migrations.kt
+++ b/backend/src/main/kotlin/co/chainring/core/db/Migrations.kt
@@ -39,6 +39,7 @@ import co.chainring.core.model.db.migrations.V42_ChainConfiguration
 import co.chainring.core.model.db.migrations.V43_AddFsmSessionStateToTelegramBotUser
 import co.chainring.core.model.db.migrations.V44_AddSentToSequencerStatusToDeposit
 import co.chainring.core.model.db.migrations.V45_ChainSettlementBatchIndexes
+import co.chainring.core.model.db.migrations.V46_MarketMinMaxPrice
 import co.chainring.core.model.db.migrations.V4_AddDecimalsToERC20Token
 import co.chainring.core.model.db.migrations.V5_ChainTable
 import co.chainring.core.model.db.migrations.V6_MarketTable
@@ -92,4 +93,5 @@ val migrations = listOf(
     V43_AddFsmSessionStateToTelegramBotUser(),
     V44_AddSentToSequencerStatusToDeposit(),
     V45_ChainSettlementBatchIndexes(),
+    V46_MarketMinMaxPrice(),
 )

--- a/backend/src/main/kotlin/co/chainring/core/model/db/Market.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/Market.kt
@@ -29,6 +29,8 @@ object MarketTable : GUIDTable<MarketId>("market", ::MarketId) {
     val quoteSymbolGuid = reference("quote_symbol_guid", SymbolTable)
     val tickSize = decimal("tick_size", 30, 18)
     val lastPrice = decimal("last_price", 30, 18)
+    val minAllowedBidPrice = decimal("min_allowed_bid_price", 30, 18)
+    val maxAllowedOfferPrice = decimal("max_allowed_offer_price", 30, 18)
 }
 
 class MarketEntity(guid: EntityID<MarketId>) : GUIDEntity<MarketId>(guid) {
@@ -43,6 +45,8 @@ class MarketEntity(guid: EntityID<MarketId>) : GUIDEntity<MarketId>(guid) {
             this.quoteSymbolGuid = quoteSymbol.guid
             this.tickSize = tickSize
             this.lastPrice = lastPrice
+            this.minAllowedBidPrice = lastPrice
+            this.maxAllowedOfferPrice = lastPrice
         }
 
         override fun all(): SizedIterable<MarketEntity> =
@@ -64,6 +68,8 @@ class MarketEntity(guid: EntityID<MarketId>) : GUIDEntity<MarketId>(guid) {
     var quoteSymbolGuid by MarketTable.quoteSymbolGuid
     var tickSize by MarketTable.tickSize
     var lastPrice by MarketTable.lastPrice
+    var minAllowedBidPrice by MarketTable.minAllowedBidPrice
+    var maxAllowedOfferPrice by MarketTable.maxAllowedOfferPrice
 
     var baseSymbol by SymbolEntity referencedOn MarketTable.baseSymbolGuid
     var quoteSymbol by SymbolEntity referencedOn MarketTable.quoteSymbolGuid

--- a/backend/src/main/kotlin/co/chainring/core/model/db/migrations/V46_MarketMinMaxPrice.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/migrations/V46_MarketMinMaxPrice.kt
@@ -1,0 +1,45 @@
+package co.chainring.core.model.db.migrations
+
+import co.chainring.core.db.Migration
+import co.chainring.core.model.db.GUIDTable
+import co.chainring.core.model.db.MarketEntity
+import co.chainring.core.model.db.MarketId
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.math.BigDecimal
+import kotlin.math.min
+
+@Suppress("ClassName")
+class V46_MarketMinMaxPrice : Migration() {
+
+    object V46_MarketTable : GUIDTable<MarketId>("market", ::MarketId) {
+        val minAllowedBidPrice = decimal("min_allowed_bid_price", 30, 18).nullable()
+        val maxAllowedOfferPrice = decimal("max_allowed_offer_price", 30, 18).nullable()
+    }
+
+    override fun run() {
+        transaction {
+            SchemaUtils.createMissingTablesAndColumns(V46_MarketTable)
+
+            MarketEntity.all().forEach { marketEntity ->
+                val levels = 1000
+                val lastPrice = marketEntity.lastPrice
+                val tickSize = marketEntity.tickSize
+                val halfTick = tickSize.setScale(tickSize.scale() + 1) / BigDecimal.valueOf(2)
+
+                val marketIx = min(levels / 2, (lastPrice - halfTick).divideToIntegralValue(tickSize).toInt())
+
+                val minAllowedBidPrice = lastPrice.minus(tickSize.multiply((marketIx - 0.5).toBigDecimal()))
+                val maxAllowedOfferPrice = lastPrice.plus(tickSize.multiply((levels - marketIx + 0.5).toBigDecimal()))
+
+                // min/max prices are calculated based on last price (not initial price)
+                // need manual adjustment after deployment is required
+                marketEntity.minAllowedBidPrice = minAllowedBidPrice
+                marketEntity.maxAllowedOfferPrice = maxAllowedOfferPrice
+            }
+
+            exec("""ALTER TABLE market ALTER COLUMN min_allowed_bid_price SET NOT NULL""")
+            exec("""ALTER TABLE market ALTER COLUMN max_allowed_offer_price SET NOT NULL""")
+        }
+    }
+}

--- a/mocker/src/main/kotlin/co/chainring/mocker/Main.kt
+++ b/mocker/src/main/kotlin/co/chainring/mocker/Main.kt
@@ -49,7 +49,17 @@ fun main() {
     val makers = mutableListOf<Maker>()
     val takers = mutableListOf<Taker>()
 
-    val usdcDai = Market(MarketId("USDC/DAI"), Symbol("USDC"), 6, Symbol("DAI"), 18, 0.05.toBigDecimal(), "0.995".toBigDecimal())
+    val usdcDai = Market(
+        id = MarketId("USDC/DAI"),
+        baseSymbol = Symbol("USDC"),
+        baseDecimals = 6,
+        quoteSymbol = Symbol("DAI"),
+        quoteDecimals = 18,
+        tickSize = BigDecimal("0.05"),
+        lastPrice = BigDecimal("0.995"),
+        minAllowedBidPrice = BigDecimal("0.05"),
+        maxAllowedOfferPrice = BigDecimal("2")
+    )
     val priceFunction = DeterministicHarmonicPriceMovement.generateRandom(initialValue = 17.0, maxFluctuation = 1.5)
 
     // schedule metrics

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/apps/SequencerApp.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/apps/SequencerApp.kt
@@ -14,6 +14,7 @@ import co.chainring.sequencer.core.sumBigIntegers
 import co.chainring.sequencer.core.toAsset
 import co.chainring.sequencer.core.toBigDecimal
 import co.chainring.sequencer.core.toBigInteger
+import co.chainring.sequencer.core.toDecimalValue
 import co.chainring.sequencer.core.toIntegerValue
 import co.chainring.sequencer.core.toOrderGuid
 import co.chainring.sequencer.core.toWalletAddress
@@ -94,6 +95,10 @@ class SequencerApp(
                                 this.tickSize = market.tickSize
                                 this.baseDecimals = market.baseDecimals
                                 this.quoteDecimals = market.quoteDecimals
+                                state.markets[marketId]?.levels?.let { levels ->
+                                    this.minAllowedBid = levels[0].price.toDecimalValue()
+                                    this.maxAllowedOffer = levels[levels.lastIndex - 1].price.toDecimalValue()
+                                }
                             },
                         )
                     }

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/apps/services/SequencerResponseProcessorService.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/apps/services/SequencerResponseProcessorService.kt
@@ -134,6 +134,17 @@ object SequencerResponseProcessorService {
                 }
             }
 
+            SequencerRequest.Type.AddMarket -> {
+                if (response.error == SequencerError.None) {
+                    response.marketsCreatedList.forEach { marketCreated ->
+                        MarketEntity[MarketId(marketCreated.marketId)].let {
+                            it.minAllowedBidPrice = marketCreated.minAllowedBid.toBigDecimal()
+                            it.maxAllowedOfferPrice = marketCreated.maxAllowedOffer.toBigDecimal()
+                        }
+                    }
+                }
+            }
+
             else -> {}
         }
     }

--- a/sequencercommon/src/main/proto/sequencer.proto
+++ b/sequencercommon/src/main/proto/sequencer.proto
@@ -38,6 +38,8 @@ message MarketCreated {
   DecimalValue tickSize = 2;
   uint32 baseDecimals = 3;
   uint32 quoteDecimals = 4;
+  DecimalValue maxAllowedOffer = 5;
+  DecimalValue minAllowedBid = 6;
 }
 
 message FeeRates {

--- a/web-ui/src/apiClient.ts
+++ b/web-ui/src/apiClient.ts
@@ -61,7 +61,9 @@ const MarketSchema = z.object({
   baseSymbol: z.string(),
   quoteSymbol: z.string(),
   tickSize: decimal(),
-  lastPrice: decimal()
+  lastPrice: decimal(),
+  minAllowedBidPrice: decimal(),
+  maxAllowedOfferPrice: decimal()
 })
 export type Market = z.infer<typeof MarketSchema>
 

--- a/web-ui/src/components/Screens/HomeScreen/swap/LimitModal.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/swap/LimitModal.tsx
@@ -371,11 +371,19 @@ export function LimitModal({
                         }
                       } else if (sr.mutation.isSuccess) {
                         return '✓ Submitted'
+                      } else if (sr.limitPriceTooLow) {
+                        return 'Price Too Low'
+                      } else if (sr.limitPriceTooHigh) {
+                        return 'Price Too High'
                       } else {
                         return 'Swap'
                       }
                     }}
-                    status={sr.mutation.status}
+                    status={
+                      sr.limitPriceTooLow || sr.limitPriceTooHigh
+                        ? 'error'
+                        : sr.mutation.status
+                    }
                   />
                 </>
               ) : (

--- a/web-ui/src/components/Screens/HomeScreen/swap/SwapWidget.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/swap/SwapWidget.tsx
@@ -320,12 +320,20 @@ export function SwapWidget({
                         return '✓'
                       } else if (sr.sellAssetsNeeded > 0n) {
                         return 'Insufficient Balance'
+                      } else if (sr.limitPriceTooLow) {
+                        return 'Price Too Low'
+                      } else if (sr.limitPriceTooHigh) {
+                        return 'Price Too High'
                       } else {
                         return 'Swap'
                       }
                     }}
                     status={
-                      sr.sellAssetsNeeded > 0n ? 'error' : sr.mutation.status
+                      sr.sellAssetsNeeded > 0n ||
+                      sr.limitPriceTooLow ||
+                      sr.limitPriceTooHigh
+                        ? 'error'
+                        : sr.mutation.status
                     }
                   />
                 </>

--- a/web-ui/src/markets.ts
+++ b/web-ui/src/markets.ts
@@ -10,13 +10,17 @@ export class Market {
   readonly tickSize: Decimal
   readonly quoteDecimalPlaces: number
   readonly lastPrice: Decimal
+  readonly minAllowedBidPrice: Decimal
+  readonly maxAllowedOfferPrice: Decimal
 
   constructor(
     id: string,
     baseSymbol: TradingSymbol,
     quoteSymbol: TradingSymbol,
     tickSize: Decimal,
-    lastPrice: Decimal
+    lastPrice: Decimal,
+    minAllowedBidPrice: Decimal,
+    maxAllowedOfferPrice: Decimal
   ) {
     this.id = id
     this.baseSymbol = baseSymbol
@@ -24,6 +28,8 @@ export class Market {
     this.tickSize = tickSize
     this.lastPrice = lastPrice
     this.quoteDecimalPlaces = this.tickSize.decimalPlaces() + 1
+    this.minAllowedBidPrice = minAllowedBidPrice
+    this.maxAllowedOfferPrice = maxAllowedOfferPrice
   }
 }
 
@@ -38,7 +44,9 @@ export default class Markets {
         symbols.getByName(m.baseSymbol),
         symbols.getByName(m.quoteSymbol),
         m.tickSize,
-        m.lastPrice
+        m.lastPrice,
+        m.minAllowedBidPrice,
+        m.maxAllowedOfferPrice
       )
     })
     this.marketById = new Map(this.markets.map((m) => [m.id, m]))


### PR DESCRIPTION
 - added `minAllowedBidPrice` and `maxAllowedOfferPrice` to market configuration. Actual values are set by sequencer on market creation
 - migration uses `last_price` to backfill data, values  would need to be adjusted after deployment 

==== Dashboard ====

<img width="350" alt="Screenshot 2024-06-21 at 5 16 39 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/2faf090f-bf41-4769-b877-a6b02c25d060"> <img width="350" alt="Screenshot 2024-06-21 at 5 16 47 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/c3537628-4519-495d-bfc4-2c453e849bd0"> <img width="350" alt="Screenshot 2024-06-21 at 5 23 27 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/75a114dc-3c05-4e22-938c-3bdd5b92831e">

==== Limit ====
<img width="350" alt="Screenshot 2024-06-21 at 5 23 53 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/eca690cd-649a-4423-9d59-27bc12932aba"> <img width="350" alt="Screenshot 2024-06-21 at 5 24 05 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/9de251ba-93ce-4bec-b7f7-288d8ea7cc4e"> <img width="350" alt="Screenshot 2024-06-21 at 5 23 46 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/b160af68-d79c-4ce1-b4c7-f08f0ef740a5">
