### PR TITLE
Chain 319/dynamic price levels

### DIFF
--- a/backend/src/main/kotlin/co/chainring/apps/api/TestRoutes.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/TestRoutes.kt
@@ -42,7 +42,6 @@ class TestRoutes(
         data class CreateMarketInSequencer(
             val id: String,
             val tickSize: BigDecimalJson,
-            val marketPrice: BigDecimalJson,
             val baseDecimals: Int,
             val quoteDecimals: Int,
             val minFee: BigDecimalJson,
@@ -89,8 +88,6 @@ class TestRoutes(
             data class Market(
                 val id: String,
                 val tickSize: BigDecimalJson,
-                val marketPrice: BigDecimalJson,
-                val maxLevels: Int,
                 val maxOrdersPerLevel: Int,
                 val baseDecimals: Int,
                 val quoteDecimals: Int,
@@ -170,8 +167,6 @@ class TestRoutes(
                         StateDump.Market(
                             id = "marketId",
                             tickSize = "123".toBigDecimal(),
-                            marketPrice = "123".toBigDecimal(),
-                            maxLevels = 123,
                             maxOrdersPerLevel = 123,
                             baseDecimals = 18,
                             quoteDecimals = 18,
@@ -240,8 +235,6 @@ class TestRoutes(
                             StateDump.Market(
                                 id = m.id,
                                 tickSize = m.tickSize.toBigDecimal(),
-                                marketPrice = m.marketPrice.toBigDecimal(),
-                                maxLevels = m.maxLevels,
                                 maxOrdersPerLevel = m.maxOrdersPerLevel,
                                 baseDecimals = m.baseDecimals,
                                 quoteDecimals = m.quoteDecimals,
@@ -287,7 +280,6 @@ class TestRoutes(
                 requestBody to CreateMarketInSequencer(
                     id = "BTC/ETH",
                     tickSize = "0.05".toBigDecimal(),
-                    marketPrice = "17.55".toBigDecimal(),
                     baseDecimals = 18,
                     quoteDecimals = 18,
                     minFee = "0.000005".toBigDecimal(),
@@ -302,7 +294,6 @@ class TestRoutes(
                 val sequencerResponse = sequencerClient.createMarket(
                     marketId = payload.id,
                     tickSize = payload.tickSize,
-                    marketPrice = payload.marketPrice,
                     baseDecimals = payload.baseDecimals,
                     quoteDecimals = payload.quoteDecimals,
                     minFee = payload.minFee,

--- a/backend/src/main/kotlin/co/chainring/apps/api/TestRoutes.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/TestRoutes.kt
@@ -101,7 +101,6 @@ class TestRoutes(
             data class OrderBookLevel(
                 val levelIx: Int,
                 val side: String,
-                val price: BigDecimalJson,
                 val maxOrderCount: Int,
                 val totalQuantity: BigIntegerJson,
                 val orderHead: Int,
@@ -114,7 +113,6 @@ class TestRoutes(
                 val guid: Long,
                 val wallet: String,
                 val quantity: BigIntegerJson,
-                val levelIx: Int,
                 val originalQuantity: BigIntegerJson,
             )
         }
@@ -177,7 +175,6 @@ class TestRoutes(
                                 StateDump.OrderBookLevel(
                                     levelIx = 123,
                                     side = "Buy",
-                                    price = "123".toBigDecimal(),
                                     maxOrderCount = 123,
                                     totalQuantity = "123".toBigInteger(),
                                     orderHead = 123,
@@ -187,7 +184,6 @@ class TestRoutes(
                                             guid = 123L,
                                             wallet = "Wallet",
                                             quantity = "123".toBigInteger(),
-                                            levelIx = 123,
                                             originalQuantity = "123".toBigInteger(),
                                         ),
                                     ),
@@ -245,7 +241,6 @@ class TestRoutes(
                                     StateDump.OrderBookLevel(
                                         levelIx = l.levelIx,
                                         side = l.side.name,
-                                        price = l.price.toBigDecimal(),
                                         maxOrderCount = l.maxOrderCount,
                                         totalQuantity = l.totalQuantity.toBigInteger(),
                                         orderHead = l.orderHead,
@@ -255,7 +250,6 @@ class TestRoutes(
                                                 guid = lo.guid,
                                                 wallet = walletAddresses[lo.wallet] ?: lo.wallet.toString(),
                                                 quantity = lo.quantity.toBigInteger(),
-                                                levelIx = lo.levelIx,
                                                 originalQuantity = lo.originalQuantity.toBigInteger(),
                                             )
                                         },

--- a/backend/src/main/kotlin/co/chainring/apps/api/services/ExchangeApiService.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/services/ExchangeApiService.kt
@@ -137,7 +137,7 @@ class ExchangeApiService(
             SequencerClient.Order(
                 sequencerOrderId = orderId.toSequencerId().value,
                 amount = orderRequest.amount.fixedAmount(),
-                price = price?.toString(),
+                levelIx = price?.divideToIntegralValue(market.tickSize)?.toInt(),
                 wallet = walletAddress.toSequencerId().value,
                 orderType = toSequencerOrderType(orderRequest is CreateOrderApiRequest.Market, orderRequest.side),
                 nonce = BigInteger(1, orderRequest.nonce.toHexBytes()),
@@ -171,7 +171,7 @@ class ExchangeApiService(
             SequencerClient.Order(
                 sequencerOrderId = orderRequest.orderId.toSequencerId().value,
                 amount = orderRequest.amount,
-                price = orderRequest.price.toString(),
+                levelIx = orderRequest.price.divideToIntegralValue(market.tickSize).toInt(),
                 wallet = walletAddress.toSequencerId().value,
                 orderType = toSequencerOrderType(false, orderRequest.side),
                 nonce = BigInteger(1, orderRequest.nonce.toHexBytes()),

--- a/backend/src/main/kotlin/co/chainring/apps/ring/SettlementCoordinator.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/ring/SettlementCoordinator.kt
@@ -425,6 +425,8 @@ class SettlementCoordinator(
             val sellExecution = executions.first { it.order.side == OrderSide.Sell }
             val sellOrder = sellExecution.order
 
+            val market = tradeEntity.market
+
             val sequencerResponse = runBlocking {
                 sequencerClient.failSettlement(
                     buyWallet = buyOrder.wallet.address.toSequencerId().value,
@@ -433,7 +435,7 @@ class SettlementCoordinator(
                     buyOrderId = buyOrder.guid.value,
                     sellOrderId = sellOrder.guid.value,
                     amount = tradeEntity.amount,
-                    price = tradeEntity.price,
+                    levelIx = tradeEntity.price.divideToIntegralValue(market.tickSize).toInt(),
                     buyerFee = buyExecution.feeAmount,
                     sellerFee = sellExecution.feeAmount,
                 )

--- a/backend/src/main/kotlin/co/chainring/core/model/db/Order.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/Order.kt
@@ -105,7 +105,7 @@ data class CreateOrderAssignment(
     val type: OrderType,
     val side: OrderSide,
     val amount: BigInteger,
-    val price: BigDecimal?,
+    val levelIx: Int?,
     val signature: EvmSignature,
     val sequencerOrderId: SequencerOrderId,
     val sequencerTimeNs: BigInteger,
@@ -114,7 +114,7 @@ data class CreateOrderAssignment(
 data class UpdateOrderAssignment(
     val orderId: OrderId,
     val amount: BigInteger,
-    val price: BigDecimal?,
+    val levelIx: Int?,
     val nonce: BigInteger,
     val signature: EvmSignature,
 )
@@ -236,7 +236,7 @@ class OrderEntity(guid: EntityID<OrderId>) : GUIDEntity<OrderId>(guid) {
                 this[OrderTable.type] = assignment.type
                 this[OrderTable.amount] = assignment.amount.toBigDecimal()
                 this[OrderTable.originalAmount] = assignment.amount.toBigDecimal()
-                this[OrderTable.price] = assignment.price
+                this[OrderTable.price] = assignment.levelIx?.let { market.tickSize.multiply(it.toBigDecimal()) }
                 this[OrderTable.nonce] = assignment.nonce.toByteArrayNoSign().toHex(false)
                 this[OrderTable.signature] = assignment.signature.value
                 this[OrderTable.sequencerOrderId] = assignment.sequencerOrderId.value
@@ -247,7 +247,7 @@ class OrderEntity(guid: EntityID<OrderId>) : GUIDEntity<OrderId>(guid) {
                     updateAssignments.forEach { assignment ->
                         addBatch(EntityID(assignment.orderId, OrderTable))
                         this[OrderTable.amount] = assignment.amount.toBigDecimal()
-                        this[OrderTable.price] = assignment.price
+                        this[OrderTable.price] = assignment.levelIx?.let { market.tickSize.multiply(it.toBigDecimal()) }
                         this[OrderTable.nonce] = assignment.nonce.toByteArrayNoSign().toHex(false)
                         this[OrderTable.signature] = assignment.signature.value
                         this[BalanceTable.updatedAt] = now

--- a/backend/src/main/kotlin/co/chainring/core/sequencer/SequencerClient.kt
+++ b/backend/src/main/kotlin/co/chainring/core/sequencer/SequencerClient.kt
@@ -79,7 +79,7 @@ open class SequencerClient {
     data class Order(
         val sequencerOrderId: Long,
         val amount: BigInteger,
-        val price: String?,
+        val levelIx: Int?,
         val wallet: Long,
         val orderType: co.chainring.sequencer.proto.Order.Type,
         val nonce: BigInteger?,
@@ -292,7 +292,7 @@ open class SequencerClient {
         buyOrderId: OrderId,
         sellOrderId: OrderId,
         amount: BigInteger,
-        price: BigDecimal,
+        levelIx: Int,
         buyerFee: BigInteger,
         sellerFee: BigInteger,
     ): SequencerResponse {
@@ -309,7 +309,7 @@ open class SequencerClient {
                                 this.buyOrderGuid = buyOrderId.toSequencerId().value
                                 this.sellOrderGuid = sellOrderId.toSequencerId().value
                                 this.amount = amount.toIntegerValue()
-                                this.price = price.toDecimalValue()
+                                this.levelIx = levelIx
                                 this.buyerFee = buyerFee.toIntegerValue()
                                 this.sellerFee = sellerFee.toIntegerValue()
                             }
@@ -359,7 +359,7 @@ open class SequencerClient {
     private fun toOrderDSL(order: Order) = order {
         this.guid = order.sequencerOrderId
         this.amount = order.amount.toIntegerValue()
-        this.price = order.price?.toBigDecimal()?.toDecimalValue() ?: BigDecimal.ZERO.toDecimalValue()
+        this.levelIx = order.levelIx ?: 0
         this.type = order.orderType
         this.nonce = order.nonce?.toIntegerValue() ?: BigInteger.ZERO.toIntegerValue()
         this.signature = order.signature?.value ?: EvmSignature.emptySignature().value

--- a/backend/src/main/kotlin/co/chainring/core/sequencer/SequencerClient.kt
+++ b/backend/src/main/kotlin/co/chainring/core/sequencer/SequencerClient.kt
@@ -128,16 +128,14 @@ open class SequencerClient {
         }.sequencerResponse
     }
 
-    suspend fun createMarket(marketId: String, tickSize: BigDecimal = "0.05".toBigDecimal(), marketPrice: BigDecimal, baseDecimals: Int, quoteDecimals: Int, minFee: BigDecimal): SequencerResponse {
+    suspend fun createMarket(marketId: String, tickSize: BigDecimal = "0.05".toBigDecimal(), baseDecimals: Int, quoteDecimals: Int, minFee: BigDecimal): SequencerResponse {
         return Tracer.newCoroutineSpan(ServerSpans.sqrClt) {
             stub.addMarket(
                 market {
                     this.guid = UUID.randomUUID().toString()
                     this.marketId = marketId
                     this.tickSize = tickSize.toDecimalValue()
-                    this.maxLevels = 1000
                     this.maxOrdersPerLevel = 1000
-                    this.marketPrice = marketPrice.toDecimalValue()
                     this.baseDecimals = baseDecimals
                     this.quoteDecimals = quoteDecimals
                     this.minFee = minFee.toFundamentalUnits(quoteDecimals).toIntegerValue()

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/testutils/AppUnderTestRunner.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/testutils/AppUnderTestRunner.kt
@@ -191,7 +191,6 @@ class AppUnderTestRunner : BeforeAllCallback, BeforeEachCallback {
                 TestRoutes.Companion.CreateMarketInSequencer(
                     id = "${baseSymbol.name}/${quoteSymbol.name}",
                     tickSize = market.tickSize,
-                    marketPrice = market.marketPrice,
                     quoteDecimals = quoteSymbol.decimals,
                     baseDecimals = baseSymbol.decimals,
                     minFee = market.minFee,

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/apps/SequencerApp.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/apps/SequencerApp.kt
@@ -527,7 +527,7 @@ class SequencerApp(
     }
 
     private fun calculateLimitBuyOrderNotionalPlusFee(order: Order, market: Market): BigInteger {
-        return if (order.price.toBigDecimal() >= market.bestOffer) {
+        return if (market.levelIx(order.price.toBigDecimal()) >= market.bestOfferIx) {
             // limit order crosses the market
             val orderPrice = order.price.toBigDecimal()
             val levelIx = market.levelIx(orderPrice)

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/apps/SequencerApp.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/apps/SequencerApp.kt
@@ -105,8 +105,13 @@ class SequencerApp(
                                 this.baseDecimals = market.baseDecimals
                                 this.quoteDecimals = market.quoteDecimals
                                 state.markets[marketId]?.levels?.let { levels ->
-                                    this.minAllowedBid = levels[0].price.toDecimalValue()
-                                    this.maxAllowedOffer = levels[levels.lastIndex - 1].price.toDecimalValue()
+                                    // TODO drop min/max values
+                                    this.minAllowedBid = market.tickSize
+                                    val marketIx = market.marketPrice.toBigDecimal().divideToIntegralValue(tickSize.toBigDecimal()).toInt()
+                                    this.maxAllowedOffer = market.tickSize.toBigDecimal().multiply((marketIx * 2).toBigDecimal()).toDecimalValue()
+                                    // market.marketPrice.toBigDecimal().multiply(BigDecimal("2")).divideToIntegralValue(tickSize).toInt()
+//                                    this.minAllowedBid = levels[0].price.toDecimalValue()
+//                                    this.maxAllowedOffer = levels[levels.lastIndex - 1].price.toDecimalValue()
                                 }
                                 this.minFee = if (market.hasMinFee()) market.minFee else BigInteger.ZERO.toIntegerValue()
                             },
@@ -470,7 +475,7 @@ class SequencerApp(
                     )
                 }
                 if (oldQuoteAssets > BigInteger.ZERO) { // LimitBuy
-                    val previousNotionalAndFee = notionalPlusFee(order.quantity, market.levels[order.levelIx].price, market.baseDecimals, market.quoteDecimals, state.feeRates.maker)
+                    val previousNotionalAndFee = notionalPlusFee(order.quantity, market.price(order.levelIx), market.baseDecimals, market.quoteDecimals, state.feeRates.maker)
                     val notionalAndFee = calculateLimitBuyOrderNotionalPlusFee(orderChange, market)
                     quoteAssetsRequired.merge(order.wallet, notionalAndFee - previousNotionalAndFee, ::sumBigIntegers)
                 }

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/apps/services/SequencerResponseProcessorService.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/apps/services/SequencerResponseProcessorService.kt
@@ -142,8 +142,9 @@ object SequencerResponseProcessorService {
                 if (response.error == SequencerError.None) {
                     response.marketsCreatedList.forEach { marketCreated ->
                         MarketEntity[MarketId(marketCreated.marketId)].let {
-                            it.minAllowedBidPrice = marketCreated.minAllowedBid.toBigDecimal()
-                            it.maxAllowedOfferPrice = marketCreated.maxAllowedOffer.toBigDecimal()
+                            // TODO delete min/max allowed price OR apply logical dynamic range
+                            it.minAllowedBidPrice = BigDecimal.ZERO
+                            it.maxAllowedOfferPrice = Integer.MAX_VALUE.toBigDecimal()
                             it.minFee = if (marketCreated.hasMinFee()) marketCreated.minFee.toBigInteger() else BigInteger.ZERO
                         }
                     }

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/apps/services/SequencerResponseProcessorService.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/apps/services/SequencerResponseProcessorService.kt
@@ -100,10 +100,8 @@ object SequencerResponseProcessorService {
 
             SequencerRequest.Type.ApplyOrderBatch -> {
                 response.bidOfferState?.let {
-                    val bestBid = it.bestBid.toBigDecimal()
-                    val bestOffer = it.bestOffer.toBigDecimal()
-                    logger.debug { "bestBid = $bestBid, bestOffer = $bestOffer, minBidIx=${it.minBidIx.toBigInteger()}, maxOfferIx=${it.maxOfferIx.toBigInteger()}}" }
-                    if (bestBid >= bestOffer) {
+                    logger.debug { "minBidIx=${it.minBidIx}, bestBidIx = ${it.bestBidIx}, bestOfferIx = ${it.bestOfferIx}, maxOfferIx=${it.maxOfferIx}" }
+                    if (it.bestBidIx >= it.bestOfferIx) {
                         request.orderBatch.ordersToAddList.forEach {
                             logger.debug { "add - ${it.guid} ${it.externalGuid} ${it.type} ${it.amount.toBigInteger()} ${it.price.toBigDecimal()}" }
                         }

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/core/Market.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/core/Market.kt
@@ -40,7 +40,7 @@ data class Market(
 
     val levels = AVLTree<OrderBookLevel>()
 
-    private val pool = ObjectPool(
+    private val levelPool = ObjectPool(
         create = { OrderBookLevel.empty(maxOrdersPerLevel) },
         reset = { it.reset() },
         initialSize = 1000,
@@ -454,7 +454,7 @@ data class Market(
 
             exhaustedLevels.forEach {
                 levels.remove(it.ix)
-                pool.release(it)
+                levelPool.release(it)
             }
         }
 
@@ -555,7 +555,7 @@ data class Market(
                     }
                 }
                 levels.remove(level.ix)
-                pool.release(level)
+                levelPool.release(level)
             }
             ordersByGuid.remove(guid)
         }
@@ -701,7 +701,7 @@ data class Market(
 
     private fun getOrCreateLevel(levelIx: Int, side: BookSide): OrderBookLevel {
         return levels.get(levelIx)
-            ?: pool
+            ?: levelPool
                 .borrow { level -> level.init(levelIx, side, price(levelIx)) }
                 .let { levels.add(it) }
     }

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/core/Market.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/core/Market.kt
@@ -23,7 +23,6 @@ import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.concurrent.CopyOnWriteArrayList
 
-// market price must be exactly halfway between two ticks
 data class Market(
     val id: MarketId,
     val tickSize: BigDecimal,
@@ -46,47 +45,18 @@ data class Market(
         OrderBookLevel(
             levelIx = levelIx,
             side = side,
-            // the initial market price is between ticks, which introduces an additional '0' in the end
-            // price = price(levelIx).setScale(initialMarketPrice.scale()),
             price = price(levelIx),
             maxOrderCount = maxOrdersPerLevel,
         )
 
-//    private val halfTick = tickSize.setScale(tickSize.scale() + 1) / BigDecimal.valueOf(2)
-//    private fun marketIx(): Int = min(maxLevels / 2, (initialMarketPrice - halfTick).divideToIntegralValue(tickSize).toInt())
-//    fun levelIx(price: BigDecimal): Int = (price - levels[0].price).divideToIntegralValue(tickSize).toInt()
-//    val levels: Array<OrderBookLevel> = marketIx().let { marketIx ->
-//        Array(maxLevels) { n ->
-//            if (n < marketIx) {
-//                OrderBookLevel(
-//                    n,
-//                    BookSide.Buy,
-//                    initialMarketPrice.minus(tickSize.multiply((marketIx - n - 0.5).toBigDecimal())),
-//                    maxOrdersPerLevel,
-//                )
-//            } else {
-//                OrderBookLevel(
-//                    n,
-//                    BookSide.Sell,
-//                    initialMarketPrice.plus(tickSize.multiply((n - marketIx + 0.5).toBigDecimal())),
-//                    maxOrdersPerLevel,
-//                )
-//            }
-//        }
-//    }
-
-    // sell boundary
     var maxOfferIx: Int = -1
         private set
     var bestOfferIx: Int = -1
         private set
-
-    // spread
     var bestBidIx: Int = -1
         private set
     var minBidIx: Int = -1
         private set
-    // buy boundary
 
     // TODO - change these mutable maps to a HashMap that pre-allocates
     val buyOrdersByWallet = mutableMapOf<WalletAddress, CopyOnWriteArrayList<LevelOrder>>()
@@ -1012,8 +982,8 @@ data class Market(
                 minFee = if (checkpoint.hasMinFee()) checkpoint.minFee.toBigInteger() else BigInteger.ZERO,
             ).apply {
                 maxOfferIx = checkpoint.maxOfferIx
-                bestOfferIx = checkpoint.bestOfferIx // TODO make backward compatible
-                bestBidIx = checkpoint.bestBidIx // TODO make backward compatible
+                bestOfferIx = checkpoint.bestOfferIx
+                bestBidIx = checkpoint.bestBidIx
                 minBidIx = checkpoint.minBidIx
 
                 checkpoint.levelsList

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/core/Market.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/core/Market.kt
@@ -48,14 +48,6 @@ data class Market(
     )
     val levels = AVLTree<OrderBookLevel>()
 
-    private fun initLevel(levelIx: Int, side: BookSide): OrderBookLevel =
-        OrderBookLevel(
-            ix = levelIx,
-            side = side,
-            price = price(levelIx),
-            maxOrderCount = maxOrdersPerLevel,
-        )
-
     var maxOfferIx: Int = -1
         private set
     var bestOfferIx: Int = -1

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/core/OrderBook.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/core/OrderBook.kt
@@ -95,11 +95,6 @@ class OrderBookLevel(ix: Int, var side: BookSide, var price: BigDecimal, val max
         side = BookSide.Sell
         price = BigDecimal.ZERO
         totalQuantity = BigInteger.ZERO
-
-        // level orders are provided back in Executions, reset causes effects
-        /*orderHead = 0
-        orderTail = 0
-        orders.forEach { it.reset() }*/
         super.reset()
     }
 

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/core/OrderBook.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/core/OrderBook.kt
@@ -26,7 +26,7 @@ data class LevelOrder(
     var wallet: WalletAddress,
     var quantity: BigInteger,
     var feeRate: FeeRate,
-    var levelIx: Int,
+    var level: OrderBookLevel,
     var originalQuantity: BigInteger = quantity,
 ) {
     fun update(wallet: Long, order: Order, feeRate: FeeRate) {
@@ -50,26 +50,52 @@ data class LevelOrder(
             this.guid = this@LevelOrder.guid.value
             this.wallet = this@LevelOrder.wallet.value
             this.quantity = this@LevelOrder.quantity.toIntegerValue()
-            this.levelIx = this@LevelOrder.levelIx
             this.originalQuantity = this@LevelOrder.originalQuantity.toIntegerValue()
             this.feeRate = this@LevelOrder.feeRate.value
         }
     }
 
-    fun fromCheckpoint(checkpoint: MarketCheckpoint.LevelOrder) {
+    fun fromCheckpoint(checkpoint: MarketCheckpoint.LevelOrder, level: OrderBookLevel) {
         this.guid = OrderGuid(checkpoint.guid)
         this.wallet = WalletAddress(checkpoint.wallet)
         this.quantity = checkpoint.quantity.toBigInteger()
-        this.levelIx = checkpoint.levelIx
+        this.level = level
         this.originalQuantity = checkpoint.originalQuantity.toBigInteger()
         this.feeRate = FeeRate(checkpoint.feeRate)
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as LevelOrder
+
+        if (guid != other.guid) return false
+        if (wallet != other.wallet) return false
+        if (quantity != other.quantity) return false
+        if (feeRate != other.feeRate) return false
+        if (level.ix != other.level.ix) return false
+        if (originalQuantity != other.originalQuantity) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = guid.hashCode()
+        result = 31 * result + wallet.hashCode()
+        result = 31 * result + quantity.hashCode()
+        result = 31 * result + feeRate.hashCode()
+        result = 31 * result + level.ix.hashCode()
+        result = 31 * result + originalQuantity.hashCode()
+        return result
+    }
 }
 
+// price is used for notional calculation
 class OrderBookLevel(ix: Int, var side: BookSide, var price: BigDecimal, val maxOrderCount: Int) : AVLTree.Node<OrderBookLevel>(ix) {
 
     val orders = Array(maxOrderCount) { _ ->
-        LevelOrder(guid = 0L.toOrderGuid(), wallet = 0L.toWalletAddress(), quantity = BigInteger.ZERO, feeRate = FeeRate.zero, levelIx = ix)
+        LevelOrder(guid = 0L.toOrderGuid(), wallet = 0L.toWalletAddress(), quantity = BigInteger.ZERO, feeRate = FeeRate.zero, level = this)
     }
     var totalQuantity = BigInteger.ZERO
     var orderHead = 0
@@ -85,8 +111,6 @@ class OrderBookLevel(ix: Int, var side: BookSide, var price: BigDecimal, val max
         this.ix = levelIx
         this.side = buy
         this.price = price
-        // level orders keep reference to levelIx, not to the level object, hence need to be touched
-        orders.forEach { it.levelIx = levelIx }
         return this
     }
 
@@ -135,7 +159,7 @@ class OrderBookLevel(ix: Int, var side: BookSide, var price: BigDecimal, val max
         for (i in 0 until checkpointOrdersCount) {
             val orderCheckpoint = checkpoint.ordersList[i]
             val index = (orderHead + i) % maxOrderCount
-            orders[index].fromCheckpoint(orderCheckpoint)
+            orders[index].fromCheckpoint(orderCheckpoint, level = this)
         }
         totalQuantity = checkpoint.totalQuantity.toBigInteger()
     }
@@ -154,28 +178,30 @@ class OrderBookLevel(ix: Int, var side: BookSide, var price: BigDecimal, val max
     }
 
     fun fillOrder(requestedAmount: BigInteger): OrderBookLevelFill {
-        var ix = orderHead
+        var orderIx = orderHead
         val executions = mutableListOf<Execution>()
         var remainingAmount = requestedAmount
-        while (ix != orderTail && remainingAmount > BigInteger.ZERO) {
-            val curOrder = orders[ix]
+        while (orderIx != orderTail && remainingAmount > BigInteger.ZERO) {
+            val curOrder = orders[orderIx]
             if (remainingAmount >= curOrder.quantity) {
                 executions.add(
                     Execution(
                         counterOrder = curOrder,
                         amount = curOrder.quantity,
+                        levelIx = this.ix,
                         price = this.price,
                         counterOrderExhausted = true,
                     ),
                 )
                 totalQuantity -= curOrder.quantity
                 remainingAmount -= curOrder.quantity
-                ix = (ix + 1) % maxOrderCount
+                orderIx = (orderIx + 1) % maxOrderCount
             } else {
                 executions.add(
                     Execution(
                         counterOrder = curOrder,
                         amount = remainingAmount,
+                        levelIx = this.ix,
                         price = this.price,
                         counterOrderExhausted = false,
                     ),
@@ -186,7 +212,7 @@ class OrderBookLevel(ix: Int, var side: BookSide, var price: BigDecimal, val max
             }
         }
         // remove consumed orders
-        orderHead = ix // TODO: CHAIN-274 Also reset consumed orders
+        orderHead = orderIx // TODO: CHAIN-274 Also reset consumed orders
 
         return OrderBookLevelFill(
             remainingAmount,
@@ -228,7 +254,6 @@ class OrderBookLevel(ix: Int, var side: BookSide, var price: BigDecimal, val max
 
         if (ix != other.ix) return false
         if (side != other.side) return false
-        if (price != other.price) return false
         if (maxOrderCount != other.maxOrderCount) return false
         if (totalQuantity != other.totalQuantity) return false
 
@@ -251,7 +276,6 @@ class OrderBookLevel(ix: Int, var side: BookSide, var price: BigDecimal, val max
     override fun hashCode(): Int {
         var result = ix
         result = 31 * result + side.hashCode()
-        result = 31 * result + price.hashCode()
         result = 31 * result + maxOrderCount
         result = 31 * result + totalQuantity.hashCode()
         result = 31 * result + orderHead
@@ -271,6 +295,7 @@ class OrderBookLevel(ix: Int, var side: BookSide, var price: BigDecimal, val max
 data class Execution(
     val counterOrder: LevelOrder,
     val amount: BigInteger,
+    val levelIx: Int,
     val price: BigDecimal,
     val counterOrderExhausted: Boolean,
 )

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/core/OrderBook.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/core/OrderBook.kt
@@ -1,5 +1,6 @@
 package co.chainring.sequencer.core
 
+import co.chainring.sequencer.core.datastructure.AVLTree
 import co.chainring.sequencer.proto.MarketCheckpoint
 import co.chainring.sequencer.proto.MarketCheckpointKt.levelOrder
 import co.chainring.sequencer.proto.MarketCheckpointKt.orderBookLevel
@@ -65,7 +66,9 @@ data class LevelOrder(
     }
 }
 
-class OrderBookLevel(val levelIx: Int, var side: BookSide, val price: BigDecimal, val maxOrderCount: Int) {
+class OrderBookLevel(var levelIx: Int, var side: BookSide, val price: BigDecimal, val maxOrderCount: Int) :
+    AVLTree.Node<OrderBookLevel>(id = levelIx) {
+
     val orders = Array(maxOrderCount) { _ ->
         LevelOrder(guid = 0L.toOrderGuid(), wallet = 0L.toWalletAddress(), quantity = BigInteger.ZERO, feeRate = FeeRate.zero, levelIx = levelIx)
     }

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/core/OrderBookLevels.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/core/OrderBookLevels.kt
@@ -1,0 +1,306 @@
+package co.chainring.sequencer.core
+
+import kotlin.random.Random
+import kotlin.system.measureNanoTime
+
+class MarketLevels {
+
+    data class TreeNode(
+        var value: OrderBookLevel,
+        var height: Int = 1,
+        var left: TreeNode? = null,
+        var right: TreeNode? = null,
+        var parent: TreeNode? = null,
+    ) {
+        fun next(): TreeNode? {
+            var current: TreeNode? = this
+            if (current?.right != null) {
+                current = current.right
+                while (current?.left != null) {
+                    current = current.left
+                }
+                return current
+            } else {
+                var parent = current?.parent
+                while (parent != null && current == parent.right) {
+                    current = parent
+                    parent = parent.parent
+                }
+                return parent
+            }
+        }
+
+        fun previous(): TreeNode? {
+            var current: TreeNode? = this
+            if (current?.left != null) {
+                current = current.left
+                while (current?.right != null) {
+                    current = current.right
+                }
+                return current
+            } else {
+                var parent = current?.parent
+                while (parent != null && current == parent.left) {
+                    current = parent
+                    parent = parent.parent
+                }
+                return parent
+            }
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is TreeNode) return false
+            return value == other.value
+        }
+
+        override fun hashCode(): Int {
+            return value.hashCode()
+        }
+
+        override fun toString(): String {
+            return "Node(levelIx=${value.levelIx}, levelIx=${value.price}, quantity=${value.totalQuantity}, height=$height)"
+        }
+    }
+
+    private var root: TreeNode? = null
+
+    fun add(value: OrderBookLevel): OrderBookLevel {
+        root = add(root, value)
+        return value
+    }
+
+    private fun add(treeNode: TreeNode?, value: OrderBookLevel): TreeNode {
+        if (treeNode == null) return TreeNode(value)
+
+        if (value.levelIx < treeNode.value.levelIx) {
+            treeNode.left = add(treeNode.left, value)
+            treeNode.left?.parent = treeNode
+        } else if (value.levelIx > treeNode.value.levelIx) {
+            treeNode.right = add(treeNode.right, value)
+            treeNode.right?.parent = treeNode
+        } else {
+            return treeNode
+        }
+
+        treeNode.height = 1 + maxOf(height(treeNode.left), height(treeNode.right))
+
+        return balance(treeNode)
+    }
+
+    fun get(levelIx: Int): OrderBookLevel? {
+        val node = getTreeNode(root, levelIx)
+        return node?.value
+    }
+
+    fun getTreeNode(levelIx: Int): TreeNode? {
+        return getTreeNode(root, levelIx)
+    }
+
+    private fun getTreeNode(treeNode: TreeNode?, levelIx: Int): TreeNode? {
+        if (treeNode == null || treeNode.value.levelIx == levelIx) return treeNode
+
+        return if (levelIx < treeNode.value.levelIx) {
+            getTreeNode(treeNode.left, levelIx)
+        } else {
+            getTreeNode(treeNode.right, levelIx)
+        }
+    }
+
+    fun remove(levelIx: Int) {
+        root = remove(root, levelIx)
+    }
+
+    private fun remove(treeNode: TreeNode?, levelIx: Int): TreeNode? {
+        if (treeNode == null) return treeNode
+
+        when {
+            levelIx < treeNode.value.levelIx -> {
+                treeNode.left = remove(treeNode.left, levelIx)
+            }
+            levelIx > treeNode.value.levelIx -> {
+                treeNode.right = remove(treeNode.right, levelIx)
+            }
+            else -> {
+                if (treeNode.left == null || treeNode.right == null) {
+                    val temp = treeNode.left ?: treeNode.right
+
+                    if (temp == null) {
+                        return null
+                    } else {
+                        temp.parent = treeNode.parent
+                        return temp
+                    }
+                }
+
+                val temp = minValueNode(treeNode.right!!)
+                treeNode.value = temp.value
+                treeNode.right = remove(treeNode.right, temp.value.levelIx)
+            }
+        }
+
+        treeNode.height = 1 + maxOf(height(treeNode.left), height(treeNode.right))
+
+        return balance(treeNode)
+    }
+
+    fun first(): TreeNode? {
+        var current = root ?: return null
+        while (current.left != null) {
+            current = current.left!!
+        }
+        return current
+    }
+
+    fun last(): TreeNode? {
+        var current = root ?: return null
+        while (current.right != null) {
+            current = current.right!!
+        }
+        return current
+    }
+
+    private fun height(treeNode: TreeNode?): Int {
+        return treeNode?.height ?: 0
+    }
+
+    private fun balance(treeNode: TreeNode): TreeNode {
+        val balance = getBalance(treeNode)
+
+        return when {
+            balance > 1 && getBalance(treeNode.left) >= 0 -> rightRotate(treeNode)
+            balance > 1 && getBalance(treeNode.left) < 0 -> {
+                treeNode.left = leftRotate(treeNode.left!!)
+                rightRotate(treeNode)
+            }
+            balance < -1 && getBalance(treeNode.right) <= 0 -> leftRotate(treeNode)
+            balance < -1 && getBalance(treeNode.right) > 0 -> {
+                treeNode.right = rightRotate(treeNode.right!!)
+                leftRotate(treeNode)
+            }
+            else -> treeNode
+        }
+    }
+
+    private fun getBalance(treeNode: TreeNode?): Int {
+        return if (treeNode == null) 0 else height(treeNode.left) - height(treeNode.right)
+    }
+
+    private fun rightRotate(y: TreeNode): TreeNode {
+        val x = y.left!!
+        val T2 = x.right
+
+        x.right = y
+        y.left = T2
+
+        y.height = maxOf(height(y.left), height(y.right)) + 1
+        x.height = maxOf(height(x.left), height(x.right)) + 1
+
+        x.parent = y.parent
+        y.parent = x
+        if (T2 != null) T2.parent = y
+
+        return x
+    }
+
+    private fun leftRotate(x: TreeNode): TreeNode {
+        val y = x.right!!
+        val T2 = y.left
+
+        y.left = x
+        x.right = T2
+
+        x.height = maxOf(height(x.left), height(x.right)) + 1
+        y.height = maxOf(height(y.left), height(y.right)) + 1
+
+        y.parent = x.parent
+        x.parent = y
+        if (T2 != null) T2.parent = x
+
+        return y
+    }
+
+    private fun minValueNode(treeNode: TreeNode): TreeNode {
+        var current = treeNode
+        while (current.left != null) {
+            current = current.left!!
+        }
+        return current
+    }
+
+    fun traverse(action: (OrderBookLevel) -> Unit) {
+        inorderTraversal(root, action)
+    }
+
+    private fun inorderTraversal(treeNode: TreeNode?, action: (OrderBookLevel) -> Unit) {
+        if (treeNode != null) {
+            inorderTraversal(treeNode.left, action)
+            action(treeNode.value)
+            inorderTraversal(treeNode.right, action)
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is MarketLevels) return false
+
+        var thisNode = this.first()
+        var otherNode = other.first()
+
+        while (thisNode != null && otherNode != null) {
+            if (thisNode.value != otherNode.value) return false
+            thisNode = thisNode.next()
+            otherNode = otherNode.next()
+        }
+
+        return thisNode == null && otherNode == null
+    }
+
+    override fun hashCode(): Int {
+        var result = 1
+        var node = first()
+
+        while (node != null) {
+            result = 31 * result + node.value.hashCode()
+            node = node.next()
+        }
+
+        return result
+    }
+}
+
+fun main() {
+    val tree = MarketLevels()
+
+    repeat(50) { i ->
+        measureNanoTime {
+            repeat(1000) { j ->
+                tree.add(OrderBookLevel(i * 1000 + j, side = BookSide.Sell, (i * 1000 + j).toBigDecimal(), 0))
+            }
+        }.also {
+            println("Adding 1000 entries took $it nanos")
+        }
+    }
+
+    repeat(50) { i ->
+        measureNanoTime {
+            repeat(1000) { j ->
+                tree.get(Random.nextInt())
+            }
+        }.also {
+            println("Getting 1000 entries took $it nanos")
+        }
+    }
+
+    /*repeat(100) { i ->
+        measureNanoTime {
+            (0 until 1000).forEach { j ->
+                tree.delete(i * j)
+            }
+        }.also {
+            println("Removing 1000 entries took $it nanos")
+        }
+    }*/
+
+    // skipList.dumpListState()
+}

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/core/datastructure/AVLTree.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/core/datastructure/AVLTree.kt
@@ -9,6 +9,7 @@ class AVLTree<T : AVLTree.Node<T>> {
         var right: T? = null,
         var parent: T? = null,
     ) {
+        @Suppress("UNCHECKED_CAST")
         fun next(): T? {
             var current: T? = this as T
             if (current?.right != null) {
@@ -27,6 +28,7 @@ class AVLTree<T : AVLTree.Node<T>> {
             }
         }
 
+        @Suppress("UNCHECKED_CAST")
         fun previous(): T? {
             var current: T? = this as T
             if (current?.left != null) {

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/core/datastructure/AVLTree.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/core/datastructure/AVLTree.kt
@@ -137,11 +137,11 @@ class AVLTree<T : AVLTree.Node<T>> {
                     successor.right?.parent = successor
                 }
 
-                // Connect the left child of the treeNode to the successor
+                // connect the left child of the treeNode to the successor
                 successor.left = parent.left
                 successor.left?.parent = successor
 
-                // Update the parent of the treeNode to point to the successor
+                // update the parent of the treeNode to point to the successor
                 successor.parent = parent.parent
                 if (parent.parent == null) {
                     root = successor
@@ -251,20 +251,14 @@ class AVLTree<T : AVLTree.Node<T>> {
     }
 
     fun traverse(action: (T) -> Unit) {
-        inorderTraversal(root, action)
+        traverse(root, action)
     }
 
-    fun toList(): List<T> {
-        val result = mutableListOf<T>()
-        traverse { result.add(it) }
-        return result
-    }
-
-    private fun inorderTraversal(parent: T?, action: (T) -> Unit) {
+    private fun traverse(parent: T?, action: (T) -> Unit) {
         if (parent != null) {
-            inorderTraversal(parent.left, action)
+            traverse(parent.left, action)
             action(parent)
-            inorderTraversal(parent.right, action)
+            traverse(parent.right, action)
         }
     }
 

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/core/datastructure/AVLTree.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/core/datastructure/AVLTree.kt
@@ -168,7 +168,6 @@ class AVLTree<T : AVLTree.Node<T>> {
 
     fun first(): T? = root?.let { minValueNode(it) }
 
-
     fun last(): T? {
         var current = root ?: return null
         while (current.right != null) {

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/core/datastructure/AVLTree.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/core/datastructure/AVLTree.kt
@@ -166,18 +166,21 @@ class AVLTree<T : AVLTree.Node<T>> {
         return balance(parent)
     }
 
-    fun first(): T? {
-        var current = root ?: return null
-        while (current.left != null) {
-            current = current.left!!
-        }
-        return current
-    }
+    fun first(): T? = root?.let { minValueNode(it) }
+
 
     fun last(): T? {
         var current = root ?: return null
         while (current.right != null) {
             current = current.right!!
+        }
+        return current
+    }
+
+    private fun minValueNode(parent: T): T {
+        var current = parent
+        while (current.left != null) {
+            current = current.left!!
         }
         return current
     }
@@ -242,14 +245,6 @@ class AVLTree<T : AVLTree.Node<T>> {
         return y
     }
 
-    private fun minValueNode(parent: T): T {
-        var current = parent
-        while (current.left != null) {
-            current = current.left!!
-        }
-        return current
-    }
-
     fun traverse(action: (T) -> Unit) {
         traverse(root, action)
     }
@@ -280,13 +275,7 @@ class AVLTree<T : AVLTree.Node<T>> {
 
     override fun hashCode(): Int {
         var result = 1
-        var node = first()
-
-        while (node != null) {
-            result = 31 * result + node.hashCode()
-            node = node.next()
-        }
-
+        traverse { result = 31 * result + it.hashCode() }
         return result
     }
 }

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/core/datastructure/AVLTree.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/core/datastructure/AVLTree.kt
@@ -29,7 +29,7 @@ class AVLTree<T : AVLTree.Node<T>> {
         }
 
         @Suppress("UNCHECKED_CAST")
-        fun previous(): T? {
+        fun prev(): T? {
             var current: T? = this as T
             if (current?.left != null) {
                 current = current.left

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/core/datastructure/ObjectPool.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/core/datastructure/ObjectPool.kt
@@ -1,0 +1,34 @@
+package co.chainring.sequencer.core.datastructure
+
+class ObjectPool<T>(
+    private val create: () -> T,
+    private val reset: (T) -> Unit,
+    initialSize: Int,
+) {
+    private var borrowedCount = 0
+    private val pool: MutableList<T> = ArrayList<T>(initialSize).apply {
+        repeat(initialSize) {
+            add(create())
+        }
+    }
+
+    fun borrow(init: ((T) -> T)? = null): T {
+        borrowedCount++
+        val obj = if (pool.isNotEmpty()) {
+            pool.removeAt(pool.size - 1)
+        } else {
+            create()
+        }
+        return init?.invoke(obj) ?: obj
+    }
+
+    fun release(obj: T) {
+        reset(obj)
+        pool.add(obj)
+        borrowedCount--
+    }
+
+    fun getBorrowedCount(): Int = borrowedCount
+
+    fun getPoolSize(): Int = pool.size
+}

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/core/datastructure/ObjectPool.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/core/datastructure/ObjectPool.kt
@@ -14,11 +14,7 @@ class ObjectPool<T>(
 
     fun borrow(init: ((T) -> T)? = null): T {
         borrowedCount++
-        val obj = if (pool.isNotEmpty()) {
-            pool.removeAt(pool.size - 1)
-        } else {
-            create()
-        }
+        val obj = pool.removeLastOrNull() ?: create()
         return init?.invoke(obj) ?: obj
     }
 

--- a/sequencer/src/test/kotlin/co/chainring/TestMarket.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestMarket.kt
@@ -22,8 +22,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class TestMarket {
-    private val tickSize = BigDecimal("0.05")
-
     private lateinit var market: Market
 
     @BeforeEach
@@ -40,215 +38,219 @@ class TestMarket {
         )
     }
 
+    private fun String.levelIx(market: Market): Int {
+        return (BigDecimal(this) - market.levels[0].price).divideToIntegralValue(market.tickSize).toInt()
+    }
+
     @Test
     fun testBidValues() {
-        validateBidAndOffer("0.050", -1, "50.000", -1)
+        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
 
         addOrder(1L, Order.Type.LimitBuy, "1", "17.500")
         addOrder(2L, Order.Type.LimitBuy, "1", "17.500")
         validateBid(
-            bestBid = "17.500",
-            minBidIx = (BigDecimal("17.500") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.500".levelIx(market),
+            minBidIx = "17.500".levelIx(market),
         )
 
         addOrder(3L, Order.Type.LimitBuy, "1", "17.450")
         addOrder(4L, Order.Type.LimitBuy, "1", "17.450")
         validateBid(
-            bestBid = "17.500",
-            minBidIx = (BigDecimal("17.450") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.500".levelIx(market),
+            minBidIx = "17.450".levelIx(market),
         )
 
         addOrder(5L, Order.Type.LimitBuy, "1", "17.400")
         addOrder(6L, Order.Type.LimitBuy, "1", "17.400")
         validateBid(
-            bestBid = "17.500",
-            minBidIx = (BigDecimal("17.400") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.500".levelIx(market),
+            minBidIx = "17.400".levelIx(market),
         )
 
         // cancel order 1, 3 and 5 - nothing should change
         cancelOrders(listOf(1L, 3L, 5L))
         validateBid(
-            bestBid = "17.500",
-            minBidIx = (BigDecimal("17.400") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.500".levelIx(market),
+            minBidIx = "17.400".levelIx(market),
         )
 
         // cancel order 2, bestBid should change
         cancelOrders(listOf(2L))
         validateBid(
-            bestBid = "17.450",
-            minBidIx = (BigDecimal("17.400") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.450".levelIx(market),
+            minBidIx = "17.400".levelIx(market),
         )
 
         // cancel order 6, minBidIx should change
         cancelOrders(listOf(6L))
         validateBid(
-            bestBid = "17.450",
-            minBidIx = (BigDecimal("17.450") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.450".levelIx(market),
+            minBidIx = "17.450".levelIx(market),
         )
 
         // cancel order 4, minBidIx and bestBid should be back at initial values
         cancelOrders(listOf(4L))
-        validateBidAndOffer("0.050", -1, "50.000", -1)
+        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
     }
 
     @Test
     fun testOfferValues() {
-        validateBidAndOffer("0.050", -1, "50.000", -1)
+        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
 
         addOrder(1L, Order.Type.LimitSell, "1", "17.550")
         addOrder(2L, Order.Type.LimitSell, "1", "17.550")
         validateOffer(
-            bestOffer = "17.550",
-            maxOfferIx = (BigDecimal("17.550") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestOfferIx = "17.550".levelIx(market),
+            maxOfferIx = "17.550".levelIx(market),
         )
 
         addOrder(3L, Order.Type.LimitSell, "1", "17.600")
         addOrder(4L, Order.Type.LimitSell, "1", "17.600")
         validateOffer(
-            bestOffer = "17.550",
-            maxOfferIx = (BigDecimal("17.600") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestOfferIx = "17.550".levelIx(market),
+            maxOfferIx = "17.600".levelIx(market),
         )
 
         addOrder(5L, Order.Type.LimitSell, "1", "17.700")
         addOrder(6L, Order.Type.LimitSell, "1", "17.700")
         validateOffer(
-            bestOffer = "17.550",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestOfferIx = "17.550".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // cancel order 1, 3 and 5 - nothing should change
         cancelOrders(listOf(1L, 3L, 5L))
         validateOffer(
-            bestOffer = "17.550",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestOfferIx = "17.550".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // cancel order 2, bestOffer should change
         cancelOrders(listOf(2L))
         validateOffer(
-            bestOffer = "17.600",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestOfferIx = "17.600".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // cancel order 6, maxOfferIx should change
         cancelOrders(listOf(6L))
         validateOffer(
-            bestOffer = "17.600",
-            maxOfferIx = (BigDecimal("17.600") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestOfferIx = "17.600".levelIx(market),
+            maxOfferIx = "17.600".levelIx(market),
         )
 
         // cancel order 4, should be back at initial values
         cancelOrders(listOf(4L))
-        validateBidAndOffer("0.050", -1, "50.000", -1)
+        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
     }
 
     @Test
     fun testOrderMatching() {
-        validateBidAndOffer("0.050", -1, "50.000", -1)
+        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
 
         addOrder(1L, Order.Type.LimitBuy, "5", "17.300")
         addOrder(2L, Order.Type.LimitBuy, "5", "17.500")
         addOrder(3L, Order.Type.LimitSell, "5", "17.550")
         addOrder(4L, Order.Type.LimitSell, "5", "17.700")
         validateBidAndOffer(
-            bestBid = "17.500",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.550",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.500".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.550".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // market sell - no levels exhausted
         addOrder(5L, Order.Type.MarketSell, "3", "0", OrderDisposition.Filled, counterOrderGuid = 2L)
         validateBidAndOffer(
-            bestBid = "17.500",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.550",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.500".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.550".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // market sell - level with best bid exhausted - should go to the next level with orders
         addOrder(6L, Order.Type.MarketSell, "2", "0", OrderDisposition.Filled, counterOrderGuid = 2L)
         validateBidAndOffer(
-            bestBid = "17.300",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.550",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.300".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.550".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // market buy - no levels exhausted
         addOrder(7L, Order.Type.MarketBuy, "3", "0", OrderDisposition.Filled, counterOrderGuid = 3L)
         validateBidAndOffer(
-            bestBid = "17.300",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.550",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.300".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.550".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // market buy - best offer exhausted - should go to the next level with orders
         addOrder(8L, Order.Type.MarketBuy, "2", "0", OrderDisposition.Filled, counterOrderGuid = 3L)
         validateBidAndOffer(
-            bestBid = "17.300",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.700",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.300".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.700".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // exhaust levels - should go back to initial values
         addOrder(9L, Order.Type.MarketSell, "5", "0", OrderDisposition.Filled, counterOrderGuid = 1L)
         addOrder(10L, Order.Type.MarketBuy, "5", "0", OrderDisposition.Filled, counterOrderGuid = 4L)
 
-        validateBidAndOffer("0.050", -1, "50.000", -1)
+        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
     }
 
     @Test
     fun testCrossingLimitSellOrders() {
-        validateBidAndOffer("0.050", -1, "50.000", -1)
+        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
 
         addOrder(1L, Order.Type.LimitBuy, "5", "17.300")
         addOrder(2L, Order.Type.LimitBuy, "5", "17.500")
         addOrder(3L, Order.Type.LimitSell, "5", "17.550")
         addOrder(4L, Order.Type.LimitSell, "5", "17.700")
         validateBidAndOffer(
-            bestBid = "17.500",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.550",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.500".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.550".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // limit sell that crosses - bestBid should be adjusted to next level
         addOrder(5L, Order.Type.LimitSell, "7", "17.450", OrderDisposition.PartiallyFilled, counterOrderGuid = 2L)
         validateBidAndOffer(
-            bestBid = "17.300",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.450",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.300".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.450".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // next market sell should match against limit buy
         addOrder(6L, Order.Type.MarketSell, "1", "0", OrderDisposition.Filled, counterOrderGuid = 1L)
         validateBidAndOffer(
-            bestBid = "17.300",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.450",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.300".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.450".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // next market buy should match against limit sell that crossed and bestOffer should change since we consumed that level
         addOrder(7L, Order.Type.MarketBuy, "2", "0", OrderDisposition.Filled, counterOrderGuid = 5L)
         validateBidAndOffer(
-            bestBid = "17.300",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.550",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.300".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.550".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // submit limit sell that crosses and exhausts all the buys, bidIx and bestBid should go back to initial values
         addOrder(8L, Order.Type.LimitSell, "6", "17.250", OrderDisposition.PartiallyFilled, counterOrderGuid = 1L)
         validateBidAndOffer(
-            bestBid = "0.050",
+            bestBidIx = "0.050".levelIx(market),
             minBidIx = -1,
-            bestOffer = "17.250",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestOfferIx = "17.250".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // market sell should be rejected since no buys
@@ -257,129 +259,129 @@ class TestMarket {
 
     @Test
     fun testCrossingEdgeCases() {
-        validateBidAndOffer("0.050", -1, "50.000", -1)
+        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
 
         addOrder(1L, Order.Type.LimitSell, "5", "50.000")
         addOrder(2L, Order.Type.LimitBuy, "5", "0.050")
 
         validateBidAndOffer(
-            bestBid = "0.050",
+            bestBidIx = "0.050".levelIx(market),
             minBidIx = 0,
-            bestOffer = "50.000",
+            bestOfferIx = "50.000".levelIx(market),
             maxOfferIx = 999,
         )
 
         // limit buy that exactly consumes all of resting sell
         addOrder(3L, Order.Type.LimitBuy, "5", "50.000", OrderDisposition.Filled, counterOrderGuid = 1L)
         validateBidAndOffer(
-            bestBid = "0.050",
+            bestBidIx = "0.050".levelIx(market),
             minBidIx = 0,
-            bestOffer = "50.000",
+            bestOfferIx = "50.000".levelIx(market),
             maxOfferIx = -1,
         )
 
         // put the LimitSell back
         addOrder(4L, Order.Type.LimitSell, "5", "50.000")
         validateBidAndOffer(
-            bestBid = "0.050",
+            bestBidIx = "0.050".levelIx(market),
             minBidIx = 0,
-            bestOffer = "50.000",
+            bestOfferIx = "50.000".levelIx(market),
             maxOfferIx = 999,
         )
 
         // LimitBuy that consumes all of resting sell and stays on the book
         addOrder(5L, Order.Type.LimitBuy, "6", "50.000", OrderDisposition.PartiallyFilled, counterOrderGuid = 4L)
         validateBidAndOffer(
-            bestBid = "50.000",
+            bestBidIx = "50.000".levelIx(market),
             minBidIx = 0,
-            bestOffer = "50.000",
+            bestOfferIx = "50.000".levelIx(market),
             maxOfferIx = -1,
         )
         // cancel that Limit Buy
         cancelOrders(listOf(5L))
         validateBidAndOffer(
-            bestBid = "0.050",
+            bestBidIx = "0.050".levelIx(market),
             minBidIx = 0,
-            bestOffer = "50.000",
+            bestOfferIx = "50.000".levelIx(market),
             maxOfferIx = -1,
         )
 
         // add a LimitSell that exactly consumes resting buy
         addOrder(6L, Order.Type.LimitSell, "5", "0.050", OrderDisposition.Filled, counterOrderGuid = 2L)
         validateBidAndOffer(
-            bestBid = "0.050",
+            bestBidIx = "0.050".levelIx(market),
             minBidIx = -1,
-            bestOffer = "50.000",
+            bestOfferIx = "50.000".levelIx(market),
             maxOfferIx = -1,
         )
 
         // put a LimitBuy back at the edge
         addOrder(7L, Order.Type.LimitBuy, "5", "0.050")
         validateBidAndOffer(
-            bestBid = "0.050",
+            bestBidIx = "0.050".levelIx(market),
             minBidIx = 0,
-            bestOffer = "50.000",
+            bestOfferIx = "50.000".levelIx(market),
             maxOfferIx = -1,
         )
 
         // LimitSell that consumes all of resting buy and stays on the book
         addOrder(8L, Order.Type.LimitSell, "6", "0.050", OrderDisposition.PartiallyFilled, counterOrderGuid = 7L)
         validateBidAndOffer(
-            bestBid = "0.050",
+            bestBidIx = "0.050".levelIx(market),
             minBidIx = -1,
-            bestOffer = "0.050",
+            bestOfferIx = "0.050".levelIx(market),
             maxOfferIx = 0,
         )
     }
 
     @Test
     fun testCrossingLimitBuyOrders() {
-        validateBidAndOffer("0.050", -1, "50.000", -1)
+        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
 
         addOrder(1L, Order.Type.LimitBuy, "5", "17.300")
         addOrder(2L, Order.Type.LimitBuy, "5", "17.500")
         addOrder(3L, Order.Type.LimitSell, "5", "17.550")
         addOrder(4L, Order.Type.LimitSell, "5", "17.700")
         validateBidAndOffer(
-            bestBid = "17.500",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.550",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.500".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.550".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // limit buy that crosses - best Bid and Offer should adjust
         addOrder(5L, Order.Type.LimitBuy, "7", "17.600", OrderDisposition.PartiallyFilled, counterOrderGuid = 3L)
         validateBidAndOffer(
-            bestBid = "17.600",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.700",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.600".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.700".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // next market buy should match against limit sell
         addOrder(6L, Order.Type.MarketBuy, "1", "0", OrderDisposition.Filled, counterOrderGuid = 4L)
         validateBidAndOffer(
-            bestBid = "17.600",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.700",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.600".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.700".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // next market sell should match against limit buy that crossed and bestBid should change since we consumed that level
         addOrder(7L, Order.Type.MarketSell, "2", "0", OrderDisposition.Filled, counterOrderGuid = 5L)
         validateBidAndOffer(
-            bestBid = "17.500",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.700",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.500".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.700".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // submit limit buy that crosses and exhausts all the sells, bestOffer and minOfferIx should go back to initial values
         addOrder(8L, Order.Type.LimitBuy, "6", "17.700", OrderDisposition.PartiallyFilled, counterOrderGuid = 4L)
         validateBidAndOffer(
-            bestBid = "17.700",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "50.000",
+            bestBidIx = "17.700".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "50.000".levelIx(market),
             maxOfferIx = -1,
         )
 
@@ -389,87 +391,87 @@ class TestMarket {
 
     @Test
     fun testUpdateOrderCrossingLimitSellOrders() {
-        validateBidAndOffer("0.050", -1, "50.000", -1)
+        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
 
         addOrder(1L, Order.Type.LimitBuy, "5", "17.300")
         addOrder(2L, Order.Type.LimitBuy, "5", "17.500")
         addOrder(3L, Order.Type.LimitSell, "5", "17.550")
         addOrder(4L, Order.Type.LimitSell, "5", "17.700")
         validateBidAndOffer(
-            bestBid = "17.500",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.550",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.500".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.550".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // update limit sell that crosses - fully filled
         updateOrder(3L, Order.Type.LimitSell, "5", "17.450", OrderDisposition.Filled, counterOrderGuid = 2L)
         validateBidAndOffer(
-            bestBid = "17.300",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.700",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.300".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.700".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // add back similar orders
         addOrder(5L, Order.Type.LimitBuy, "5", "17.500")
         addOrder(6L, Order.Type.LimitSell, "5", "17.550")
         validateBidAndOffer(
-            bestBid = "17.500",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.550",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.500".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.550".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
         // update limit sell that crosses - partially filled
         updateOrder(6L, Order.Type.LimitSell, "7", "17.450", OrderDisposition.PartiallyFilled, counterOrderGuid = 5L)
         validateBidAndOffer(
-            bestBid = "17.300",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.450",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.300".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.450".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
     }
 
     @Test
     fun testUpdateOrderCrossingLimitBuyOrders() {
-        validateBidAndOffer("0.050", -1, "50.000", -1)
+        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
 
         addOrder(1L, Order.Type.LimitBuy, "5", "17.300")
         addOrder(2L, Order.Type.LimitBuy, "5", "17.500")
         addOrder(3L, Order.Type.LimitSell, "5", "17.550")
         addOrder(4L, Order.Type.LimitSell, "5", "17.700")
         validateBidAndOffer(
-            bestBid = "17.500",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.550",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.500".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.550".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // update limit buy that crosses - fully filled
         updateOrder(2L, Order.Type.LimitBuy, "5", "17.550", OrderDisposition.Filled, counterOrderGuid = 3L)
         validateBidAndOffer(
-            bestBid = "17.300",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.700",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.300".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.700".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
 
         // add back similar orders
         addOrder(5L, Order.Type.LimitBuy, "5", "17.500")
         addOrder(6L, Order.Type.LimitSell, "5", "17.550")
         validateBidAndOffer(
-            bestBid = "17.500",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.550",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.500".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.550".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
         // update limit sell that crosses - partially filled
         updateOrder(5L, Order.Type.LimitBuy, "7", "17.550", OrderDisposition.PartiallyFilled, counterOrderGuid = 6L)
         validateBidAndOffer(
-            bestBid = "17.550",
-            minBidIx = (BigDecimal("17.300") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
-            bestOffer = "17.700",
-            maxOfferIx = (BigDecimal("17.700") - BigDecimal("0.050")).divideToIntegralValue(tickSize).toInt(),
+            bestBidIx = "17.550".levelIx(market),
+            minBidIx = "17.300".levelIx(market),
+            bestOfferIx = "17.700".levelIx(market),
+            maxOfferIx = "17.700".levelIx(market),
         )
     }
 
@@ -681,18 +683,18 @@ class TestMarket {
         )
     }
 
-    private fun validateBidAndOffer(bestBid: String, minBidIx: Int, bestOffer: String, maxOfferIx: Int) {
-        validateBid(bestBid, minBidIx)
-        validateOffer(bestOffer, maxOfferIx)
+    private fun validateBidAndOffer(bestBidIx: Int, minBidIx: Int, bestOfferIx: Int, maxOfferIx: Int) {
+        validateBid(bestBidIx, minBidIx)
+        validateOffer(bestOfferIx, maxOfferIx)
     }
 
-    private fun validateBid(bestBid: String, minBidIx: Int) {
-        assertEquals(market.bestBid, BigDecimal(bestBid))
-        assertEquals(market.retrieveMinBidIx(), minBidIx)
+    private fun validateBid(bestBidIx: Int, minBidIx: Int) {
+        assertEquals(market.bestBidIx, bestBidIx)
+        assertEquals(market.minBidIx, minBidIx)
     }
 
-    private fun validateOffer(bestOffer: String, maxOfferIx: Int) {
-        assertEquals(market.bestOffer, BigDecimal(bestOffer))
-        assertEquals(market.retrieveMaxOfferIx(), maxOfferIx)
+    private fun validateOffer(bestOfferIx: Int, maxOfferIx: Int) {
+        assertEquals(market.bestOfferIx, bestOfferIx)
+        assertEquals(market.maxOfferIx, maxOfferIx)
     }
 }

--- a/sequencer/src/test/kotlin/co/chainring/TestMarket.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestMarket.kt
@@ -39,7 +39,7 @@ class TestMarket {
     }
 
     private fun String.levelIx(market: Market): Int {
-        return (BigDecimal(this) - market.levels[0].price).divideToIntegralValue(market.tickSize).toInt()
+        return BigDecimal(this).divideToIntegralValue(market.tickSize).toInt()
     }
 
     @Test
@@ -153,19 +153,19 @@ class TestMarket {
         addOrder(3L, Order.Type.LimitSell, "5", "17.550")
         addOrder(4L, Order.Type.LimitSell, "5", "17.700")
         validateBidAndOffer(
+            maxOfferIx = "17.700".levelIx(market),
+            bestOfferIx = "17.550".levelIx(market),
             bestBidIx = "17.500".levelIx(market),
             minBidIx = "17.300".levelIx(market),
-            bestOfferIx = "17.550".levelIx(market),
-            maxOfferIx = "17.700".levelIx(market),
         )
 
         // market sell - no levels exhausted
         addOrder(5L, Order.Type.MarketSell, "3", "0", OrderDisposition.Filled, counterOrderGuid = 2L)
         validateBidAndOffer(
+            maxOfferIx = "17.700".levelIx(market),
+            bestOfferIx = "17.550".levelIx(market),
             bestBidIx = "17.500".levelIx(market),
             minBidIx = "17.300".levelIx(market),
-            bestOfferIx = "17.550".levelIx(market),
-            maxOfferIx = "17.700".levelIx(market),
         )
 
         // market sell - level with best bid exhausted - should go to the next level with orders
@@ -266,9 +266,9 @@ class TestMarket {
 
         validateBidAndOffer(
             bestBidIx = "0.050".levelIx(market),
-            minBidIx = 0,
+            minBidIx = "0.050".levelIx(market),
             bestOfferIx = "50.000".levelIx(market),
-            maxOfferIx = 999,
+            maxOfferIx = "50.000".levelIx(market),
         )
 
         // limit buy that exactly consumes all of resting sell

--- a/sequencer/src/test/kotlin/co/chainring/TestMarket.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestMarket.kt
@@ -29,8 +29,6 @@ class TestMarket {
         market = Market(
             id = MarketId("BTC/ETH"),
             tickSize = BigDecimal("0.05"),
-            initialMarketPrice = BigDecimal("17.525"),
-            maxLevels = 1000,
             maxOrdersPerLevel = 100,
             baseDecimals = 18,
             quoteDecimals = 18,
@@ -561,8 +559,6 @@ class TestMarket {
         market = Market(
             id = MarketId("BTC/USDC"),
             tickSize = BigDecimal("10"),
-            initialMarketPrice = BigDecimal("69005"),
-            maxLevels = 1000,
             maxOrdersPerLevel = 100,
             baseDecimals = 18,
             quoteDecimals = 6,
@@ -613,8 +609,6 @@ class TestMarket {
         market = Market(
             id = MarketId("BTC/USDC"),
             tickSize = BigDecimal("10"),
-            initialMarketPrice = BigDecimal("69005"),
-            maxLevels = 1000,
             maxOrdersPerLevel = 100,
             baseDecimals = 8,
             quoteDecimals = 6,

--- a/sequencer/src/test/kotlin/co/chainring/TestMarket.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestMarket.kt
@@ -493,11 +493,11 @@ class TestMarket {
         )
         if (response.createdTrades.isNotEmpty()) {
             if (orderType == Order.Type.MarketSell || orderType == Order.Type.LimitSell) {
-                assertEquals(response.createdTrades.first().sellOrderGuid, guid)
-                assertEquals(response.createdTrades.first().buyOrderGuid, counterOrderGuid)
+                assertEquals(guid, response.createdTrades.first().sellOrderGuid)
+                assertEquals(counterOrderGuid, response.createdTrades.first().buyOrderGuid)
             } else {
-                assertEquals(response.createdTrades.first().buyOrderGuid, guid)
-                assertEquals(response.createdTrades.first().sellOrderGuid, counterOrderGuid)
+                assertEquals(guid, response.createdTrades.first().buyOrderGuid)
+                assertEquals(counterOrderGuid, response.createdTrades.first().sellOrderGuid)
             }
         }
         assertEquals(

--- a/sequencer/src/test/kotlin/co/chainring/TestMarket.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestMarket.kt
@@ -6,7 +6,6 @@ import co.chainring.sequencer.core.Market
 import co.chainring.sequencer.core.MarketId
 import co.chainring.sequencer.core.WalletAddress
 import co.chainring.sequencer.core.notionalPlusFee
-import co.chainring.sequencer.core.toDecimalValue
 import co.chainring.sequencer.core.toIntegerValue
 import co.chainring.sequencer.proto.Order
 import co.chainring.sequencer.proto.OrderDisposition
@@ -46,42 +45,54 @@ class TestMarket {
 
         addOrder(1L, Order.Type.LimitBuy, "1", "17.500")
         addOrder(2L, Order.Type.LimitBuy, "1", "17.500")
-        validateBid(
+        validateBidAndOffer(
+            maxOfferIx = -1,
+            bestOfferIx = -1,
             bestBidIx = "17.500".levelIx(market),
             minBidIx = "17.500".levelIx(market),
         )
 
         addOrder(3L, Order.Type.LimitBuy, "1", "17.450")
         addOrder(4L, Order.Type.LimitBuy, "1", "17.450")
-        validateBid(
+        validateBidAndOffer(
+            maxOfferIx = -1,
+            bestOfferIx = -1,
             bestBidIx = "17.500".levelIx(market),
             minBidIx = "17.450".levelIx(market),
         )
 
         addOrder(5L, Order.Type.LimitBuy, "1", "17.400")
         addOrder(6L, Order.Type.LimitBuy, "1", "17.400")
-        validateBid(
+        validateBidAndOffer(
+            maxOfferIx = -1,
+            bestOfferIx = -1,
             bestBidIx = "17.500".levelIx(market),
             minBidIx = "17.400".levelIx(market),
         )
 
         // cancel order 1, 3 and 5 - nothing should change
         cancelOrders(listOf(1L, 3L, 5L))
-        validateBid(
+        validateBidAndOffer(
+            maxOfferIx = -1,
+            bestOfferIx = -1,
             bestBidIx = "17.500".levelIx(market),
             minBidIx = "17.400".levelIx(market),
         )
 
         // cancel order 2, bestBid should change
         cancelOrders(listOf(2L))
-        validateBid(
+        validateBidAndOffer(
+            maxOfferIx = -1,
+            bestOfferIx = -1,
             bestBidIx = "17.450".levelIx(market),
             minBidIx = "17.400".levelIx(market),
         )
 
         // cancel order 6, minBidIx should change
         cancelOrders(listOf(6L))
-        validateBid(
+        validateBidAndOffer(
+            maxOfferIx = -1,
+            bestOfferIx = -1,
             bestBidIx = "17.450".levelIx(market),
             minBidIx = "17.450".levelIx(market),
         )
@@ -97,44 +108,56 @@ class TestMarket {
 
         addOrder(1L, Order.Type.LimitSell, "1", "17.550")
         addOrder(2L, Order.Type.LimitSell, "1", "17.550")
-        validateOffer(
-            bestOfferIx = "17.550".levelIx(market),
+        validateBidAndOffer(
             maxOfferIx = "17.550".levelIx(market),
+            bestOfferIx = "17.550".levelIx(market),
+            bestBidIx = -1,
+            minBidIx = -1,
         )
 
         addOrder(3L, Order.Type.LimitSell, "1", "17.600")
         addOrder(4L, Order.Type.LimitSell, "1", "17.600")
-        validateOffer(
+        validateBidAndOffer(
             bestOfferIx = "17.550".levelIx(market),
             maxOfferIx = "17.600".levelIx(market),
+            bestBidIx = -1,
+            minBidIx = -1,
         )
 
         addOrder(5L, Order.Type.LimitSell, "1", "17.700")
         addOrder(6L, Order.Type.LimitSell, "1", "17.700")
-        validateOffer(
+        validateBidAndOffer(
             bestOfferIx = "17.550".levelIx(market),
             maxOfferIx = "17.700".levelIx(market),
+            bestBidIx = -1,
+            minBidIx = -1,
         )
 
         // cancel order 1, 3 and 5 - nothing should change
         cancelOrders(listOf(1L, 3L, 5L))
-        validateOffer(
+        validateBidAndOffer(
             bestOfferIx = "17.550".levelIx(market),
             maxOfferIx = "17.700".levelIx(market),
+            bestBidIx = -1,
+            minBidIx = -1,
         )
 
         // cancel order 2, bestOffer should change
         cancelOrders(listOf(2L))
-        validateOffer(
+        validateBidAndOffer(
             bestOfferIx = "17.600".levelIx(market),
             maxOfferIx = "17.700".levelIx(market),
+            bestBidIx = -1,
+            minBidIx = -1,
         )
 
         // cancel order 6, maxOfferIx should change
         cancelOrders(listOf(6L))
-        validateOffer(
+        validateBidAndOffer(
             bestOfferIx = "17.600".levelIx(market),
             maxOfferIx = "17.600".levelIx(market),
+            bestBidIx = -1,
+            minBidIx = -1,
         )
 
         // cancel order 4, should be back at initial values
@@ -483,7 +506,7 @@ class TestMarket {
                         this.guid = guid
                         this.type = orderType
                         this.amount = BigInteger(amount).toIntegerValue()
-                        this.price = BigDecimal(price).toDecimalValue()
+                        this.levelIx = price.levelIx(market)
                     },
                 )
             },
@@ -636,7 +659,7 @@ class TestMarket {
                         this.guid = guid
                         this.type = orderType
                         this.amount = BigInteger(amount).toIntegerValue()
-                        this.price = BigDecimal(price).toDecimalValue()
+                        this.levelIx = price.levelIx(market)
                     },
                 )
             },

--- a/sequencer/src/test/kotlin/co/chainring/TestMarket.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestMarket.kt
@@ -44,7 +44,7 @@ class TestMarket {
 
     @Test
     fun testBidValues() {
-        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
+        validateBidAndOffer(-1, -1, -1, -1)
 
         addOrder(1L, Order.Type.LimitBuy, "1", "17.500")
         addOrder(2L, Order.Type.LimitBuy, "1", "17.500")
@@ -90,12 +90,12 @@ class TestMarket {
 
         // cancel order 4, minBidIx and bestBid should be back at initial values
         cancelOrders(listOf(4L))
-        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
+        validateBidAndOffer(-1, -1, -1, -1)
     }
 
     @Test
     fun testOfferValues() {
-        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
+        validateBidAndOffer(-1, -1, -1, -1)
 
         addOrder(1L, Order.Type.LimitSell, "1", "17.550")
         addOrder(2L, Order.Type.LimitSell, "1", "17.550")
@@ -141,12 +141,12 @@ class TestMarket {
 
         // cancel order 4, should be back at initial values
         cancelOrders(listOf(4L))
-        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
+        validateBidAndOffer(-1, -1, -1, -1)
     }
 
     @Test
     fun testOrderMatching() {
-        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
+        validateBidAndOffer(-1, -1, -1, -1)
 
         addOrder(1L, Order.Type.LimitBuy, "5", "17.300")
         addOrder(2L, Order.Type.LimitBuy, "5", "17.500")
@@ -199,12 +199,12 @@ class TestMarket {
         addOrder(9L, Order.Type.MarketSell, "5", "0", OrderDisposition.Filled, counterOrderGuid = 1L)
         addOrder(10L, Order.Type.MarketBuy, "5", "0", OrderDisposition.Filled, counterOrderGuid = 4L)
 
-        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
+        validateBidAndOffer(-1, -1, -1, -1)
     }
 
     @Test
     fun testCrossingLimitSellOrders() {
-        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
+        validateBidAndOffer(-1, -1, -1, -1)
 
         addOrder(1L, Order.Type.LimitBuy, "5", "17.300")
         addOrder(2L, Order.Type.LimitBuy, "5", "17.500")
@@ -247,7 +247,7 @@ class TestMarket {
         // submit limit sell that crosses and exhausts all the buys, bidIx and bestBid should go back to initial values
         addOrder(8L, Order.Type.LimitSell, "6", "17.250", OrderDisposition.PartiallyFilled, counterOrderGuid = 1L)
         validateBidAndOffer(
-            bestBidIx = "0.050".levelIx(market),
+            bestBidIx = -1,
             minBidIx = -1,
             bestOfferIx = "17.250".levelIx(market),
             maxOfferIx = "17.700".levelIx(market),
@@ -259,7 +259,7 @@ class TestMarket {
 
     @Test
     fun testCrossingEdgeCases() {
-        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
+        validateBidAndOffer(-1, -1, -1, -1)
 
         addOrder(1L, Order.Type.LimitSell, "5", "50.000")
         addOrder(2L, Order.Type.LimitBuy, "5", "0.050")
@@ -275,8 +275,8 @@ class TestMarket {
         addOrder(3L, Order.Type.LimitBuy, "5", "50.000", OrderDisposition.Filled, counterOrderGuid = 1L)
         validateBidAndOffer(
             bestBidIx = "0.050".levelIx(market),
-            minBidIx = 0,
-            bestOfferIx = "50.000".levelIx(market),
+            minBidIx = "0.050".levelIx(market),
+            bestOfferIx = -1,
             maxOfferIx = -1,
         )
 
@@ -284,34 +284,34 @@ class TestMarket {
         addOrder(4L, Order.Type.LimitSell, "5", "50.000")
         validateBidAndOffer(
             bestBidIx = "0.050".levelIx(market),
-            minBidIx = 0,
+            minBidIx = "0.050".levelIx(market),
             bestOfferIx = "50.000".levelIx(market),
-            maxOfferIx = 999,
+            maxOfferIx = "50.000".levelIx(market),
         )
 
         // LimitBuy that consumes all of resting sell and stays on the book
         addOrder(5L, Order.Type.LimitBuy, "6", "50.000", OrderDisposition.PartiallyFilled, counterOrderGuid = 4L)
         validateBidAndOffer(
             bestBidIx = "50.000".levelIx(market),
-            minBidIx = 0,
-            bestOfferIx = "50.000".levelIx(market),
+            minBidIx = "0.050".levelIx(market),
+            bestOfferIx = -1,
             maxOfferIx = -1,
         )
         // cancel that Limit Buy
         cancelOrders(listOf(5L))
         validateBidAndOffer(
             bestBidIx = "0.050".levelIx(market),
-            minBidIx = 0,
-            bestOfferIx = "50.000".levelIx(market),
+            minBidIx = "0.050".levelIx(market),
+            bestOfferIx = -1,
             maxOfferIx = -1,
         )
 
         // add a LimitSell that exactly consumes resting buy
         addOrder(6L, Order.Type.LimitSell, "5", "0.050", OrderDisposition.Filled, counterOrderGuid = 2L)
         validateBidAndOffer(
-            bestBidIx = "0.050".levelIx(market),
+            bestBidIx = -1,
             minBidIx = -1,
-            bestOfferIx = "50.000".levelIx(market),
+            bestOfferIx = -1,
             maxOfferIx = -1,
         )
 
@@ -319,24 +319,24 @@ class TestMarket {
         addOrder(7L, Order.Type.LimitBuy, "5", "0.050")
         validateBidAndOffer(
             bestBidIx = "0.050".levelIx(market),
-            minBidIx = 0,
-            bestOfferIx = "50.000".levelIx(market),
+            minBidIx = "0.050".levelIx(market),
+            bestOfferIx = -1,
             maxOfferIx = -1,
         )
 
         // LimitSell that consumes all of resting buy and stays on the book
         addOrder(8L, Order.Type.LimitSell, "6", "0.050", OrderDisposition.PartiallyFilled, counterOrderGuid = 7L)
         validateBidAndOffer(
-            bestBidIx = "0.050".levelIx(market),
+            bestBidIx = -1,
             minBidIx = -1,
             bestOfferIx = "0.050".levelIx(market),
-            maxOfferIx = 0,
+            maxOfferIx = "0.050".levelIx(market),
         )
     }
 
     @Test
     fun testCrossingLimitBuyOrders() {
-        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
+        validateBidAndOffer(-1, -1, -1, -1)
 
         addOrder(1L, Order.Type.LimitBuy, "5", "17.300")
         addOrder(2L, Order.Type.LimitBuy, "5", "17.500")
@@ -381,7 +381,7 @@ class TestMarket {
         validateBidAndOffer(
             bestBidIx = "17.700".levelIx(market),
             minBidIx = "17.300".levelIx(market),
-            bestOfferIx = "50.000".levelIx(market),
+            bestOfferIx = -1,
             maxOfferIx = -1,
         )
 
@@ -391,7 +391,7 @@ class TestMarket {
 
     @Test
     fun testUpdateOrderCrossingLimitSellOrders() {
-        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
+        validateBidAndOffer(-1, -1, -1, -1)
 
         addOrder(1L, Order.Type.LimitBuy, "5", "17.300")
         addOrder(2L, Order.Type.LimitBuy, "5", "17.500")
@@ -434,7 +434,7 @@ class TestMarket {
 
     @Test
     fun testUpdateOrderCrossingLimitBuyOrders() {
-        validateBidAndOffer("0.050".levelIx(market), -1, "50.000".levelIx(market), -1)
+        validateBidAndOffer(-1, -1, -1, -1)
 
         addOrder(1L, Order.Type.LimitBuy, "5", "17.300")
         addOrder(2L, Order.Type.LimitBuy, "5", "17.500")
@@ -689,12 +689,12 @@ class TestMarket {
     }
 
     private fun validateBid(bestBidIx: Int, minBidIx: Int) {
-        assertEquals(market.bestBidIx, bestBidIx)
-        assertEquals(market.minBidIx, minBidIx)
+        assertEquals(bestBidIx, market.bestBidIx)
+        assertEquals(minBidIx, market.minBidIx)
     }
 
     private fun validateOffer(bestOfferIx: Int, maxOfferIx: Int) {
-        assertEquals(market.bestOfferIx, bestOfferIx)
-        assertEquals(market.maxOfferIx, maxOfferIx)
+        assertEquals(bestOfferIx, market.bestOfferIx)
+        assertEquals(maxOfferIx, market.maxOfferIx)
     }
 }

--- a/sequencer/src/test/kotlin/co/chainring/TestObjectPool.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestObjectPool.kt
@@ -1,0 +1,126 @@
+package co.chainring
+
+import co.chainring.sequencer.core.datastructure.ObjectPool
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+class TestObjectPool {
+
+    data class TestObject(var value: Int)
+
+    @Test
+    fun testBorrowAndReturn() {
+        val pool = ObjectPool(
+            create = { TestObject(Int.MIN_VALUE) },
+            reset = { it.value = Int.MIN_VALUE },
+            initialSize = 100
+        )
+        assertEquals(100, pool.getPoolSize())
+        assertEquals(0, pool.getBorrowedCount())
+
+        // borrow object
+        val obj1 = pool.borrow(init = { it.also { it.value = Random.nextInt(0, Int.MAX_VALUE) } })
+        assertEquals(99, pool.getPoolSize())
+        assertEquals(1, pool.getBorrowedCount())
+
+        // borrow all
+        val allOther = (1 until 100).map { pool.borrow(init = { it.also { it.value = Random.nextInt(0, Int.MAX_VALUE) } }) }
+        assertEquals(0, pool.getPoolSize())
+        assertEquals(100, pool.getBorrowedCount())
+
+        // release object
+        pool.release(obj1)
+        assertEquals(1, pool.getPoolSize())
+        assertEquals(99, pool.getBorrowedCount())
+
+        // release all
+        allOther.forEach { pool.release(it) }
+        assertEquals(100, pool.getPoolSize())
+        assertEquals(0, pool.getBorrowedCount())
+    }
+
+    @Test
+    fun testRecycleObjects() {
+        val pool = ObjectPool(
+            create = { TestObject(Int.MIN_VALUE) },
+            reset = { it.value = Int.MIN_VALUE },
+            initialSize = 100
+        )
+
+        val allObjectsAttempt1 = (1 until 100).map { pool.borrow(init = { it.also { it.value = 1 } }) }
+        allObjectsAttempt1.forEach { assertEquals(1, it.value)}
+        allObjectsAttempt1.forEach { pool.release(it) }
+        allObjectsAttempt1.forEach { assertEquals(Int.MIN_VALUE, it.value)}
+
+        val allObjectsAttempt2 = (1 until 100).map { pool.borrow(init = { it.also { it.value = 2 } }) }
+        allObjectsAttempt2.forEach { assertEquals(2, it.value)}
+        allObjectsAttempt2.forEach { pool.release(it) }
+        allObjectsAttempt2.forEach { assertEquals(Int.MIN_VALUE, it.value)}
+
+        val allObjectsAttempt3 = (1 until 100).map { pool.borrow(init = { it.also { it.value = 3 } }) }
+        allObjectsAttempt3.forEach { assertEquals(3, it.value)}
+    }
+
+    @Test
+    fun testCanGetAnyAmountOfObjectsFromThePool() {
+        val pool = ObjectPool(
+            create = { TestObject(Int.MIN_VALUE) },
+            reset = { it.value = Int.MIN_VALUE },
+            initialSize = 100
+        )
+
+        val allExisting = (0 until 100).map { pool.borrow(init = { it.also { it.value = 1 } }) }
+        allExisting.forEach { assertEquals(1, it.value)}
+        assertEquals(0, pool.getPoolSize())
+        assertEquals(100, pool.getBorrowedCount())
+
+        val newObjectsWithInit = (0 until 100).map { pool.borrow(init = { it.also { it.value = 2 } }) }
+        assertEquals(0, pool.getPoolSize())
+        assertEquals(200, pool.getBorrowedCount())
+
+        val newObjectsWithoutInit = (0 until 100).map { pool.borrow() }
+        assertEquals(0, pool.getPoolSize())
+        assertEquals(300, pool.getBorrowedCount())
+
+        // release all
+        allExisting.forEach { pool.release(it) }
+        newObjectsWithInit.forEach { pool.release(it) }
+        newObjectsWithoutInit.forEach { pool.release(it) }
+
+        // pool size has increased
+        assertEquals(300, pool.getPoolSize())
+        assertEquals(0, pool.getBorrowedCount())
+    }
+
+    @Test
+    fun testObjectInitOnBorrow() {
+        val pool = ObjectPool(
+            create = { TestObject(Int.MIN_VALUE) },
+            reset = { it.value = Int.MIN_VALUE },
+            initialSize = 100
+        )
+
+        val obj1 = pool.borrow()
+        assertEquals(Int.MIN_VALUE, obj1.value)
+
+        val obj2 = pool.borrow(init = { it.also { it.value = 10 } })
+        assertEquals(10, obj2.value)
+    }
+
+    @Test
+    fun testResetOnRelease() {
+        val pool = ObjectPool(
+            create = { TestObject(Int.MIN_VALUE) },
+            reset = { it.value = Int.MIN_VALUE },
+            initialSize = 100
+        )
+
+        val obj = pool.borrow { it.also { it.value = 10 } }
+        assertEquals(10, obj.value)
+
+        pool.release(obj)
+        assertEquals(Int.MIN_VALUE, obj.value)
+    }
+
+}

--- a/sequencer/src/test/kotlin/co/chainring/TestObjectPool.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestObjectPool.kt
@@ -1,9 +1,9 @@
 package co.chainring
 
 import co.chainring.sequencer.core.datastructure.ObjectPool
+import org.junit.jupiter.api.Test
 import kotlin.random.Random
 import kotlin.test.assertEquals
-import org.junit.jupiter.api.Test
 
 class TestObjectPool {
 
@@ -14,7 +14,7 @@ class TestObjectPool {
         val pool = ObjectPool(
             create = { TestObject(Int.MIN_VALUE) },
             reset = { it.value = Int.MIN_VALUE },
-            initialSize = 100
+            initialSize = 100,
         )
         assertEquals(100, pool.getPoolSize())
         assertEquals(0, pool.getBorrowedCount())
@@ -45,21 +45,21 @@ class TestObjectPool {
         val pool = ObjectPool(
             create = { TestObject(Int.MIN_VALUE) },
             reset = { it.value = Int.MIN_VALUE },
-            initialSize = 100
+            initialSize = 100,
         )
 
         val allObjectsAttempt1 = (1 until 100).map { pool.borrow(init = { it.also { it.value = 1 } }) }
-        allObjectsAttempt1.forEach { assertEquals(1, it.value)}
+        allObjectsAttempt1.forEach { assertEquals(1, it.value) }
         allObjectsAttempt1.forEach { pool.release(it) }
-        allObjectsAttempt1.forEach { assertEquals(Int.MIN_VALUE, it.value)}
+        allObjectsAttempt1.forEach { assertEquals(Int.MIN_VALUE, it.value) }
 
         val allObjectsAttempt2 = (1 until 100).map { pool.borrow(init = { it.also { it.value = 2 } }) }
-        allObjectsAttempt2.forEach { assertEquals(2, it.value)}
+        allObjectsAttempt2.forEach { assertEquals(2, it.value) }
         allObjectsAttempt2.forEach { pool.release(it) }
-        allObjectsAttempt2.forEach { assertEquals(Int.MIN_VALUE, it.value)}
+        allObjectsAttempt2.forEach { assertEquals(Int.MIN_VALUE, it.value) }
 
         val allObjectsAttempt3 = (1 until 100).map { pool.borrow(init = { it.also { it.value = 3 } }) }
-        allObjectsAttempt3.forEach { assertEquals(3, it.value)}
+        allObjectsAttempt3.forEach { assertEquals(3, it.value) }
     }
 
     @Test
@@ -67,11 +67,11 @@ class TestObjectPool {
         val pool = ObjectPool(
             create = { TestObject(Int.MIN_VALUE) },
             reset = { it.value = Int.MIN_VALUE },
-            initialSize = 100
+            initialSize = 100,
         )
 
         val allExisting = (0 until 100).map { pool.borrow(init = { it.also { it.value = 1 } }) }
-        allExisting.forEach { assertEquals(1, it.value)}
+        allExisting.forEach { assertEquals(1, it.value) }
         assertEquals(0, pool.getPoolSize())
         assertEquals(100, pool.getBorrowedCount())
 
@@ -98,7 +98,7 @@ class TestObjectPool {
         val pool = ObjectPool(
             create = { TestObject(Int.MIN_VALUE) },
             reset = { it.value = Int.MIN_VALUE },
-            initialSize = 100
+            initialSize = 100,
         )
 
         val obj1 = pool.borrow()
@@ -113,7 +113,7 @@ class TestObjectPool {
         val pool = ObjectPool(
             create = { TestObject(Int.MIN_VALUE) },
             reset = { it.value = Int.MIN_VALUE },
-            initialSize = 100
+            initialSize = 100,
         )
 
         val obj = pool.borrow { it.also { it.value = 10 } }
@@ -122,5 +122,4 @@ class TestObjectPool {
         pool.release(obj)
         assertEquals(Int.MIN_VALUE, obj.value)
     }
-
 }

--- a/sequencer/src/test/kotlin/co/chainring/TestOrderBookLevel.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestOrderBookLevel.kt
@@ -5,7 +5,6 @@ import co.chainring.sequencer.core.FeeRate
 import co.chainring.sequencer.core.LevelOrder
 import co.chainring.sequencer.core.OrderBookLevel
 import co.chainring.sequencer.core.toBigInteger
-import co.chainring.sequencer.core.toDecimalValue
 import co.chainring.sequencer.core.toIntegerValue
 import co.chainring.sequencer.proto.Order
 import co.chainring.sequencer.proto.OrderDisposition
@@ -272,7 +271,7 @@ class TestOrderBookLevel {
         return order {
             this.guid = nextOrderId++
             this.amount = amount.toIntegerValue()
-            this.price = BigDecimal.ONE.toDecimalValue()
+            this.levelIx = 1
             this.type = Order.Type.LimitBuy
         }.also {
             if (addToSet) {

--- a/sequencer/src/test/kotlin/co/chainring/TestSequencer.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestSequencer.kt
@@ -2,23 +2,19 @@ package co.chainring
 
 import co.chainring.core.model.Symbol
 import co.chainring.core.model.db.FeeRates
-import co.chainring.sequencer.apps.SequencerApp
 import co.chainring.sequencer.core.MarketId
 import co.chainring.sequencer.core.WalletAddress
 import co.chainring.sequencer.core.notional
 import co.chainring.sequencer.core.notionalFee
 import co.chainring.sequencer.core.toBigInteger
-import co.chainring.sequencer.core.toDecimalValue
 import co.chainring.sequencer.core.toOrderGuid
 import co.chainring.sequencer.core.toWalletAddress
 import co.chainring.sequencer.proto.Order
 import co.chainring.sequencer.proto.OrderChangeRejected
 import co.chainring.sequencer.proto.OrderDisposition
 import co.chainring.sequencer.proto.SequencerError
-import co.chainring.sequencer.proto.SequencerRequest
 import co.chainring.sequencer.proto.market
 import co.chainring.sequencer.proto.newQuantityOrNull
-import co.chainring.sequencer.proto.sequencerRequest
 import co.chainring.testutils.ExpectedTrade
 import co.chainring.testutils.SequencerClient
 import co.chainring.testutils.assertBalanceChanges
@@ -33,7 +29,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.math.BigDecimal
-import java.util.UUID
 import kotlin.random.Random
 
 class TestSequencer {
@@ -393,7 +388,7 @@ class TestSequencer {
     fun `test limit checking on orders`() {
         val sequencer = SequencerClient()
         sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
-        val market1 = sequencer.createMarket(MarketId("BTC3/ETH3"), marketPrice = BigDecimal("11.025"))
+        val market1 = sequencer.createMarket(MarketId("BTC3/ETH3"))
 
         val maker = generateWalletAddress()
         // cannot place a buy or sell limit order without any deposits
@@ -417,7 +412,7 @@ class TestSequencer {
         assertEquals(SequencerError.ExceedsLimit, sequencer.addOrder(market1, BigDecimal("0.001"), BigDecimal("11.00"), maker, Order.Type.LimitBuy).error)
 
         // but we can reuse the same liquidity in another market
-        val market2 = sequencer.createMarket(MarketId("ETH3/USDC3"), baseDecimals = 18, quoteDecimals = 6, tickSize = BigDecimal("1"), marketPrice = BigDecimal("100.5"))
+        val market2 = sequencer.createMarket(MarketId("ETH3/USDC3"), baseDecimals = 18, quoteDecimals = 6, tickSize = BigDecimal("1"))
         sequencer.addOrderAndVerifyAccepted(market2, BigDecimal("1.111"), BigDecimal("100.00"), maker, Order.Type.LimitSell)
 
         // if we deposit some more we can add another order
@@ -992,9 +987,9 @@ class TestSequencer {
         val sequencer = SequencerClient()
         sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
 
-        val market1 = sequencer.createMarket(MarketId("BTC6/ETH6"), tickSize = BigDecimal(1), marketPrice = BigDecimal(10.5), baseDecimals = 8, quoteDecimals = 18)
-        val market2 = sequencer.createMarket(MarketId("ETH6/USDC6"), tickSize = BigDecimal(1), marketPrice = BigDecimal(9.5), baseDecimals = 18, quoteDecimals = 6)
-        val market3 = sequencer.createMarket(MarketId("XXX6/ETH6"), tickSize = BigDecimal(1), marketPrice = BigDecimal(20.5), baseDecimals = 1, quoteDecimals = 18)
+        val market1 = sequencer.createMarket(MarketId("BTC6/ETH6"), tickSize = BigDecimal(1), baseDecimals = 8, quoteDecimals = 18)
+        val market2 = sequencer.createMarket(MarketId("ETH6/USDC6"), tickSize = BigDecimal(1), baseDecimals = 18, quoteDecimals = 6)
+        val market3 = sequencer.createMarket(MarketId("XXX6/ETH6"), tickSize = BigDecimal(1), baseDecimals = 1, quoteDecimals = 18)
 
         val maker = generateWalletAddress()
 
@@ -1105,52 +1100,6 @@ class TestSequencer {
                 ),
             )
         }
-    }
-
-    @Test
-    fun `initial market price should exactly between ticks`() {
-        fun expectMarketCreationFail(sequencerApp: SequencerApp, marketId: MarketId, tickSize: BigDecimal, marketPrice: BigDecimal, baseDecimals: Int = 8, quoteDecimals: Int = 18) {
-            val createMarketResponse = sequencerApp.processRequest(
-                sequencerRequest {
-                    this.guid = UUID.randomUUID().toString()
-                    this.type = SequencerRequest.Type.AddMarket
-                    this.addMarket = market {
-                        this.guid = UUID.randomUUID().toString()
-                        this.marketId = marketId.value
-                        this.tickSize = tickSize.toDecimalValue()
-                        this.maxLevels = 1000
-                        this.maxOrdersPerLevel = 1000
-                        this.marketPrice = marketPrice.toDecimalValue()
-                        this.baseDecimals = baseDecimals
-                        this.quoteDecimals = quoteDecimals
-                    }
-                },
-            )
-            assertEquals(0, createMarketResponse.marketsCreatedCount)
-            assertEquals(0, createMarketResponse.marketsCreatedList.size)
-            assertEquals(SequencerError.InvalidPrice, createMarketResponse.error)
-        }
-
-        val sequencerApp = SequencerApp(checkpointsPath = null)
-        val sequencerClient = SequencerClient()
-
-        // fail
-        expectMarketCreationFail(sequencerApp, MarketId("BTC98/ETH98"), tickSize = BigDecimal("1"), marketPrice = BigDecimal("1"))
-        expectMarketCreationFail(sequencerApp, MarketId("BTC98/ETH98"), tickSize = BigDecimal("1"), marketPrice = BigDecimal("100"))
-        expectMarketCreationFail(sequencerApp, MarketId("BTC98/ETH98"), tickSize = BigDecimal("1"), marketPrice = BigDecimal("100.001"))
-        expectMarketCreationFail(sequencerApp, MarketId("BTC98/ETH98"), tickSize = BigDecimal("1"), marketPrice = BigDecimal("100.501"))
-        // succeed
-        sequencerClient.createMarket(MarketId("BTC98/ETH98"), tickSize = BigDecimal("1"), marketPrice = BigDecimal("100.50"))
-
-        // fail
-        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("17"))
-        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("17.05"))
-        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.024"))
-        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.026"))
-        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.0251"))
-        expectMarketCreationFail(sequencerApp, MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.005"), marketPrice = BigDecimal("60.02500001"))
-        // succeed
-        sequencerClient.createMarket(MarketId("BTC99/ETH99"), tickSize = BigDecimal("0.05"), marketPrice = BigDecimal("60.025"))
     }
 
     @Test

--- a/sequencer/src/test/kotlin/co/chainring/TestSequencer.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestSequencer.kt
@@ -91,7 +91,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = makerOrder.guid,
-                        price = BigDecimal("12.000"),
+                        price = BigDecimal("12.00"),
                         amount = BigDecimal("0.2"),
                         buyerFee = BigDecimal("0.048"),
                         sellerFee = BigDecimal("0.024"),
@@ -131,7 +131,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = makerOrder.guid,
                         sellOrderGuid = takerOrder.guid,
-                        price = BigDecimal("10.000"),
+                        price = BigDecimal("10.00"),
                         amount = BigDecimal("0.1"),
                         buyerFee = BigDecimal("0.01"),
                         sellerFee = BigDecimal("0.02"),
@@ -226,7 +226,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = makerOrder1.guid,
-                        price = BigDecimal("17.550"),
+                        price = BigDecimal("17.55"),
                         amount = BigDecimal("0.01"),
                         buyerFee = BigDecimal("0.00351"),
                         sellerFee = BigDecimal("0.001755"),
@@ -234,7 +234,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = makerOrder2.guid,
-                        price = BigDecimal("17.550"),
+                        price = BigDecimal("17.55"),
                         amount = BigDecimal("0.01"),
                         buyerFee = BigDecimal("0.00351"),
                         sellerFee = BigDecimal("0.001755"),
@@ -242,7 +242,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = makerOrder3.guid,
-                        price = BigDecimal("17.600"),
+                        price = BigDecimal("17.60"),
                         amount = BigDecimal("0.1"),
                         buyerFee = BigDecimal("0.0352"),
                         sellerFee = BigDecimal("0.0176"),
@@ -250,7 +250,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = makerOrder4.guid,
-                        price = BigDecimal("17.600"),
+                        price = BigDecimal("17.60"),
                         amount = BigDecimal("0.05"),
                         buyerFee = BigDecimal("0.0176"),
                         sellerFee = BigDecimal("0.0088"),
@@ -281,7 +281,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = sell4Order.guid,
-                        price = BigDecimal("17.600"),
+                        price = BigDecimal("17.60"),
                         amount = BigDecimal("0.05"),
                         buyerFee = BigDecimal("0.0176"),
                         sellerFee = BigDecimal("0.0088"),
@@ -289,7 +289,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = sell5Order.guid,
-                        price = BigDecimal("17.700"),
+                        price = BigDecimal("17.70"),
                         amount = BigDecimal("0.2"),
                         buyerFee = BigDecimal("0.0708"),
                         sellerFee = BigDecimal("0.0354"),
@@ -297,7 +297,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = sell6Order.guid,
-                        price = BigDecimal("17.700"),
+                        price = BigDecimal("17.70"),
                         amount = BigDecimal("0.2"),
                         buyerFee = BigDecimal(if (percentage == 100) "0.070851408" else "0.0708"),
                         sellerFee = BigDecimal("0.0354"),
@@ -468,7 +468,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = makerOrder.guid,
-                        price = BigDecimal("17.550"),
+                        price = BigDecimal("17.55"),
                         amount = BigDecimal("0.1"),
                         buyerFee = BigDecimal("0.0351"),
                         sellerFee = BigDecimal("0.01755"),
@@ -501,7 +501,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = makerOrder.guid,
-                        price = BigDecimal("17.550"),
+                        price = BigDecimal("17.55"),
                         amount = BigDecimal("0.1"),
                         buyerFee = BigDecimal("0.0351"),
                         sellerFee = BigDecimal("0.01755"),
@@ -567,7 +567,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = sellOrder1.guid,
-                        price = BigDecimal("17.550"),
+                        price = BigDecimal("17.55"),
                         amount = BigDecimal("0.01"),
                         buyerFee = BigDecimal("0.003510"),
                         sellerFee = BigDecimal("0.001755"),
@@ -575,7 +575,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = sellOrder2.guid,
-                        price = BigDecimal("18.000"),
+                        price = BigDecimal("18.00"),
                         amount = BigDecimal("0.01"),
                         buyerFee = BigDecimal("0.0036"),
                         sellerFee = BigDecimal("0.0018"),
@@ -583,7 +583,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = sellOrder3.guid,
-                        price = BigDecimal("18.500"),
+                        price = BigDecimal("18.50"),
                         amount = BigDecimal("0.01"),
                         buyerFee = BigDecimal("0.00370"),
                         sellerFee = BigDecimal("0.00185"),
@@ -632,7 +632,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = makerOrder.guid,
                         sellOrderGuid = takerOrder.guid,
-                        price = BigDecimal("17.500"),
+                        price = BigDecimal("17.50"),
                         amount = BigDecimal("0.1"),
                         buyerFee = BigDecimal("0.01750"),
                         sellerFee = BigDecimal("0.03500"),
@@ -669,7 +669,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = makerOrder.guid,
                         sellOrderGuid = takerOrder.guid,
-                        price = BigDecimal("17.500"),
+                        price = BigDecimal("17.50"),
                         amount = BigDecimal("0.1"),
                         buyerFee = BigDecimal("0.01750"),
                         sellerFee = BigDecimal("0.03500"),
@@ -724,7 +724,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = buyOrder1.guid,
                         sellOrderGuid = takerOrder.guid,
-                        price = BigDecimal("17.500"),
+                        price = BigDecimal("17.50"),
                         amount = BigDecimal("0.01"),
                         buyerFee = BigDecimal("0.001750"),
                         sellerFee = BigDecimal("0.003500"),
@@ -732,7 +732,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = buyOrder2.guid,
                         sellOrderGuid = takerOrder.guid,
-                        price = BigDecimal("17.000"),
+                        price = BigDecimal("17.00"),
                         amount = BigDecimal("0.01"),
                         buyerFee = BigDecimal("0.001700"),
                         sellerFee = BigDecimal("0.003400"),
@@ -740,7 +740,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = buyOrder3.guid,
                         sellOrderGuid = takerOrder.guid,
-                        price = BigDecimal("16.500"),
+                        price = BigDecimal("16.50"),
                         amount = BigDecimal("0.01"),
                         buyerFee = BigDecimal("0.001650"),
                         sellerFee = BigDecimal("0.003300"),
@@ -933,7 +933,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = m1buy1.guid,
                         sellOrderGuid = response.ordersChangedList[0].guid,
-                        price = BigDecimal("17.500"),
+                        price = BigDecimal("17.50"),
                         amount = BigDecimal("0.1"),
                         buyerFee = BigDecimal("0.01750"),
                         sellerFee = BigDecimal("0.03500"),
@@ -967,7 +967,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = response.ordersChangedList[0].guid,
                         sellOrderGuid = m1sell1.guid,
-                        price = BigDecimal("17.550"),
+                        price = BigDecimal("17.55"),
                         amount = BigDecimal("0.1"),
                         buyerFee = BigDecimal("0.03510"),
                         sellerFee = BigDecimal("0.01755"),
@@ -1085,7 +1085,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = response.ordersChangedList[0].guid,
                         sellOrderGuid = sellOrder1.guid,
-                        price = BigDecimal("10.000"),
+                        price = BigDecimal("10.00"),
                         amount = BigDecimal("5.0"),
                         // taker's fee is 4%
                         buyerFee = BigDecimal("2.0"),
@@ -1095,7 +1095,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = response.ordersChangedList[0].guid,
                         sellOrderGuid = sellOrder2.guid,
-                        price = BigDecimal("10.000"),
+                        price = BigDecimal("10.00"),
                         amount = BigDecimal("5.0"),
                         // taker's fee is 4%
                         buyerFee = BigDecimal("2.0"),
@@ -1222,7 +1222,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = makerOrder.guid,
-                        price = BigDecimal("17.550"),
+                        price = BigDecimal("17.55"),
                         amount = BigDecimal("0.43210"),
                         buyerFee = BigDecimal("0.1516671000000000"),
                         sellerFee = BigDecimal("0.075833550000000"),
@@ -1304,7 +1304,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = makerOrder.guid,
-                        price = BigDecimal("17.550"),
+                        price = BigDecimal("17.55"),
                         amount = BigDecimal("1"),
                         buyerFee = BigDecimal("0.3510"),
                         sellerFee = BigDecimal("0.1755"),
@@ -1397,7 +1397,7 @@ class TestSequencer {
                     ExpectedTrade(
                         buyOrderGuid = takerOrder.guid,
                         sellOrderGuid = makerOrder.guid,
-                        price = BigDecimal("17.550"),
+                        price = BigDecimal("17.55"),
                         amount = BigDecimal("0.43210"),
                         buyerFee = BigDecimal("0.1516671"),
                         sellerFee = BigDecimal("0.07583355"),

--- a/sequencer/src/test/kotlin/co/chainring/TestSequencerCheckpoints.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestSequencerCheckpoints.kt
@@ -5,14 +5,11 @@ import co.chainring.sequencer.apps.GatewayApp
 import co.chainring.sequencer.apps.GatewayConfig
 import co.chainring.sequencer.apps.SequencerApp
 import co.chainring.sequencer.core.Asset
-import co.chainring.sequencer.core.FeeRate
 import co.chainring.sequencer.core.FeeRates
-import co.chainring.sequencer.core.LevelOrder
 import co.chainring.sequencer.core.Market
 import co.chainring.sequencer.core.MarketId
 import co.chainring.sequencer.core.OrderGuid
 import co.chainring.sequencer.core.SequencerState
-import co.chainring.sequencer.core.WalletAddress
 import co.chainring.sequencer.core.queueHome
 import co.chainring.sequencer.core.toBigDecimal
 import co.chainring.sequencer.core.toBigInteger
@@ -76,8 +73,12 @@ class TestSequencerCheckpoints {
     private val btc = Asset("BTC")
     private val eth = Asset("ETH")
     private val usdc = Asset("USDC")
+
     private val btcEthMarketId = MarketId("BTC/ETH")
+    private val btcEthMarketTickSize = "0.05".toBigDecimal()
+
     private val btcUsdcMarketId = MarketId("BTC/USDC")
+    private val btcUsdcMarketTickSize = "1".toBigDecimal()
 
     @BeforeEach
     fun beforeEach() {
@@ -123,7 +124,7 @@ class TestSequencerCheckpoints {
                     market {
                         this.guid = UUID.randomUUID().toString()
                         this.marketId = btcEthMarketId.value
-                        this.tickSize = "0.05".toBigDecimal().toDecimalValue()
+                        this.tickSize = btcEthMarketTickSize.toDecimalValue()
                         this.maxOrdersPerLevel = 1000
                         this.baseDecimals = 8
                         this.quoteDecimals = 18
@@ -224,7 +225,7 @@ class TestSequencerCheckpoints {
                             order {
                                 this.guid = Random.nextLong()
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.550").toDecimalValue()
+                                this.levelIx = "17.550".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitSell
                             },
                         )
@@ -246,7 +247,7 @@ class TestSequencerCheckpoints {
                             order {
                                 this.guid = Random.nextLong()
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.560").toDecimalValue()
+                                this.levelIx = "17.560".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitSell
                             },
                         )
@@ -265,7 +266,7 @@ class TestSequencerCheckpoints {
                             order {
                                 this.guid = Random.nextLong()
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.570").toDecimalValue()
+                                this.levelIx = "17.570".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitSell
                             },
                         )
@@ -331,7 +332,7 @@ class TestSequencerCheckpoints {
                         order {
                             this.guid = Random.nextLong()
                             this.amount = BigDecimal("0.000005").inSats().toIntegerValue()
-                            this.price = BigDecimal("17.570").toDecimalValue()
+                            this.levelIx = "17.570".levelIx(btcEthMarketTickSize)
                             this.type = Order.Type.LimitSell
                         },
                     )
@@ -354,7 +355,7 @@ class TestSequencerCheckpoints {
                         order {
                             this.guid = Random.nextLong()
                             this.amount = BigDecimal("0.0011").inSats().toIntegerValue()
-                            this.price = BigDecimal.ZERO.toDecimalValue()
+                            this.levelIx = 0
                             this.type = Order.Type.MarketBuy
                         },
                     )
@@ -402,7 +403,7 @@ class TestSequencerCheckpoints {
                             order {
                                 this.guid = Random.nextLong()
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.550").toDecimalValue()
+                                this.levelIx = "17.550".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitSell
                             },
                         )
@@ -427,7 +428,7 @@ class TestSequencerCheckpoints {
                         order {
                             this.guid = Random.nextLong()
                             this.amount = BigDecimal("0.0011").inSats().toIntegerValue()
-                            this.price = BigDecimal.ZERO.toDecimalValue()
+                            this.levelIx = 0
                             this.type = Order.Type.MarketBuy
                         },
                     )
@@ -597,19 +598,19 @@ class TestSequencerCheckpoints {
                             order {
                                 this.guid = 1
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.550").toDecimalValue()
+                                this.levelIx = "17.550".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitSell
                             },
                             order {
                                 this.guid = 2
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.560").toDecimalValue()
+                                this.levelIx = "17.560".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitSell
                             },
                             order {
                                 this.guid = 3
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.600").toDecimalValue()
+                                this.levelIx = "17.600".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitSell
                             },
                         ).forEach { order ->
@@ -651,19 +652,19 @@ class TestSequencerCheckpoints {
                             order {
                                 this.guid = 1
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.3").toDecimalValue()
+                                this.levelIx = "17.3".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitBuy
                             },
                             order {
                                 this.guid = 2
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.4").toDecimalValue()
+                                this.levelIx = "17.4".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitBuy
                             },
                             order {
                                 this.guid = 3
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.5").toDecimalValue()
+                                this.levelIx = "17.5".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitBuy
                             },
                         ).forEach { order ->
@@ -707,37 +708,37 @@ class TestSequencerCheckpoints {
                             order {
                                 this.guid = 1
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.3").toDecimalValue()
+                                this.levelIx = "17.3".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitBuy
                             },
                             order {
                                 this.guid = 2
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.4").toDecimalValue()
+                                this.levelIx = "17.4".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitBuy
                             },
                             order {
                                 this.guid = 3
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.5").toDecimalValue()
+                                this.levelIx = "17.5".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitBuy
                             },
                             order {
                                 this.guid = 4
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.550").toDecimalValue()
+                                this.levelIx = "17.550".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitSell
                             },
                             order {
                                 this.guid = 5
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.560").toDecimalValue()
+                                this.levelIx = "17.560".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitSell
                             },
                             order {
                                 this.guid = 6
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("17.600").toDecimalValue()
+                                this.levelIx = "17.600".levelIx(btcEthMarketTickSize)
                                 this.type = Order.Type.LimitSell
                             },
                         ).forEach { order ->
@@ -759,37 +760,37 @@ class TestSequencerCheckpoints {
                             order {
                                 this.guid = 1
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("69997").toDecimalValue()
+                                this.levelIx = "69997".levelIx(btcUsdcMarketTickSize)
                                 this.type = Order.Type.LimitBuy
                             },
                             order {
                                 this.guid = 2
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("69998").toDecimalValue()
+                                this.levelIx = "69998".levelIx(btcUsdcMarketTickSize)
                                 this.type = Order.Type.LimitBuy
                             },
                             order {
                                 this.guid = 3
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("69999").toDecimalValue()
+                                this.levelIx = "69999".levelIx(btcUsdcMarketTickSize)
                                 this.type = Order.Type.LimitBuy
                             },
                             order {
                                 this.guid = 4
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("70001").toDecimalValue()
+                                this.levelIx = "70001".levelIx(btcUsdcMarketTickSize)
                                 this.type = Order.Type.LimitSell
                             },
                             order {
                                 this.guid = 5
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("70002").toDecimalValue()
+                                this.levelIx = "70002".levelIx(btcUsdcMarketTickSize)
                                 this.type = Order.Type.LimitSell
                             },
                             order {
                                 this.guid = 6
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = BigDecimal("70003").toDecimalValue()
+                                this.levelIx = "70003".levelIx(btcUsdcMarketTickSize)
                                 this.type = Order.Type.LimitSell
                             },
                         ).forEach { order ->
@@ -817,9 +818,9 @@ class TestSequencerCheckpoints {
 
     private fun `test state storing and loading - order level circular buffer`(orderType: Type) {
         val feeRates = FeeRates.fromPercents(maker = 1.0, taker = 2.0)
-        val price = when (orderType) {
-            Type.LimitBuy -> BigDecimal("17.500").toDecimalValue()
-            Type.LimitSell -> BigDecimal("17.550").toDecimalValue()
+        val levelIx = when (orderType) {
+            Type.LimitBuy -> "17.500".levelIx(btcEthMarketTickSize)
+            Type.LimitSell -> "17.550".levelIx(btcEthMarketTickSize)
             else -> throw IllegalArgumentException("$orderType not supported")
         }
 
@@ -851,7 +852,7 @@ class TestSequencerCheckpoints {
                             order {
                                 this.guid = it.toLong()
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = price
+                                this.levelIx = levelIx
                                 this.type = orderType
                             }
                         }.also { orders ->
@@ -888,7 +889,7 @@ class TestSequencerCheckpoints {
                             order {
                                 this.guid = it.toLong()
                                 this.amount = BigDecimal("0.0005").inSats().toIntegerValue()
-                                this.price = price
+                                this.levelIx = levelIx
                                 this.type = orderType
                             }
                         }.forEach { order ->
@@ -896,7 +897,7 @@ class TestSequencerCheckpoints {
                         }
 
                         // verify setup
-                        val targetLevel = market.levels.get(market.levelIx(price.toBigDecimal()))!!
+                        val targetLevel = market.levels.get(levelIx)!!
                         assertEquals(990, targetLevel.orderHead)
                         assertEquals(11, targetLevel.orderTail)
                     },
@@ -978,20 +979,19 @@ class TestSequencerCheckpoints {
 
                     // verify checkpoint contains exact number of orders
                     assertEquals(
-                        initialMarket.ordersByGuid.map { (_, v) -> v }.toSet(),
-                        marketCheckpoint.levelsList.flatMap { it.ordersList }.map {
-                            LevelOrder(
-                                OrderGuid(it.guid),
-                                WalletAddress(it.wallet),
-                                it.quantity.toBigInteger(),
-                                FeeRate(it.feeRate),
-                                it.levelIx,
-                                it.originalQuantity.toBigInteger(),
-                            )
-                        }.toSet(),
+                        initialMarket.ordersByGuid.map { (_, v) -> v.guid }.toSet(),
+                        marketCheckpoint.levelsList.map { level ->
+                            level.ordersList.map {
+                                OrderGuid(it.guid)
+                            }
+                        }.flatten().toSet(),
                     )
                 }
             }
         }
+    }
+
+    private fun String.levelIx(tickSize: BigDecimal): Int {
+        return BigDecimal(this).divideToIntegralValue(tickSize).toInt()
     }
 }

--- a/sequencer/src/test/kotlin/co/chainring/TestSequencerCheckpoints.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestSequencerCheckpoints.kt
@@ -944,9 +944,9 @@ class TestSequencerCheckpoints {
 
                 // Compare the level indices
                 assertEquals(
-                    initialStateLevel.levelIx,
-                    restoredStateLevel.levelIx,
-                    "Level index mismatch at initial levelIx=${initialStateLevel.levelIx} vs restored levelIx=${restoredStateLevel.levelIx}",
+                    initialStateLevel.ix,
+                    restoredStateLevel.ix,
+                    "Level index mismatch at initial levelIx=${initialStateLevel.ix} vs restored levelIx=${restoredStateLevel.ix}",
                 )
 
                 // Compare the orders in each level
@@ -954,7 +954,7 @@ class TestSequencerCheckpoints {
                     assertEquals(
                         initialStateOrder,
                         restoredStateLevel.orders[i],
-                        "Order mismatch at levelIx=${initialStateLevel.levelIx}, orderIx=$i",
+                        "Order mismatch at levelIx=${initialStateLevel.ix}, orderIx=$i",
                     )
                 }
 

--- a/sequencer/src/test/kotlin/co/chainring/TestSequencerCheckpoints.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestSequencerCheckpoints.kt
@@ -124,9 +124,7 @@ class TestSequencerCheckpoints {
                         this.guid = UUID.randomUUID().toString()
                         this.marketId = btcEthMarketId.value
                         this.tickSize = "0.05".toBigDecimal().toDecimalValue()
-                        this.maxLevels = 1000
                         this.maxOrdersPerLevel = 1000
-                        this.marketPrice = "17.525".toBigDecimal().toDecimalValue()
                         this.baseDecimals = 8
                         this.quoteDecimals = 18
                     },
@@ -564,9 +562,7 @@ class TestSequencerCheckpoints {
                     btcEthMarketId to Market(
                         id = btcEthMarketId,
                         tickSize = BigDecimal("0.05"),
-                        maxLevels = 1000,
                         maxOrdersPerLevel = 1000,
-                        initialMarketPrice = BigDecimal("17.525"),
                         baseDecimals = 18,
                         quoteDecimals = 18,
                     ),
@@ -593,9 +589,7 @@ class TestSequencerCheckpoints {
                     btcEthMarketId to Market(
                         id = btcEthMarketId,
                         tickSize = BigDecimal("0.05"),
-                        maxLevels = 1000,
                         maxOrdersPerLevel = 1000,
-                        initialMarketPrice = BigDecimal("17.525"),
                         baseDecimals = 18,
                         quoteDecimals = 18,
                     ).also { market ->
@@ -649,9 +643,7 @@ class TestSequencerCheckpoints {
                     btcEthMarketId to Market(
                         id = btcEthMarketId,
                         tickSize = BigDecimal("0.05"),
-                        maxLevels = 1000,
                         maxOrdersPerLevel = 1000,
-                        initialMarketPrice = BigDecimal("17.525"),
                         baseDecimals = 18,
                         quoteDecimals = 18,
                     ).also { market ->
@@ -707,9 +699,7 @@ class TestSequencerCheckpoints {
                     btcEthMarketId to Market(
                         id = btcEthMarketId,
                         tickSize = BigDecimal("0.05"),
-                        maxLevels = 1000,
                         maxOrdersPerLevel = 1000,
-                        initialMarketPrice = BigDecimal("17.525"),
                         baseDecimals = 18,
                         quoteDecimals = 18,
                     ).also { market ->
@@ -761,9 +751,7 @@ class TestSequencerCheckpoints {
                     btcUsdcMarketId to Market(
                         id = btcUsdcMarketId,
                         tickSize = BigDecimal("1.00"),
-                        maxLevels = 1000,
                         maxOrdersPerLevel = 1000,
-                        initialMarketPrice = BigDecimal("70000"),
                         baseDecimals = 18,
                         quoteDecimals = 18,
                     ).also { market ->
@@ -854,9 +842,7 @@ class TestSequencerCheckpoints {
                     btcEthMarketId to Market(
                         id = btcEthMarketId,
                         tickSize = BigDecimal("0.05"),
-                        maxLevels = 1000,
                         maxOrdersPerLevel = 1000,
-                        initialMarketPrice = BigDecimal("17.525"),
                         baseDecimals = 18,
                         quoteDecimals = 18,
                     ).also { market ->
@@ -986,8 +972,6 @@ class TestSequencerCheckpoints {
                 initialState.markets[marketId]!!.let { initialMarket ->
                     assertEquals(initialMarket.id, marketCheckpoint.id.toMarketId())
                     assertEquals(initialMarket.tickSize, marketCheckpoint.tickSize.toBigDecimal())
-                    assertEquals(initialMarket.initialMarketPrice, marketCheckpoint.marketPrice.toBigDecimal())
-                    assertEquals(initialMarket.maxLevels, marketCheckpoint.maxLevels)
                     assertEquals(initialMarket.maxOrdersPerLevel, marketCheckpoint.maxOrdersPerLevel)
                     assertEquals(initialMarket.baseDecimals, marketCheckpoint.baseDecimals)
                     assertEquals(initialMarket.quoteDecimals, marketCheckpoint.quoteDecimals)

--- a/sequencer/src/test/kotlin/co/chainring/TestSequencerCheckpoints.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestSequencerCheckpoints.kt
@@ -939,8 +939,8 @@ class TestSequencerCheckpoints {
             var restoredNode = restoredStateMarket.levels.first()
 
             while (initialNode != null && restoredNode != null) {
-                val initialStateLevel = initialNode.value
-                val restoredStateLevel = restoredNode.value
+                val initialStateLevel = initialNode
+                val restoredStateLevel = restoredNode
 
                 // Compare the level indices
                 assertEquals(

--- a/sequencer/src/test/kotlin/co/chainring/datastructure/TestAVLTree.kt
+++ b/sequencer/src/test/kotlin/co/chainring/datastructure/TestAVLTree.kt
@@ -1,0 +1,260 @@
+package co.chainring.datastructure
+
+import co.chainring.sequencer.core.datastructure.AVLTree
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class TestAVLTree {
+
+    class TestLevel(ix: Int) : AVLTree.Node<TestLevel>(ix)
+
+    @Test
+    fun testInsert1() {
+        //        20+      20++         20++      15
+        //       /        /            /         /  \
+        //      4     => 4-     =>   15+     => 4    20
+        //                \         /
+        //                 15      4
+
+        val avlTree = AVLTree<TestLevel>()
+        avlTree.add(TestLevel(20))
+        avlTree.add(TestLevel(4))
+
+        avlTree.add(TestLevel(15))
+        assertEquals(2, avlTree.get(15)?.height)
+        assertEquals(1, avlTree.get(4)?.height)
+        assertEquals(1, avlTree.get(20)?.height)
+    }
+
+    @Test
+    fun testInsert2() {
+        //          20+          20++           20++         9
+        //         /  \         /  \           /  \         / \
+        //        4    26 =>   4-   26 =>     9+   26 =>   4+  20
+        //       / \          / \            / \          /   /  \
+        //      3   9        3   9-         4+  15       3  15    26
+        //                         \       /
+        //                          15    3
+
+        val avlTree = AVLTree<TestLevel>()
+        avlTree.add(TestLevel(20))
+        avlTree.add(TestLevel(4))
+        avlTree.add(TestLevel(26))
+        avlTree.add(TestLevel(3))
+        avlTree.add(TestLevel(9))
+
+        avlTree.add(TestLevel(15))
+        assertEquals(3, avlTree.get(9)?.height)
+        assertEquals(2, avlTree.get(4)?.height)
+        assertEquals(2, avlTree.get(20)?.height)
+        assertEquals(1, avlTree.get(3)?.height)
+        assertEquals(1, avlTree.get(15)?.height)
+        assertEquals(1, avlTree.get(26)?.height)
+    }
+
+    @Test
+    fun testInsert3() {
+        //          20+          20++           20++         9
+        //         /  \         /  \           /  \         / \
+        //        4    26 =>   4-   26 =>     9++  26 =>   4   20-
+        //       / \          / \            /            / \    \
+        //      3   9        3   9+         4            3   8    26
+        //                      /          / \
+        //                     8          3   8
+
+        val avlTree = AVLTree<TestLevel>()
+        avlTree.add(TestLevel(20))
+        avlTree.add(TestLevel(4))
+        avlTree.add(TestLevel(26))
+        avlTree.add(TestLevel(3))
+        avlTree.add(TestLevel(9))
+
+        avlTree.add(TestLevel(8))
+        assertEquals(3, avlTree.get(9)?.height)
+        assertEquals(2, avlTree.get(4)?.height)
+        assertEquals(2, avlTree.get(20)?.height)
+        assertEquals(1, avlTree.get(3)?.height)
+        assertEquals(1, avlTree.get(8)?.height)
+        assertEquals(1, avlTree.get(26)?.height)
+    }
+
+    @Test
+    fun testInsert4() {
+        //            __20+__                _20++_                  __20++_                ___9___
+        //           /       \              /      \                /       \              /       \
+        //          4         26    =>     4-       26    =>       9+        26    =>     4+      __20__
+        //         / \       /  \         / \      /  \           / \       /  \         / \     /      \
+        //        3+  9    21    30      3+  9-  21    30        4+  11-  21    30      3+  7  11-       26
+        //       /   / \                /   / \                 / \   \                /         \      /  \
+        //      2   7   11             2   7   11-             3+  7   15             2           15  21    30
+        //                                       \            /
+        //                                        15         2
+
+        val avlTree = AVLTree<TestLevel>()
+        avlTree.add(TestLevel(20))
+        avlTree.add(TestLevel(4))
+        avlTree.add(TestLevel(26))
+        avlTree.add(TestLevel(3))
+        avlTree.add(TestLevel(9))
+        avlTree.add(TestLevel(21))
+        avlTree.add(TestLevel(30))
+        avlTree.add(TestLevel(2))
+        avlTree.add(TestLevel(7))
+        avlTree.add(TestLevel(11))
+
+        avlTree.add(TestLevel(15))
+        assertEquals(4, avlTree.get(9)?.height)
+        assertEquals(3, avlTree.get(4)?.height)
+        assertEquals(3, avlTree.get(20)?.height)
+        assertEquals(2, avlTree.get(3)?.height)
+        assertEquals(1, avlTree.get(7)?.height)
+        assertEquals(2, avlTree.get(11)?.height)
+        assertEquals(2, avlTree.get(26)?.height)
+        assertEquals(1, avlTree.get(2)?.height)
+        assertEquals(1, avlTree.get(15)?.height)
+        assertEquals(1, avlTree.get(21)?.height)
+        assertEquals(1, avlTree.get(30)?.height)
+    }
+
+    @Test
+    fun testInsertRotate5() {
+        //            __20+__                _20++_                  __20++_                ___9___
+        //           /       \              /      \                /       \              /       \
+        //          4         26           4-       26             9+        26           4        _20-
+        //         / \       /  \         / \      /  \           / \       /  \         / \      /    \
+        //        3+  9    21    30 =>   3+  9+  21    30 =>     4   11   21    30 =>   3+  7-  11      26
+        //       /   / \                /   / \                 / \                    /     \         /  \
+        //      2   7   11             2   7-  11              3+  7-                 2       8      21    30
+        //                                  \                 /     \
+        //                                   8               2       8
+
+        val avlTree = AVLTree<TestLevel>()
+        avlTree.add(TestLevel(20))
+        avlTree.add(TestLevel(4))
+        avlTree.add(TestLevel(26))
+        avlTree.add(TestLevel(3))
+        avlTree.add(TestLevel(9))
+        avlTree.add(TestLevel(21))
+        avlTree.add(TestLevel(30))
+        avlTree.add(TestLevel(2))
+        avlTree.add(TestLevel(7))
+        avlTree.add(TestLevel(11))
+
+        avlTree.add(TestLevel(8))
+        assertEquals(4, avlTree.get(9)?.height)
+        assertEquals(3, avlTree.get(4)?.height)
+        assertEquals(3, avlTree.get(20)?.height)
+        assertEquals(2, avlTree.get(3)?.height)
+        assertEquals(2, avlTree.get(7)?.height)
+        assertEquals(1, avlTree.get(11)?.height)
+        assertEquals(2, avlTree.get(26)?.height)
+        assertEquals(1, avlTree.get(2)?.height)
+        assertEquals(1, avlTree.get(8)?.height)
+        assertEquals(1, avlTree.get(21)?.height)
+        assertEquals(1, avlTree.get(30)?.height)
+    }
+
+    @Test
+    fun testDelete1() {
+        //        2          2            4
+        //       / \          \          / \
+        //      1   4    =>    4    =>  2   5
+        //         / \        / \        \
+        //        3   5      3   5        3
+
+        val avlTree = AVLTree<TestLevel>()
+        avlTree.add(TestLevel(2))
+        avlTree.add(TestLevel(1))
+        avlTree.add(TestLevel(4))
+        avlTree.add(TestLevel(3))
+        avlTree.add(TestLevel(5))
+
+        avlTree.remove(1)
+        assertEquals(3, avlTree.get(4)?.height)
+        assertEquals(2, avlTree.get(2)?.height)
+        assertEquals(1, avlTree.get(5)?.height)
+        assertEquals(1, avlTree.get(3)?.height)
+    }
+
+    @Test
+    fun testDelete2() {
+        //          ___6___                ___6___                 ___6___
+        //         /       \              /       \               /       \
+        //        2         9            2         9             4         9
+        //       / \       / \            \       / \           / \       / \
+        //      1   4     8   11    =>     4     8   11     => 2   5     8   11
+        //         / \   /   / \          / \   /   / \         \       /   / \
+        //        3   5 7   10  12       3   5 7   10  12        3     7   10  12
+        //                       \                      \                       \
+        //                        13                     13                      13
+
+        val avlTree = AVLTree<TestLevel>()
+        avlTree.add(TestLevel(6))
+        avlTree.add(TestLevel(2))
+        avlTree.add(TestLevel(9))
+        avlTree.add(TestLevel(1))
+        avlTree.add(TestLevel(4))
+        avlTree.add(TestLevel(8))
+        avlTree.add(TestLevel(11))
+        avlTree.add(TestLevel(3))
+        avlTree.add(TestLevel(5))
+        avlTree.add(TestLevel(7))
+        avlTree.add(TestLevel(10))
+        avlTree.add(TestLevel(12))
+        avlTree.add(TestLevel(13))
+
+        avlTree.remove(1)
+        assertEquals(5, avlTree.get(6)?.height)
+        assertEquals(3, avlTree.get(4)?.height)
+        assertEquals(4, avlTree.get(9)?.height)
+        assertEquals(2, avlTree.get(2)?.height)
+        assertEquals(1, avlTree.get(5)?.height)
+        assertEquals(2, avlTree.get(8)?.height)
+        assertEquals(3, avlTree.get(11)?.height)
+        assertEquals(1, avlTree.get(3)?.height)
+        assertEquals(1, avlTree.get(7)?.height)
+        assertEquals(1, avlTree.get(10)?.height)
+        assertEquals(2, avlTree.get(12)?.height)
+        assertEquals(1, avlTree.get(13)?.height)
+    }
+
+    @Test
+    fun testDelete3() {
+        //          ___5___              ___5___                 ___5___                   ____8____
+        //         /       \            /       \               /       \                 /         \
+        //        2         8          2         8             3         8              _5_          10
+        //       / \       / \          \       / \           / \       / \            /   \        / \
+        //      1   3     7   10    =>   3     7   10     => 2   4     7   10    =>   3     7      9   11
+        //           \   /   / \          \   /   / \                 /   / \        / \   /            \
+        //            4 6   9   11         4 6   9   11              6   9   11     2   4 6              12
+        //                       \                    \                       \
+        //                        12                   12                      12
+
+        val avlTree = AVLTree<TestLevel>()
+        avlTree.add(TestLevel(5))
+        avlTree.add(TestLevel(2))
+        avlTree.add(TestLevel(8))
+        avlTree.add(TestLevel(1))
+        avlTree.add(TestLevel(3))
+        avlTree.add(TestLevel(7))
+        avlTree.add(TestLevel(10))
+        avlTree.add(TestLevel(4))
+        avlTree.add(TestLevel(6))
+        avlTree.add(TestLevel(9))
+        avlTree.add(TestLevel(11))
+        avlTree.add(TestLevel(12))
+
+        avlTree.remove(1)
+        assertEquals(4, avlTree.get(8)?.height)
+        assertEquals(3, avlTree.get(5)?.height)
+        assertEquals(3, avlTree.get(10)?.height)
+        assertEquals(2, avlTree.get(3)?.height)
+        assertEquals(2, avlTree.get(7)?.height)
+        assertEquals(1, avlTree.get(9)?.height)
+        assertEquals(2, avlTree.get(11)?.height)
+        assertEquals(1, avlTree.get(2)?.height)
+        assertEquals(1, avlTree.get(4)?.height)
+        assertEquals(1, avlTree.get(6)?.height)
+        assertEquals(1, avlTree.get(12)?.height)
+    }
+}

--- a/sequencer/src/test/kotlin/co/chainring/datastructure/TestObjectPool.kt
+++ b/sequencer/src/test/kotlin/co/chainring/datastructure/TestObjectPool.kt
@@ -1,4 +1,4 @@
-package co.chainring
+package co.chainring.datastructure
 
 import co.chainring.sequencer.core.datastructure.ObjectPool
 import org.junit.jupiter.api.Test

--- a/sequencer/src/test/kotlin/co/chainring/testutils/Assertions.kt
+++ b/sequencer/src/test/kotlin/co/chainring/testutils/Assertions.kt
@@ -1,7 +1,6 @@
 package co.chainring.testutils
 
 import co.chainring.sequencer.core.WalletAddress
-import co.chainring.sequencer.core.toBigDecimal
 import co.chainring.sequencer.core.toWalletAddress
 import co.chainring.sequencer.proto.SequencerResponse
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -32,7 +31,7 @@ fun SequencerResponse.assertTrades(
             ExpectedTrade(
                 buyOrderGuid = it.buyOrderGuid,
                 sellOrderGuid = it.sellOrderGuid,
-                price = it.price.toBigDecimal(),
+                price = market.tickSize.multiply(it.levelIx.toBigDecimal()),
                 amount = it.amount.fromFundamentalUnits(market.baseDecimals),
                 buyerFee = it.buyerFee.fromFundamentalUnits(market.quoteDecimals),
                 sellerFee = it.sellerFee.fromFundamentalUnits(market.quoteDecimals),

--- a/sequencer/src/test/kotlin/co/chainring/testutils/SequencerClient.kt
+++ b/sequencer/src/test/kotlin/co/chainring/testutils/SequencerClient.kt
@@ -46,6 +46,7 @@ class SequencerClient {
 
     data class Market(
         val id: MarketId,
+        val tickSize: BigDecimal,
         val baseDecimals: Int,
         val quoteDecimals: Int,
     ) {
@@ -79,7 +80,7 @@ class SequencerClient {
                         order {
                             this.guid = Random.nextLong()
                             this.amount = amount.toFundamentalUnits(market.baseDecimals).toIntegerValue()
-                            this.price = price?.toDecimalValue() ?: BigDecimal.ZERO.toDecimalValue()
+                            this.levelIx = price?.divideToIntegralValue(market.tickSize)?.toInt() ?: 0
                             this.type = orderType
                             this.percentage = percentage
                         },
@@ -117,7 +118,7 @@ class SequencerClient {
                     order {
                         this.guid = guid.value
                         this.amount = amount.toFundamentalUnits(market.baseDecimals).toIntegerValue()
-                        this.price = price.toDecimalValue()
+                        this.levelIx = price.divideToIntegralValue(market.tickSize).toInt()
                     },
                 )
             }
@@ -164,7 +165,12 @@ class SequencerClient {
         assertEquals(baseDecimals, createdMarket.baseDecimals)
         assertEquals(quoteDecimals, createdMarket.quoteDecimals)
 
-        return Market(marketId, baseDecimals = createdMarket.baseDecimals, quoteDecimals = createdMarket.quoteDecimals)
+        return Market(
+            marketId,
+            tickSize = createdMarket.tickSize.toBigDecimal(),
+            baseDecimals = createdMarket.baseDecimals,
+            quoteDecimals = createdMarket.quoteDecimals,
+        )
     }
 
     fun setFeeRates(feeRates: FeeRates) {

--- a/sequencer/src/test/kotlin/co/chainring/testutils/SequencerClient.kt
+++ b/sequencer/src/test/kotlin/co/chainring/testutils/SequencerClient.kt
@@ -142,7 +142,7 @@ class SequencerClient {
             },
         )
 
-    fun createMarket(marketId: MarketId, tickSize: BigDecimal = "0.05".toBigDecimal(), marketPrice: BigDecimal = "17.525".toBigDecimal(), baseDecimals: Int = 8, quoteDecimals: Int = 18): Market {
+    fun createMarket(marketId: MarketId, tickSize: BigDecimal = "0.05".toBigDecimal(), baseDecimals: Int = 8, quoteDecimals: Int = 18): Market {
         val createMarketResponse = sequencer.processRequest(
             sequencerRequest {
                 this.guid = UUID.randomUUID().toString()
@@ -151,9 +151,7 @@ class SequencerClient {
                     this.guid = UUID.randomUUID().toString()
                     this.marketId = marketId.value
                     this.tickSize = tickSize.toDecimalValue()
-                    this.maxLevels = 1000
                     this.maxOrdersPerLevel = 1000
-                    this.marketPrice = marketPrice.toDecimalValue()
                     this.baseDecimals = baseDecimals
                     this.quoteDecimals = quoteDecimals
                 }

--- a/sequencercommon/src/main/proto/checkpoint.proto
+++ b/sequencercommon/src/main/proto/checkpoint.proto
@@ -38,19 +38,15 @@ message BalancesCheckpoint {
 message MarketCheckpoint {
   string id = 1;
   DecimalValue tickSize = 2;
-  DecimalValue marketPrice = 3;
-  uint32 maxLevels = 4;
-  uint32 maxOrdersPerLevel = 5;
-  uint32 baseDecimals = 6;
-  uint32 quoteDecimals = 7;
-  int32 maxOfferIx = 8;
+  uint32 maxOrdersPerLevel = 3;
+  uint32 baseDecimals = 4;
+  uint32 quoteDecimals = 5;
+  int32 maxOfferIx = 6;
+  int32 bestOfferIx = 7;
+  int32 bestBidIx = 8;
   int32 minBidIx = 9;
   repeated OrderBookLevel levels = 10;
-  DecimalValue bestBid = 11;    // legacy
-  DecimalValue bestOffer = 12;  // legacy
-  IntegerValue minFee = 13;
-  int32 bestBidIx = 14;
-  int32 bestOfferIx = 15;
+  IntegerValue minFee = 11;
 
   message OrderBookLevel {
     int32 levelIx = 1;

--- a/sequencercommon/src/main/proto/checkpoint.proto
+++ b/sequencercommon/src/main/proto/checkpoint.proto
@@ -68,7 +68,6 @@ message MarketCheckpoint {
     uint64 guid = 1;
     uint64 wallet = 2;
     IntegerValue quantity = 3;
-    uint32 levelIx = 4;
     IntegerValue originalQuantity = 5;
     uint64 feeRate = 6;
   }

--- a/sequencercommon/src/main/proto/checkpoint.proto
+++ b/sequencercommon/src/main/proto/checkpoint.proto
@@ -46,9 +46,11 @@ message MarketCheckpoint {
   int32 maxOfferIx = 8;
   int32 minBidIx = 9;
   repeated OrderBookLevel levels = 10;
-  DecimalValue bestBid = 11;
-  DecimalValue bestOffer = 12;
+  DecimalValue bestBid = 11;    // legacy
+  DecimalValue bestOffer = 12;  // legacy
   IntegerValue minFee = 13;
+  int32 bestBidIx = 14;
+  int32 bestOfferIx = 15;
 
   message OrderBookLevel {
     int32 levelIx = 1;

--- a/sequencercommon/src/main/proto/market.proto
+++ b/sequencercommon/src/main/proto/market.proto
@@ -9,13 +9,11 @@ option java_outer_classname = "MarketSchema";
 message Market {
   string guid = 1;
   string marketId = 2;
-  DecimalValue marketPrice = 3;
-  DecimalValue tickSize = 4;
-  uint32 maxLevels = 5;
-  uint32 maxOrdersPerLevel = 6;
-  uint32 baseDecimals = 7;
-  uint32 quoteDecimals = 8;
-  optional IntegerValue minFee = 9;
+  DecimalValue tickSize = 3;
+  uint32 maxOrdersPerLevel = 4;
+  uint32 baseDecimals = 5;
+  uint32 quoteDecimals = 6;
+  optional IntegerValue minFee = 7;
 }
 
 message MarketMinFee {

--- a/sequencercommon/src/main/proto/order.proto
+++ b/sequencercommon/src/main/proto/order.proto
@@ -18,9 +18,9 @@ message Order {
 
   Type type = 3;
   IntegerValue amount = 4;
-  optional DecimalValue price = 5; // required for limit orders
+  optional int32 levelIx = 5; // required for limit orders
   optional IntegerValue nonce = 6; // required for add order
-  optional string signature = 7; // required for add order (created CHAIN-123 as order updates should require a new signature)
+  optional string signature = 7; // required for add order
   string externalGuid = 8;
   uint32 chainId = 9; // the chain id used when creating the signature - does not need to be related to the chain(s) of the market
   optional uint32 percentage = 10;

--- a/sequencercommon/src/main/proto/sequencer.proto
+++ b/sequencercommon/src/main/proto/sequencer.proto
@@ -53,6 +53,8 @@ message BidOfferState {
   int32 minBidIx = 2;
   DecimalValue bestBid = 3;
   DecimalValue bestOffer = 4;
+  int32 bestBidIx = 5;
+  int32 bestOfferIx = 6;
 }
 
 message SequencerRequest {

--- a/sequencercommon/src/main/proto/sequencer.proto
+++ b/sequencercommon/src/main/proto/sequencer.proto
@@ -38,9 +38,7 @@ message MarketCreated {
   DecimalValue tickSize = 2;
   uint32 baseDecimals = 3;
   uint32 quoteDecimals = 4;
-  DecimalValue maxAllowedOffer = 5;
-  DecimalValue minAllowedBid = 6;
-  optional IntegerValue minFee = 7;
+  optional IntegerValue minFee = 6;
 }
 
 message FeeRates {
@@ -51,8 +49,8 @@ message FeeRates {
 message BidOfferState {
   int32 maxOfferIx = 1;
   int32 minBidIx = 2;
-  int32 bestBidIx = 5;
-  int32 bestOfferIx = 6;
+  int32 bestBidIx = 3;
+  int32 bestOfferIx = 4;
 }
 
 message SequencerRequest {
@@ -83,9 +81,8 @@ enum SequencerError {
   UnknownMarket = 3;
   ExceedsLimit = 4;
   InvalidFeeRate = 5;
-  InvalidPrice = 6;
-  InvalidWithdrawalFee = 7;
-  InvalidMarketMinFee = 8;
+  InvalidWithdrawalFee = 6;
+  InvalidMarketMinFee = 7;
 }
 
 message StateDump {

--- a/sequencercommon/src/main/proto/sequencer.proto
+++ b/sequencercommon/src/main/proto/sequencer.proto
@@ -51,8 +51,6 @@ message FeeRates {
 message BidOfferState {
   int32 maxOfferIx = 1;
   int32 minBidIx = 2;
-  DecimalValue bestBid = 3;
-  DecimalValue bestOffer = 4;
   int32 bestBidIx = 5;
   int32 bestOfferIx = 6;
 }

--- a/sequencercommon/src/main/proto/trade.proto
+++ b/sequencercommon/src/main/proto/trade.proto
@@ -10,7 +10,7 @@ message TradeCreated {
   uint64 buyOrderGuid = 1;
   uint64 sellOrderGuid = 2;
   IntegerValue amount = 3;
-  DecimalValue price = 4;
+  int32 levelIx = 4;
   IntegerValue buyerFee = 5;
   IntegerValue sellerFee = 6;
 }

--- a/src/main/kotlin/co/chainring/tasks/SeedDatabase.kt
+++ b/src/main/kotlin/co/chainring/tasks/SeedDatabase.kt
@@ -66,14 +66,14 @@ fun seedDatabase(fixtures: Fixtures, symbolContractAddresses: List<SymbolContrac
 
         }.associateBy { it.id.value }
 
-        fixtures.markets.forEach { (baseSymbolId, quoteSymbolId, tickSize, marketPrice, minFee) ->
+        fixtures.markets.forEach { (baseSymbolId, quoteSymbolId, tickSize, lastPrice, minFee) ->
             val baseSymbol = symbolEntities.getValue(baseSymbolId)
             val quoteSymbol = symbolEntities.getValue(quoteSymbolId)
 
             when (val marketEntity = MarketEntity.findById(MarketId(baseSymbol, quoteSymbol))) {
                 null -> {
                     MarketEntity
-                        .create(baseSymbol, quoteSymbol, tickSize, marketPrice, minFee.toFundamentalUnits(quoteSymbol.decimals))
+                        .create(baseSymbol, quoteSymbol, tickSize, lastPrice, minFee.toFundamentalUnits(quoteSymbol.decimals))
                         .also {
                             it.flush()
                             println("Created market ${it.guid.value}")
@@ -81,7 +81,7 @@ fun seedDatabase(fixtures: Fixtures, symbolContractAddresses: List<SymbolContrac
                             OHLCEntity.updateWith(
                                 market = it.guid.value,
                                 tradeTimestamp = Clock.System.now() - 1.hours,
-                                tradePrice = marketPrice,
+                                tradePrice = lastPrice,
                                 tradeAmount = BigInteger.ZERO,
                             )
                         }

--- a/src/main/kotlin/co/chainring/tasks/SeedSequencer.kt
+++ b/src/main/kotlin/co/chainring/tasks/SeedSequencer.kt
@@ -29,7 +29,6 @@ fun seedSequencer(fixtures: Fixtures) {
             sequencerClient.createMarket(
                 marketId = "${baseSymbol.name}/${quoteSymbol.name}",
                 tickSize = market.tickSize,
-                marketPrice = market.marketPrice,
                 quoteDecimals = quoteSymbol.decimals,
                 baseDecimals = baseSymbol.decimals,
                 minFee = market.minFee

--- a/src/main/kotlin/co/chainring/tasks/fixtures/Fixtures.kt
+++ b/src/main/kotlin/co/chainring/tasks/fixtures/Fixtures.kt
@@ -39,7 +39,7 @@ data class Fixtures(
         val baseSymbol: SymbolId,
         val quoteSymbol: SymbolId,
         val tickSize: BigDecimal,
-        val marketPrice: BigDecimal,
+        val lastPrice: BigDecimal,
         val minFee: BigDecimal
     )
 
@@ -73,21 +73,21 @@ fun getFixtures(chainringChainClients: List<BlockchainClient>) = Fixtures(
                 baseSymbol = SymbolId(client.chainId, "BTC"),
                 quoteSymbol = SymbolId(client.chainId, "ETH"),
                 tickSize = "0.05".toBigDecimal(),
-                marketPrice = "17.525".toBigDecimal(),
+                lastPrice = "17.525".toBigDecimal(),
                 minFee = BigDecimal("0.00001")
             ),
             Fixtures.Market(
                 baseSymbol = SymbolId(client.chainId, "USDC"),
                 quoteSymbol = SymbolId(client.chainId, "DAI"),
                 tickSize = "0.01".toBigDecimal(),
-                marketPrice = "2.005".toBigDecimal(),
+                lastPrice = "2.005".toBigDecimal(),
                 minFee = BigDecimal("0.02")
             ),
             Fixtures.Market(
                 baseSymbol = SymbolId(client.chainId, "BTC"),
                 quoteSymbol = SymbolId(client.chainId, "USDC"),
                 tickSize = "25.00".toBigDecimal(),
-                marketPrice = "60812.500".toBigDecimal(),
+                lastPrice = "60812.500".toBigDecimal(),
                 minFee = BigDecimal("0.02")
             ),
         )
@@ -96,14 +96,14 @@ fun getFixtures(chainringChainClients: List<BlockchainClient>) = Fixtures(
             baseSymbol = SymbolId(chainringChainClients[0].chainId, "BTC"),
             quoteSymbol = SymbolId(chainringChainClients[1].chainId, "BTC"),
             tickSize = "0.001".toBigDecimal(),
-            marketPrice = "1.0005".toBigDecimal(),
+            lastPrice = "1.0005".toBigDecimal(),
             minFee = BigDecimal("0.000005")
         ),
         Fixtures.Market(
             baseSymbol = SymbolId(chainringChainClients[0].chainId, "BTC"),
             quoteSymbol = SymbolId(chainringChainClients[1].chainId, "ETH"),
             tickSize = "0.05".toBigDecimal(),
-            marketPrice = "17.525".toBigDecimal(),
+            lastPrice = "17.525".toBigDecimal(),
             BigDecimal("0.00001")
         ),
     ) else emptyList(),


### PR DESCRIPTION
 - balanced binary tree used for store market levels
 - also object pool used to avoid GC when working with levels. Initial capacity is 1000 levels.
 - `levelIx` is now representing number of ticks from 0 to the `price` (`levelIx * tickSize = level price`). No need to resolve level by levelIx to get price. 
     - `price` can be potentially dropped from the level. 
 - best bid/offer prices are represented as `Ix` with -1 if side is empty
 - unused proto fields removed (initial price, max number of levels). Migration is not backward compatible
 
==
 - level re-use requires updating all level orders with new `levelIx`. Testing performance, potentially could be replaced with the link to the level
 - some test still in progress

==
 -  `minAllowedBidPrice` and `maxAllowedOfferPrice` are removed from sequencer protocol, but will be removed from market and FE in a separate ticket. On FE those might be useful to introduce logical limits (e.g +/-50% deviation from current market price)
 