### PR TITLE
Check batch hash before marking settlement as prepared

### DIFF
--- a/backend/src/main/kotlin/co/chainring/core/blockchain/BlockchainTransactionHandler.kt
+++ b/backend/src/main/kotlin/co/chainring/core/blockchain/BlockchainTransactionHandler.kt
@@ -294,7 +294,11 @@ class BlockchainTransactionHandler(
                                     }
                                     TradeEntity.markAsFailedSettling(failedTrades.map { it.tradeHashes.map { it.toHex() } }.flatten().toSet(), "Insufficient Balance")
                                 }
-                                inProgressBatch.markAsPrepared()
+                                if (failedTrades.isEmpty() && blockchainClient.batchHash() != inProgressBatch.prepararationTx.batchHash) {
+                                    inProgressBatch.markAsFailed("Batch hash mismatch")
+                                } else {
+                                    inProgressBatch.markAsPrepared()
+                                }
                             } else {
                                 inProgressBatch.markAsFailed(error)
                             }


### PR DESCRIPTION
This prevents settlement to be marked as prepared in case we were not able to parse `SettlementFailed` events emitted by `prepareSettlementBatch` contract call.