### PR TITLE
CHAIN-369 fix order book symbol icon overlay

### DIFF
--- a/web-ui/src/components/Screens/HomeScreen/OrderBookWidget.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/OrderBookWidget.tsx
@@ -16,7 +16,7 @@ import * as d3 from 'd3'
 import Decimal from 'decimal.js'
 import { useGesture } from '@use-gesture/react'
 import TradingSymbol from 'tradingSymbol'
-import SymbolIcon from 'components/common/SymbolIcon'
+import { SymbolIconSVG } from 'components/common/SymbolIcon'
 import usePageVisibility from 'hooks/usePageVisibility'
 
 interface OrderBookChartEntry {
@@ -261,9 +261,10 @@ function OrderBookChart({
     top: 20,
     bottom: 0,
     left: lastPriceLabelWidth + 10,
-    right: 0
+    right: 40 // free space for the symbol icon
   }
   const innerWidth = width - margin.left - margin.right
+  const innerWidthWithMarginRight = width - margin.left
   const innerHeight = height - margin.top - margin.bottom
 
   const yScale = d3.scaleLinear()
@@ -329,21 +330,40 @@ function OrderBookChart({
             yScale(nearestPriceLevel.price.toNumber()) + margin.top
           })`
         )
-      tooltip.select('rect').attr('x', `${innerWidth - labelWidth - 10}`)
+      tooltip
+        .select('rect')
+        .attr('x', `${innerWidthWithMarginRight - labelWidth - 10}`)
       tooltip
         .select('text#line1')
         .text('Price ' + nearestPriceLevel.price.toFixed(tickDecimals))
-        .attr('transform', `translate(${innerWidth - labelWidth - 4},-8)`)
+        .attr(
+          'transform',
+          `translate(${innerWidthWithMarginRight - labelWidth - 4},-8)`
+        )
       tooltip
         .select('text#line2')
         .text('Amount ' + levelAmount.toFixed(tickDecimals + 1))
-        .attr('transform', `translate(${innerWidth - labelWidth - 4},4)`)
+        .attr(
+          'transform',
+          `translate(${innerWidthWithMarginRight - labelWidth - 4},4)`
+        )
       tooltip
         .select('text#line3')
         .text('Total ' + totalAmount.toFixed(tickDecimals + 1))
-        .attr('transform', `translate(${innerWidth - labelWidth - 4},16)`)
+        .attr(
+          'transform',
+          `translate(${innerWidthWithMarginRight - labelWidth - 4},16)`
+        )
     },
-    [innerWidth, lastTrade, margin.top, orderBook, svg, tickDecimals, yScale]
+    [
+      innerWidthWithMarginRight,
+      lastTrade,
+      margin.top,
+      orderBook,
+      svg,
+      tickDecimals,
+      yScale
+    ]
   )
 
   const drawChart = useCallback(() => {
@@ -536,20 +556,31 @@ function OrderBookChart({
             />
             <text transform={`translate(3,${margin.top + 4})`} />
           </g>
+          {quantitySymbol && (
+            <g transform={`translate(${width - 30},${5})`}>
+              <SymbolIconSVG symbol={quantitySymbol} />
+            </g>
+          )}
           <g className="y-axis-mouse-projection hidden text-xs">
-            <line x1={margin.left} x2={innerWidth} y1="0" y2="0" />
-            <rect x={innerWidth - 44} y="-22" width="300" height="44" rx="3" />
+            <line
+              x1={margin.left}
+              x2={innerWidthWithMarginRight}
+              y1="0"
+              y2="0"
+            />
+            <rect
+              x={innerWidthWithMarginRight - 44}
+              y="-22"
+              width="300"
+              height="44"
+              rx="3"
+            />
             <text id="line1" />
             <text id="line2" />
             <text id="line3" />
           </g>
         </g>
       </svg>
-      {quantitySymbol && (
-        <div className="absolute right-0 top-0 flex">
-          <SymbolIcon symbol={quantitySymbol} />
-        </div>
-      )}
     </div>
   )
 }

--- a/web-ui/src/components/common/SymbolIcon.tsx
+++ b/web-ui/src/components/common/SymbolIcon.tsx
@@ -14,26 +14,23 @@ interface Props {
   className?: string
 }
 
-export default function SymbolIcon(props: Props) {
-  const symbolName = props.symbol.displayName()
+function getSymbolAndChainIcons(symbol: TradingSymbol): {
+  chainIcon: string
+  icon: string
+} {
+  const symbolName = symbol.displayName()
 
-  const icon = (function () {
-    if (symbolName === 'BTC') {
-      return btc
-    } else if (symbolName === 'ETH') {
-      return eth
-    } else if (symbolName === 'USDC') {
-      return usdc
-    } else if (symbolName === 'DAI') {
-      return dai
-    } else if (symbolName === 'RING') {
-      return logo
-    }
+  const icon = (() => {
+    if (symbolName === 'BTC') return btc
+    if (symbolName === 'ETH') return eth
+    if (symbolName === 'USDC') return usdc
+    if (symbolName === 'DAI') return dai
+    if (symbolName === 'RING') return logo
     return generic
   })()
 
-  const chainIcon = (function () {
-    switch (props.symbol.chainName) {
+  const chainIcon = (() => {
+    switch (symbol.chainName) {
       case 'Botanix':
         return botanix
       case 'Bitlayer':
@@ -45,6 +42,13 @@ export default function SymbolIcon(props: Props) {
     }
   })()
 
+  return { icon, chainIcon }
+}
+
+export default function SymbolIcon(props: Props) {
+  const symbolName = props.symbol.displayName()
+  const { icon, chainIcon } = getSymbolAndChainIcons(props.symbol)
+
   return (
     <span className="relative mt-[-1px] min-w-8 p-1">
       <img src={icon} className={props.className || ''} alt={symbolName} />
@@ -54,5 +58,16 @@ export default function SymbolIcon(props: Props) {
         alt={props.symbol.chainName}
       />
     </span>
+  )
+}
+
+export function SymbolIconSVG(props: Props) {
+  const { icon, chainIcon } = getSymbolAndChainIcons(props.symbol)
+
+  return (
+    <g className={props.className}>
+      <image href={icon} width="24" height="24" />
+      <image href={chainIcon} width="12" height="12" x="16" y="12" />
+    </g>
   )
 }


### PR DESCRIPTION
- import symbol icon into the svg to let mouse projection be on top
- add margin on the right side to avoid overlap with ticks

=== before -> after ===
<img width="390" alt="Screenshot 2024-07-05 at 1 38 43 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/51f51bf4-4e78-44a8-8a26-bfd27f4e9f1c"> <img width="390" alt="Screenshot 2024-07-05 at 1 39 01 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/f60f2d71-19ec-4644-b961-4e2f88f42a56">

<img width="390" alt="Screenshot 2024-07-05 at 1 39 40 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/f59b6079-8ec2-4cf3-8ad2-d5d6aa5bc49f"> <img width="390" alt="Screenshot 2024-07-05 at 1 39 17 PM" src="https://github.com/Chainring-Inc/chainring-monorepo/assets/17568216/18d8209c-73d5-4213-b2c1-e874ca96b009">
