### PR TITLE
CHAIN-311 tag and deploy mocker

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -62,4 +62,4 @@ jobs:
           cd scripts
           test -d venv || python3 -m venv venv
           . ./venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt
-          python3 ecs-deploy.py ${{ inputs.action }} --env ${{ inputs.environment }} --services ring,api,sequencer${{ inputs.environment != 'testnet' && ',telegrambot' || '' }} --tag ${{ inputs.tag }}
+          python3 ecs-deploy.py ${{ inputs.action }} --env ${{ inputs.environment }} --services ring,api,sequencer,${{ inputs.environment != 'demo' && ',mocker' || '' }}${{ inputs.environment != 'testnet' && ',telegrambot' || '' }} --tag ${{ inputs.tag }}

--- a/mocker/build.gradle.kts
+++ b/mocker/build.gradle.kts
@@ -55,6 +55,7 @@ application {
     mainClass = "co.chainring.mocker.MockerAppMainKt"
 }
 
+val buildNumber = System.getenv("BUILD_NUMBER") ?: "1"
 jib {
     container.mainClass = "co.chainring.mocker.MockerAppMainKt"
 
@@ -70,7 +71,7 @@ jib {
     to {
         image = "851725450525.dkr.ecr.us-east-2.amazonaws.com/mocker"
         credHelper.helper = "ecr-login"
-        tags = setOf("latest")
+        tags = setOf("${version}-${buildNumber}")
     }
 
     container {


### PR DESCRIPTION
Making new mocker version to be deployed in scope of regular env deployment.
There was problem again after ECS restarted mocker until configuration API changes (`minAllowedBidPrice` and `maxAllowedOfferPrice`) were deployed to demo.