### PR TITLE
CHAIN-350 no rolling deployments for anvil and sequencer

### DIFF
--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -111,6 +111,8 @@ module "anvil" {
   health_check_status                     = "400"
   mount_efs_volume                        = true
   service_discovery_private_dns_namespace = module.vpc.service_discovery_private_dns_namespace
+  deployment_minimum_healthy_percent      = 0
+  deployment_maximum_percent              = 100
 }
 
 module "otterscan" {
@@ -164,6 +166,8 @@ module "anvil2" {
   health_check_status                     = "400"
   mount_efs_volume                        = true
   service_discovery_private_dns_namespace = module.vpc.service_discovery_private_dns_namespace
+  deployment_minimum_healthy_percent      = 0
+  deployment_maximum_percent              = 100
 }
 
 module "otterscan2" {

--- a/terraform/modules/ecs_task/main.tf
+++ b/terraform/modules/ecs_task/main.tf
@@ -211,11 +211,13 @@ resource "aws_service_discovery_service" "service_discovery_service" {
 }
 
 resource "aws_ecs_service" "service" {
-  name            = "${var.name_prefix}-${var.task_name}"
-  cluster         = var.ecs_cluster_id
-  task_definition = aws_ecs_task_definition.task.arn
-  desired_count   = 0 # supposed to be updated outside of TF during each deploy
-  launch_type     = "FARGATE"
+  name                               = "${var.name_prefix}-${var.task_name}"
+  cluster                            = var.ecs_cluster_id
+  task_definition                    = aws_ecs_task_definition.task.arn
+  desired_count                      = 0 # supposed to be updated outside of TF during each deploy
+  launch_type                        = "FARGATE"
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  deployment_maximum_percent         = var.deployment_maximum_percent
 
   network_configuration {
     security_groups = [

--- a/terraform/modules/ecs_task/variables.tf
+++ b/terraform/modules/ecs_task/variables.tf
@@ -50,3 +50,11 @@ variable "mount_efs_volume" {
 }
 variable "service_discovery_private_dns_namespace" {}
 data "aws_caller_identity" "current" {}
+variable "deployment_maximum_percent" {
+  type    = number
+  default = 200
+}
+variable "deployment_minimum_healthy_percent" {
+  type    = number
+  default = 100
+}

--- a/terraform/modules/sequencer/main.tf
+++ b/terraform/modules/sequencer/main.tf
@@ -228,10 +228,12 @@ resource "aws_service_discovery_service" "sequencer" {
 }
 
 resource "aws_ecs_service" "sequencer" {
-  name            = "${var.name_prefix}-sequencer"
-  cluster         = var.ecs_cluster_name
-  task_definition = aws_ecs_task_definition.sequencer.arn
-  desired_count   = 1
+  name                               = "${var.name_prefix}-sequencer"
+  cluster                            = var.ecs_cluster_name
+  task_definition                    = aws_ecs_task_definition.sequencer.arn
+  desired_count                      = 1
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
 
   network_configuration {
     security_groups = []
@@ -256,10 +258,12 @@ resource "aws_ecs_service" "sequencer" {
 
 
 resource "aws_ecs_service" "garp" {
-  name            = "${var.name_prefix}-garp"
-  cluster         = var.ecs_cluster_name
-  task_definition = aws_ecs_task_definition.gateway_and_response_processor.arn
-  desired_count   = 1
+  name                               = "${var.name_prefix}-garp"
+  cluster                            = var.ecs_cluster_name
+  task_definition                    = aws_ecs_task_definition.gateway_and_response_processor.arn
+  desired_count                      = 1
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
 
   network_configuration {
     security_groups = [aws_security_group.security_group.id]

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -106,6 +106,8 @@ module "anvil" {
   health_check_status                     = "400"
   mount_efs_volume                        = true
   service_discovery_private_dns_namespace = module.vpc.service_discovery_private_dns_namespace
+  deployment_minimum_healthy_percent      = 0
+  deployment_maximum_percent              = 100
 }
 
 module "otterscan" {
@@ -158,6 +160,8 @@ module "anvil2" {
   health_check_status                     = "400"
   mount_efs_volume                        = true
   service_discovery_private_dns_namespace = module.vpc.service_discovery_private_dns_namespace
+  deployment_minimum_healthy_percent      = 0
+  deployment_maximum_percent              = 100
 }
 
 module "otterscan2" {


### PR DESCRIPTION
Configuring ECS deployment to avoid rolling deployments for anvil and sequencer. 

AWS announced upgrade of fargate:  https://health.console.aws.amazon.com/health/home#/dashboard/scheduled-changes?eventID=arn:aws:health:us-east-2::event/ECS/AWS_ECS_TASK_PATCHING_RETIREMENT/AWS_ECS_TASK_PATCHING_RETIREMENT-CMH-DockerLinux-1-4-0-262-851725450525-MANAGED&eventTab=details&viewType=table