### PR TITLE
CHAIN-371: back to back orders

### DIFF
--- a/backend/src/main/kotlin/co/chainring/apps/api/Examples.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/Examples.kt
@@ -112,6 +112,7 @@ object Examples {
                 role = ExecutionRole.Maker,
                 feeAmount = BigInteger("0"),
                 feeSymbol = Symbol("ETH"),
+                marketId = MarketId("BTC/ETH"),
             ),
         ),
         timing = Order.Timing(
@@ -138,6 +139,7 @@ object Examples {
                 role = ExecutionRole.Maker,
                 feeAmount = BigInteger("0"),
                 feeSymbol = Symbol("ETH"),
+                marketId = MarketId("BTC/ETH"),
             ),
         ),
         timing = Order.Timing(

--- a/backend/src/main/kotlin/co/chainring/apps/api/model/Orders.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/model/Orders.kt
@@ -77,6 +77,18 @@ sealed class CreateOrderApiRequest {
     ) : CreateOrderApiRequest()
 
     @Serializable
+    @SerialName("backToBackMarket")
+    data class BackToBackMarket(
+        override val nonce: String,
+        override val marketId: MarketId,
+        val secondMarketId: MarketId,
+        override val side: OrderSide,
+        override val amount: OrderAmount,
+        override val signature: EvmSignature,
+        override val verifyingChainId: ChainId,
+    ) : CreateOrderApiRequest()
+
+    @Serializable
     @SerialName("limit")
     data class Limit(
         override val nonce: String,
@@ -167,6 +179,20 @@ sealed class Order {
     ) : Order()
 
     @Serializable
+    @SerialName("backToBackMarket")
+    data class BackToBackMarket(
+        override val id: OrderId,
+        override val status: OrderStatus,
+        override val marketId: MarketId,
+        val secondMarketId: MarketId,
+        override val side: OrderSide,
+        override val amount: BigIntegerJson,
+        override val originalAmount: BigIntegerJson,
+        override val executions: List<Execution>,
+        override val timing: Timing,
+    ) : Order()
+
+    @Serializable
     @SerialName("limit")
     data class Limit(
         override val id: OrderId,
@@ -188,6 +214,7 @@ sealed class Order {
         val role: ExecutionRole,
         val feeAmount: BigIntegerJson,
         val feeSymbol: Symbol,
+        val marketId: MarketId,
     )
 
     @Serializable

--- a/backend/src/main/kotlin/co/chainring/core/db/Migrations.kt
+++ b/backend/src/main/kotlin/co/chainring/core/db/Migrations.kt
@@ -57,6 +57,7 @@ import co.chainring.core.model.db.migrations.V59_NullableDepositBlockNumber
 import co.chainring.core.model.db.migrations.V5_ChainTable
 import co.chainring.core.model.db.migrations.V60_AddResponseSequenceToTradeAndWithdrawal
 import co.chainring.core.model.db.migrations.V61_CreateBlockTable
+import co.chainring.core.model.db.migrations.V62_BackToBackOrders
 import co.chainring.core.model.db.migrations.V6_MarketTable
 import co.chainring.core.model.db.migrations.V7_OrderTable
 import co.chainring.core.model.db.migrations.V8_ExecutionsAndTrades
@@ -124,4 +125,5 @@ val migrations = listOf(
     V59_NullableDepositBlockNumber(),
     V60_AddResponseSequenceToTradeAndWithdrawal(),
     V61_CreateBlockTable(),
+    V62_BackToBackOrders(),
 )

--- a/backend/src/main/kotlin/co/chainring/core/model/db/migrations/V62_BackToBackOrders.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/migrations/V62_BackToBackOrders.kt
@@ -1,0 +1,44 @@
+package co.chainring.core.model.db.migrations
+
+import co.chainring.core.db.Migration
+import co.chainring.core.db.updateEnum
+import co.chainring.core.model.db.ExecutionId
+import co.chainring.core.model.db.GUIDTable
+import co.chainring.core.model.db.MarketId
+import co.chainring.core.model.db.OrderId
+import co.chainring.core.model.db.PGEnum
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.transactions.transaction
+
+@Suppress("ClassName")
+class V62_BackToBackOrders : Migration() {
+
+    enum class V62_OrderType {
+        Market,
+        Limit,
+        BackToBackMarket,
+    }
+
+    object V62MarketTable : GUIDTable<MarketId>("market", ::MarketId)
+
+    object V62_OrderTable : GUIDTable<OrderId>("order", ::OrderId) {
+        val type = customEnumeration(
+            "type",
+            "OrderType",
+            { value -> V62_OrderType.valueOf(value as String) },
+            { PGEnum("OrderType", it) },
+        )
+        val secondMarketGuid = reference("second_market_guid", V62MarketTable).nullable()
+    }
+
+    object V62_OrderExecutionTable : GUIDTable<ExecutionId>("order_execution", ::ExecutionId) {
+        val marketGuid = reference("market_guid", V62MarketTable).nullable()
+    }
+
+    override fun run() {
+        transaction {
+            updateEnum<V62_OrderType>(listOf(V62_OrderTable.type), "OrderType")
+            SchemaUtils.createMissingTablesAndColumns(V62_OrderTable, V62_OrderExecutionTable)
+        }
+    }
+}

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/BackToBackOrderTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/BackToBackOrderTest.kt
@@ -1,0 +1,405 @@
+package co.chainring.integrationtests.api
+
+import co.chainring.apps.api.model.BatchOrdersApiRequest
+import co.chainring.apps.api.model.CreateOrderApiRequest
+import co.chainring.apps.api.model.OrderAmount
+import co.chainring.apps.api.model.RequestStatus
+import co.chainring.core.model.EvmSignature
+import co.chainring.core.model.Percentage
+import co.chainring.core.model.db.ChainId
+import co.chainring.core.model.db.OrderSide
+import co.chainring.core.model.db.OrderStatus
+import co.chainring.core.utils.generateOrderNonce
+import co.chainring.core.utils.toFundamentalUnits
+import co.chainring.integrationtests.testutils.AppUnderTestRunner
+import co.chainring.integrationtests.testutils.OrderBaseTest
+import co.chainring.integrationtests.utils.AssetAmount
+import co.chainring.integrationtests.utils.ExpectedBalance
+import co.chainring.integrationtests.utils.assertBalances
+import co.chainring.integrationtests.utils.assertBalancesMessageReceived
+import co.chainring.integrationtests.utils.assertLimitsMessageReceived
+import co.chainring.integrationtests.utils.assertOrderCreatedMessageReceived
+import co.chainring.integrationtests.utils.assertOrderUpdatedMessageReceived
+import co.chainring.integrationtests.utils.assertTradeCreatedMessageReceived
+import co.chainring.integrationtests.utils.ofAsset
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.test.Test
+
+@ExtendWith(AppUnderTestRunner::class)
+class BackToBackOrderTest : OrderBaseTest() {
+
+    @Test
+    fun `back to back - market sell - swap btc for eth2`() {
+        val (market, baseSymbol, bridgeSymbol) = Triple(btcbtc2Market, btc, btc2)
+        val (secondMarket, _, quoteSymbol) = Triple(btc2Eth2Market, btc2, eth2)
+
+        val (makerApiClient, makerWallet, makerWsClient) = setupTrader(
+            secondMarket.id,
+            airdrops = listOf(
+                AssetAmount(bridgeSymbol, "1.0"),
+                AssetAmount(quoteSymbol, "20"),
+            ),
+            deposits = listOf(
+                AssetAmount(bridgeSymbol, "0.9"),
+                AssetAmount(quoteSymbol, "20"),
+            ),
+            subscribeToOrderBook = false,
+            subscribeToOrderPrices = false,
+        )
+
+        val (takerApiClient, takerWallet, takerWsClient) = setupTrader(
+            market.id,
+            airdrops = listOf(
+                AssetAmount(baseSymbol, "0.7"),
+            ),
+            deposits = listOf(
+                AssetAmount(baseSymbol, "0.6"),
+            ),
+            subscribeToOrderBook = false,
+            subscribeToOrderPrices = false,
+        )
+
+        // starting onchain balances
+        val makerStartingBaseBalance = makerWallet.getExchangeBalance(baseSymbol)
+        val makerStartingBridgeBalance = makerWallet.getExchangeBalance(bridgeSymbol)
+        val makerStartingQuoteBalance = makerWallet.getExchangeBalance(quoteSymbol)
+        val takerStartingBaseBalance = takerWallet.getExchangeBalance(baseSymbol)
+        val takerStartingQuoteBalance = takerWallet.getExchangeBalance(quoteSymbol)
+
+        val limitBuyOrder1 = makerApiClient.batchOrders(
+            BatchOrdersApiRequest(
+                marketId = market.id,
+                createOrders = listOf(
+                    makerWallet.signOrder(
+                        CreateOrderApiRequest.Limit(
+                            nonce = generateOrderNonce(),
+                            marketId = market.id,
+                            side = OrderSide.Buy,
+                            amount = OrderAmount.Fixed(AssetAmount(baseSymbol, BigDecimal("0.8")).inFundamentalUnits),
+                            price = BigDecimal("0.95"),
+                            signature = EvmSignature.emptySignature(),
+                            verifyingChainId = ChainId.empty,
+                        ),
+                    ),
+                ),
+                updateOrders = listOf(),
+                cancelOrders = listOf(),
+            ),
+        )
+        val limitBuyOrder2 = makerApiClient.batchOrders(
+            BatchOrdersApiRequest(
+                marketId = secondMarket.id,
+                createOrders = listOf(
+                    makerWallet.signOrder(
+                        CreateOrderApiRequest.Limit(
+                            nonce = generateOrderNonce(),
+                            marketId = secondMarket.id,
+                            side = OrderSide.Buy,
+                            amount = OrderAmount.Fixed(AssetAmount(bridgeSymbol, BigDecimal("1")).inFundamentalUnits),
+                            price = BigDecimal("18.000"),
+                            signature = EvmSignature.emptySignature(),
+                            verifyingChainId = ChainId.empty,
+                        ),
+                    ),
+                ),
+                updateOrders = listOf(),
+                cancelOrders = listOf(),
+            ),
+        )
+
+        assertEquals(1, limitBuyOrder1.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
+        assertEquals(1, limitBuyOrder2.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
+
+        repeat(2) { makerWsClient.assertOrderCreatedMessageReceived() }
+        makerWsClient.assertLimitsMessageReceived(secondMarket.id)
+
+        assertEquals(2, makerApiClient.listOrders(listOf(OrderStatus.Open), null).orders.size)
+
+        takerApiClient.createBackToBackMarketOrder(
+            listOf(market, secondMarket),
+            OrderSide.Sell,
+            amount = null,
+            takerWallet,
+            percentage = Percentage(100),
+        )
+
+        takerWsClient.apply {
+            assertOrderCreatedMessageReceived()
+            assertTradeCreatedMessageReceived {
+                assertEquals(btcbtc2Market.id, it.trade.marketId)
+                assertEquals(OrderSide.Sell, it.trade.side)
+                assertEquals(takerStartingBaseBalance.inFundamentalUnits, it.trade.amount)
+                assertEquals(BigDecimal("0.95").setScale(18), it.trade.price)
+                assertEquals(BigInteger.ZERO, it.trade.feeAmount)
+                assertEquals(btc2.name, it.trade.feeSymbol.value)
+            }
+            assertTradeCreatedMessageReceived {
+                assertEquals(btc2Eth2Market.id, it.trade.marketId)
+                assertEquals(OrderSide.Sell, it.trade.side)
+                assertEquals((BigDecimal("0.95") * BigDecimal("0.6")).toFundamentalUnits(btc2.decimals), it.trade.amount)
+                assertEquals(BigDecimal("18.00").setScale(18), it.trade.price)
+                assertEquals(BigDecimal("0.2052").toFundamentalUnits(eth2.decimals), it.trade.feeAmount)
+                assertEquals(eth2.name, it.trade.feeSymbol.value)
+            }
+            assertOrderUpdatedMessageReceived {
+                assertEquals(BigDecimal("0.6").toFundamentalUnits(market.baseDecimals), it.order.amount)
+                assertEquals(it.order.status, OrderStatus.Filled)
+            }
+            assertBalancesMessageReceived(
+                listOf(
+                    ExpectedBalance(baseSymbol, total = BigDecimal("0.6"), available = BigDecimal("0")),
+                    ExpectedBalance(quoteSymbol, total = BigDecimal("0"), available = BigDecimal("10.0548")),
+                ),
+            )
+            assertLimitsMessageReceived(market.id)
+        }
+
+        makerWsClient.apply {
+            repeat(2) { assertTradeCreatedMessageReceived() }
+            repeat(2) { assertOrderUpdatedMessageReceived() }
+            assertBalancesMessageReceived()
+            assertLimitsMessageReceived(secondMarket.id)
+        }
+
+        val takerOrders = takerApiClient.listOrders(emptyList(), market.id).orders
+        assertEquals(1, takerOrders.count { it.status == OrderStatus.Filled })
+
+        assertEquals(2, makerApiClient.listOrders(listOf(OrderStatus.Filled, OrderStatus.Partial)).orders.size)
+
+        // now verify the trades
+        val trades = getTradesForOrders(takerOrders.map { it.id })
+        assertEquals(2, trades.size)
+
+        waitForSettlementToFinish(trades.map { it.id.value })
+
+        val trade1 = trades.first { it.marketGuid.value == market.id }
+        val trade2 = trades.first { it.marketGuid.value == secondMarket.id }
+
+        assertEquals(trade1.amount, takerStartingBaseBalance.inFundamentalUnits)
+        assertEquals(trade1.price, BigDecimal("0.95").setScale(18))
+
+        assertEquals(trade2.amount, (BigDecimal("0.95") * BigDecimal("0.6")).toFundamentalUnits(btc2.decimals))
+        assertEquals(trade2.price, BigDecimal("18.00").setScale(18))
+
+        val notionalTrade1 = trade1.price.ofAsset(bridgeSymbol) * AssetAmount(baseSymbol, trade1.amount).amount
+        val notionalTrade2 = trade2.price.ofAsset(quoteSymbol) * AssetAmount(bridgeSymbol, trade2.amount).amount
+
+        val makerFeeTrade1 = notionalTrade1 * BigDecimal("0.01")
+        val makerFeeTrade2 = notionalTrade2 * BigDecimal("0.01")
+        val takerFee = notionalTrade2 * BigDecimal("0.02")
+
+        assertBalances(
+            listOf(
+                ExpectedBalance(makerStartingBaseBalance + takerStartingBaseBalance),
+                ExpectedBalance(makerStartingBridgeBalance - makerFeeTrade1),
+                ExpectedBalance(makerStartingQuoteBalance - notionalTrade2 - makerFeeTrade2),
+            ),
+            makerApiClient.getBalances().balances,
+        )
+        assertBalances(
+            listOf(
+                ExpectedBalance(takerStartingBaseBalance - takerStartingBaseBalance),
+                ExpectedBalance(takerStartingQuoteBalance + notionalTrade2 - takerFee),
+            ),
+            takerApiClient.getBalances().balances,
+        )
+
+        takerApiClient.cancelOpenOrders()
+        makerApiClient.cancelOpenOrders()
+
+        makerWsClient.close()
+        takerWsClient.close()
+    }
+
+    @Test
+    fun `back to back - market buy - swap eth2 for btc`() {
+        val (market, baseSymbol, bridgeSymbol) = Triple(btcbtc2Market, btc, btc2)
+        val (secondMarket, _, quoteSymbol) = Triple(btc2Eth2Market, btc2, eth2)
+
+        val (makerApiClient, makerWallet, makerWsClient) = setupTrader(
+            market.id,
+            airdrops = listOf(
+                AssetAmount(bridgeSymbol, "1.0"),
+                AssetAmount(baseSymbol, "1.0"),
+            ),
+            deposits = listOf(
+                AssetAmount(bridgeSymbol, "0.9"),
+                AssetAmount(baseSymbol, "0.9"),
+            ),
+            subscribeToOrderBook = false,
+            subscribeToOrderPrices = false,
+        )
+
+        val (takerApiClient, takerWallet, takerWsClient) = setupTrader(
+            secondMarket.id,
+            airdrops = listOf(
+                AssetAmount(bridgeSymbol, "0.1"),
+                AssetAmount(quoteSymbol, "10"),
+            ),
+            deposits = listOf(
+                AssetAmount(quoteSymbol, "10"),
+            ),
+            subscribeToOrderBook = false,
+            subscribeToOrderPrices = false,
+        )
+
+        // starting onchain balances
+        val makerStartingBaseBalance = makerWallet.getExchangeBalance(baseSymbol)
+        val makerStartingBridgeBalance = makerWallet.getExchangeBalance(bridgeSymbol)
+        val makerStartingQuoteBalance = makerWallet.getExchangeBalance(quoteSymbol)
+        val takerStartingBaseBalance = takerWallet.getExchangeBalance(baseSymbol)
+        val takerStartingQuoteBalance = takerWallet.getExchangeBalance(quoteSymbol)
+
+        val bridgePrice = BigDecimal("1.05")
+        val quotePrice = BigDecimal("18")
+        val baseOrderAmount = AssetAmount(btc, BigDecimal("0.5"))
+        val bridgeOrderAmount = AssetAmount(btc2, baseOrderAmount.amount * bridgePrice)
+
+        val limitSellOrder1 = makerApiClient.batchOrders(
+            BatchOrdersApiRequest(
+                marketId = market.id,
+                createOrders = listOf(
+                    makerWallet.signOrder(
+                        CreateOrderApiRequest.Limit(
+                            nonce = generateOrderNonce(),
+                            marketId = market.id,
+                            side = OrderSide.Sell,
+                            amount = OrderAmount.Fixed(AssetAmount(baseSymbol, BigDecimal("0.8")).inFundamentalUnits),
+                            price = bridgePrice,
+                            signature = EvmSignature.emptySignature(),
+                            verifyingChainId = ChainId.empty,
+                        ),
+                    ),
+                ),
+                updateOrders = listOf(),
+                cancelOrders = listOf(),
+            ),
+        )
+        val limitSellOrder2 = makerApiClient.batchOrders(
+            BatchOrdersApiRequest(
+                marketId = secondMarket.id,
+                createOrders = listOf(
+                    makerWallet.signOrder(
+                        CreateOrderApiRequest.Limit(
+                            nonce = generateOrderNonce(),
+                            marketId = secondMarket.id,
+                            side = OrderSide.Sell,
+                            amount = OrderAmount.Fixed(AssetAmount(bridgeSymbol, BigDecimal("0.8")).inFundamentalUnits),
+                            price = quotePrice,
+                            signature = EvmSignature.emptySignature(),
+                            verifyingChainId = ChainId.empty,
+                        ),
+                    ),
+                ),
+                updateOrders = listOf(),
+                cancelOrders = listOf(),
+            ),
+        )
+
+        assertEquals(1, limitSellOrder1.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
+        assertEquals(1, limitSellOrder2.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
+
+        makerWsClient.assertOrderCreatedMessageReceived()
+        makerWsClient.assertLimitsMessageReceived(market.id)
+        makerWsClient.assertOrderCreatedMessageReceived()
+
+        assertEquals(2, makerApiClient.listOrders(listOf(OrderStatus.Open), null).orders.size)
+
+        takerApiClient.createBackToBackMarketOrder(
+            listOf(market, secondMarket),
+            OrderSide.Buy,
+            amount = BigDecimal("0.5"),
+            takerWallet,
+        )
+
+        takerWsClient.apply {
+            assertOrderCreatedMessageReceived()
+            assertTradeCreatedMessageReceived {
+                assertEquals(btc2Eth2Market.id, it.trade.marketId)
+                assertEquals(OrderSide.Buy, it.trade.side)
+                assertEquals(bridgeOrderAmount.inFundamentalUnits, it.trade.amount)
+                assertEquals(quotePrice.setScale(18), it.trade.price)
+                assertEquals(BigDecimal("0.189").toFundamentalUnits(quoteSymbol.decimals), it.trade.feeAmount)
+                assertEquals(eth2.name, it.trade.feeSymbol.value)
+            }
+            assertTradeCreatedMessageReceived {
+                assertEquals(btcbtc2Market.id, it.trade.marketId)
+                assertEquals(OrderSide.Buy, it.trade.side)
+                assertEquals(baseOrderAmount.inFundamentalUnits, it.trade.amount)
+                assertEquals(bridgePrice.setScale(18), it.trade.price)
+                assertEquals(BigInteger.ZERO, it.trade.feeAmount)
+                assertEquals(btc2.name, it.trade.feeSymbol.value)
+            }
+            assertOrderUpdatedMessageReceived {
+                assertEquals(baseOrderAmount.inFundamentalUnits, it.order.amount)
+                assertEquals(it.order.status, OrderStatus.Filled)
+            }
+            assertBalancesMessageReceived(
+                listOf(
+                    ExpectedBalance(baseSymbol, total = BigDecimal("0"), available = BigDecimal("0.5")),
+                    ExpectedBalance(quoteSymbol, total = BigDecimal("10"), available = BigDecimal("0.361")),
+                ),
+            )
+            assertLimitsMessageReceived(secondMarket.id)
+        }
+
+        makerWsClient.apply {
+            repeat(2) { assertTradeCreatedMessageReceived() }
+            repeat(2) { assertOrderUpdatedMessageReceived() }
+            assertBalancesMessageReceived()
+            assertLimitsMessageReceived(market.id)
+        }
+
+        val takerOrders = takerApiClient.listOrders(emptyList(), market.id).orders
+        assertEquals(1, takerOrders.count { it.status == OrderStatus.Filled })
+
+        assertEquals(2, makerApiClient.listOrders(listOf(OrderStatus.Filled, OrderStatus.Partial)).orders.size)
+
+        // now verify the trades
+        val trades = getTradesForOrders(takerOrders.map { it.id })
+        assertEquals(2, trades.size)
+
+        waitForSettlementToFinish(trades.map { it.id.value })
+
+        val trade1 = trades.first { it.marketGuid.value == secondMarket.id }
+        val trade2 = trades.first { it.marketGuid.value == market.id }
+
+        assertEquals(trade1.amount, bridgeOrderAmount.inFundamentalUnits)
+        assertEquals(trade1.price, quotePrice.setScale(18))
+
+        assertEquals(trade2.amount, baseOrderAmount.inFundamentalUnits)
+        assertEquals(trade2.price, bridgePrice.setScale(18))
+
+        val notionalTrade1 = trade1.price.ofAsset(quoteSymbol) * AssetAmount(bridgeSymbol, trade1.amount).amount
+        val notionalTrade2 = trade2.price.ofAsset(bridgeSymbol) * AssetAmount(baseSymbol, trade2.amount).amount
+
+        val makerFeeTrade1 = notionalTrade1 * BigDecimal("0.01")
+        val makerFeeTrade2 = notionalTrade2 * BigDecimal("0.01")
+        val takerFee = notionalTrade1 * BigDecimal("0.02")
+
+        assertBalances(
+            listOf(
+                ExpectedBalance(makerStartingBaseBalance - baseOrderAmount),
+                ExpectedBalance(makerStartingBridgeBalance - makerFeeTrade2),
+                ExpectedBalance(makerStartingQuoteBalance + notionalTrade1 - makerFeeTrade1),
+            ),
+            makerApiClient.getBalances().balances,
+        )
+        assertBalances(
+            listOf(
+                ExpectedBalance(takerStartingBaseBalance + baseOrderAmount),
+                ExpectedBalance(takerStartingQuoteBalance - notionalTrade1 - takerFee),
+            ),
+            takerApiClient.getBalances().balances,
+        )
+
+        takerApiClient.cancelOpenOrders()
+        makerApiClient.cancelOpenOrders()
+
+        makerWsClient.close()
+        takerWsClient.close()
+    }
+}

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/apps/GatewayApp.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/apps/GatewayApp.kt
@@ -1,5 +1,6 @@
 package co.chainring.sequencer.apps
 
+import co.chainring.sequencer.proto.BackToBackOrderRequest
 import co.chainring.sequencer.proto.BalanceBatch
 import co.chainring.sequencer.proto.GatewayGrpcKt
 import co.chainring.sequencer.proto.GatewayResponse
@@ -188,6 +189,14 @@ class GatewayApp(
                 this.guid = request.guid
                 this.type = SequencerRequest.Type.SetMarketMinFees
                 this.marketMinFees.addAll(request.marketMinFeesList)
+            }
+        }
+
+        override suspend fun applyBackToBackOrder(request: BackToBackOrderRequest): GatewayResponse {
+            return toSequencer {
+                this.guid = request.guid
+                this.type = SequencerRequest.Type.ApplyBackToBackOrder
+                this.backToBackOrder = request.order
             }
         }
     }

--- a/sequencer/src/test/kotlin/co/chainring/TestBackToBackOrders.kt
+++ b/sequencer/src/test/kotlin/co/chainring/TestBackToBackOrders.kt
@@ -1,0 +1,719 @@
+package co.chainring
+
+import co.chainring.core.model.Percentage
+import co.chainring.core.model.db.FeeRates
+import co.chainring.sequencer.core.MarketId
+import co.chainring.sequencer.core.WalletAddress
+import co.chainring.sequencer.core.toBigInteger
+import co.chainring.sequencer.core.toWalletAddress
+import co.chainring.sequencer.proto.Order
+import co.chainring.sequencer.proto.OrderDisposition
+import co.chainring.sequencer.proto.SequencerError
+import co.chainring.testutils.ExpectedTrade
+import co.chainring.testutils.MockClock
+import co.chainring.testutils.SequencerClient
+import co.chainring.testutils.assertTrade
+import co.chainring.testutils.toFundamentalUnits
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.math.BigDecimal
+import kotlin.random.Random
+
+class TestBackToBackOrders {
+    private val mockClock = MockClock()
+
+    companion object {
+        @JvmStatic
+        fun orderAmounts() = listOf(
+            Arguments.of("0.4", "1", OrderDisposition.Filled, OrderDisposition.PartiallyFilled),
+            Arguments.of("1", "0.4", OrderDisposition.PartiallyFilled, OrderDisposition.Filled),
+        )
+    }
+
+    @Test
+    fun `Test market buy`() {
+        val sequencer = SequencerClient(mockClock)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
+
+        val market1 = sequencer.createMarket(MarketId("BTC:CHAIN2/BTC:CHAIN1"), quoteDecimals = 8, baseDecimals = 8)
+        val market2 = sequencer.createMarket(MarketId("BTC:CHAIN1/ETH:CHAIN1"))
+        val btcChain2 = market1.baseAsset
+        val btcChain1 = market1.quoteAsset
+        val ethChain1 = market2.quoteAsset
+
+        val maker = generateWalletAddress()
+        sequencer.deposit(maker, btcChain2, BigDecimal("1"))
+        sequencer.deposit(maker, btcChain1, BigDecimal("1"))
+
+        // place a limit sell
+        val makerSellOrder1Guid = sequencer.addOrderAndVerifyAccepted(market1, BigDecimal("1"), BigDecimal("1.050"), maker, Order.Type.LimitSell).guid
+
+        // place a limit sell
+        val makerSellOrder2Guid = sequencer.addOrderAndVerifyAccepted(market2, BigDecimal("1"), BigDecimal("18.000"), maker, Order.Type.LimitSell).guid
+
+        val taker = generateWalletAddress()
+        sequencer.deposit(taker, ethChain1, BigDecimal("10"))
+
+        // swap ETH:CHAIN1 for BTC:CHAIN2
+        val backToBackOrderGuid = Random.nextLong()
+        sequencer.addBackToBackOrder(backToBackOrderGuid, market1, market2, BigDecimal("0.5"), taker, Order.Type.MarketBuy).also { response ->
+            assertEquals(3, response.ordersChangedCount)
+
+            val takerOrder = response.ordersChangedList.first { it.guid == backToBackOrderGuid }
+            assertEquals(OrderDisposition.Filled, takerOrder.disposition)
+
+            val makerOrder1 = response.ordersChangedList.first { it.guid == makerSellOrder1Guid }
+            assertEquals(OrderDisposition.PartiallyFilled, makerOrder1.disposition)
+
+            val makerOrder2 = response.ordersChangedList.first { it.guid == makerSellOrder2Guid }
+            assertEquals(OrderDisposition.PartiallyFilled, makerOrder2.disposition)
+
+            assertEquals(5, response.balancesChangedCount)
+
+            // taker balance deltas
+            assertEquals(
+                BigDecimal("0.5").toFundamentalUnits(btcChain2.decimals),
+                response.balancesChangedList.first { it.wallet == taker.value && it.asset == btcChain2.name }.delta.toBigInteger(),
+            )
+            // 0.5 * 1.05 * 18 + 0.189 (fee)
+            assertEquals(
+                BigDecimal("9.639").toFundamentalUnits(ethChain1.decimals).negate(),
+                response.balancesChangedList.first { it.wallet == taker.value && it.asset == ethChain1.name }.delta.toBigInteger(),
+            )
+
+            // maker balance deltas
+            assertEquals(
+                BigDecimal("0.5").toFundamentalUnits(btcChain2.decimals).negate(),
+                response.balancesChangedList.first { it.wallet == maker.value && it.asset == btcChain2.name }.delta.toBigInteger(),
+            )
+            // fee 0.00525
+            assertEquals(
+                BigDecimal("0.00525").toFundamentalUnits(btcChain1.decimals).negate(),
+                response.balancesChangedList.first { it.wallet == maker.value && it.asset == btcChain1.name }.delta.toBigInteger(),
+            )
+            // 18 * 0.525 - 0.0945
+            assertEquals(
+                BigDecimal("9.3555").toFundamentalUnits(ethChain1.decimals),
+                response.balancesChangedList.first { it.wallet == maker.value && it.asset == ethChain1.name }.delta.toBigInteger(),
+            )
+
+            assertEquals(2, response.tradesCreatedCount)
+
+            // first trade is buying the bridge asset
+            response.assertTrade(
+                market2,
+                ExpectedTrade(
+                    buyOrderGuid = backToBackOrderGuid,
+                    sellOrderGuid = makerSellOrder2Guid,
+                    price = BigDecimal("18.00"),
+                    amount = BigDecimal("0.525"),
+                    buyerFee = BigDecimal("0.189"),
+                    sellerFee = BigDecimal("0.0945"),
+                ),
+                0,
+            )
+
+            response.assertTrade(
+                market1,
+                ExpectedTrade(
+                    buyOrderGuid = backToBackOrderGuid,
+                    sellOrderGuid = makerSellOrder1Guid,
+                    price = BigDecimal("1.05"),
+                    amount = BigDecimal("0.500"),
+                    buyerFee = BigDecimal.ZERO,
+                    sellerFee = BigDecimal("0.00525"),
+                ),
+                1,
+            )
+        }
+
+        sequencer.withdrawal(taker, btcChain2, BigDecimal.ZERO, expectedAmount = BigDecimal("0.5"))
+        sequencer.withdrawal(taker, btcChain1, BigDecimal.ZERO, expectedAmount = null)
+        sequencer.withdrawal(taker, ethChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("0.361")) // 10 - 0.5 * 1.05 * 18 - 0.189 (fee)
+
+        sequencer.withdrawal(maker, btcChain2, BigDecimal.ZERO, expectedAmount = BigDecimal("0.5"))
+        sequencer.withdrawal(maker, btcChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("0.99475")) // 1 - 0.00525
+        sequencer.withdrawal(maker, ethChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("9.3555")) // 18 * 0.525 - 0.0945 (fee)
+    }
+
+    @Test
+    fun `Test market buy - max swap (100 percent)`() {
+        val sequencer = SequencerClient(mockClock)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
+
+        val market1 = sequencer.createMarket(MarketId("BTC:CHAIN2/BTC:CHAIN1"), quoteDecimals = 8, baseDecimals = 8)
+        val market2 = sequencer.createMarket(MarketId("BTC:CHAIN1/ETH:CHAIN1"))
+        val btcChain2 = market1.baseAsset
+        val btcChain1 = market1.quoteAsset
+        val ethChain1 = market2.quoteAsset
+
+        val maker = generateWalletAddress()
+        sequencer.deposit(maker, btcChain2, BigDecimal("1"))
+        sequencer.deposit(maker, btcChain1, BigDecimal("1"))
+
+        // place a limit sell
+        val makerSellOrder1Guid = sequencer.addOrderAndVerifyAccepted(market1, BigDecimal("1"), BigDecimal("1.050"), maker, Order.Type.LimitSell).guid
+
+        // place a limit sell
+        val makerSellOrder2Guid = sequencer.addOrderAndVerifyAccepted(market2, BigDecimal("1"), BigDecimal("18.000"), maker, Order.Type.LimitSell).guid
+
+        val taker = generateWalletAddress()
+        sequencer.deposit(taker, ethChain1, BigDecimal("10"))
+
+        // swap max ETH:CHAIN1 for BTC:CHAIN2
+        val backToBackOrderGuid = Random.nextLong()
+        sequencer.addBackToBackOrder(backToBackOrderGuid, market1, market2, BigDecimal.ZERO, taker, Order.Type.MarketBuy, Percentage.MAX_VALUE).also { response ->
+            assertEquals(3, response.ordersChangedCount)
+
+            val takerOrder = response.ordersChangedList.first { it.guid == backToBackOrderGuid }
+            assertEquals(OrderDisposition.Filled, takerOrder.disposition)
+
+            val makerOrder1 = response.ordersChangedList.first { it.guid == makerSellOrder1Guid }
+            assertEquals(OrderDisposition.PartiallyFilled, makerOrder1.disposition)
+
+            val makerOrder2 = response.ordersChangedList.first { it.guid == makerSellOrder2Guid }
+            assertEquals(OrderDisposition.PartiallyFilled, makerOrder2.disposition)
+
+            // taker balance deltas
+            assertEquals(
+                BigDecimal("0.518726").toFundamentalUnits(btcChain2.decimals),
+                response.balancesChangedList.first { it.wallet == taker.value && it.asset == btcChain2.name }.delta.toBigInteger(),
+            )
+            // 100% of quote
+            assertEquals(
+                BigDecimal("10").toFundamentalUnits(ethChain1.decimals).negate(),
+                response.balancesChangedList.first { it.wallet == taker.value && it.asset == ethChain1.name }.delta.toBigInteger(),
+            )
+
+            // maker balance deltas
+            assertEquals(
+                BigDecimal("0.518726").toFundamentalUnits(btcChain2.decimals).negate(),
+                response.balancesChangedList.first { it.wallet == maker.value && it.asset == btcChain2.name }.delta.toBigInteger(),
+            )
+            // fee 0.00544662
+            assertEquals(
+                BigDecimal("0.00544662").toFundamentalUnits(btcChain1.decimals).negate(),
+                response.balancesChangedList.first { it.wallet == maker.value && it.asset == btcChain1.name }.delta.toBigInteger(),
+            )
+            // 18 * 0.5446623 - 0.098039214
+            assertEquals(
+                BigDecimal("9.705882186").toFundamentalUnits(ethChain1.decimals),
+                response.balancesChangedList.first { it.wallet == maker.value && it.asset == ethChain1.name }.delta.toBigInteger(),
+            )
+
+            assertEquals(2, response.tradesCreatedCount)
+
+            // first trade is buying the bridge asset
+            response.assertTrade(
+                market2,
+                ExpectedTrade(
+                    buyOrderGuid = backToBackOrderGuid,
+                    sellOrderGuid = makerSellOrder2Guid,
+                    price = BigDecimal("18.00"),
+                    amount = BigDecimal("0.5446623"),
+                    buyerFee = BigDecimal("0.1960786"),
+                    sellerFee = BigDecimal("0.098039214"),
+                ),
+                0,
+            )
+
+            response.assertTrade(
+                market1,
+                ExpectedTrade(
+                    buyOrderGuid = backToBackOrderGuid,
+                    sellOrderGuid = makerSellOrder1Guid,
+                    price = BigDecimal("1.05"),
+                    amount = BigDecimal("0.518726"),
+                    buyerFee = BigDecimal.ZERO,
+                    sellerFee = BigDecimal("0.00544662"),
+                ),
+                1,
+            )
+        }
+
+        sequencer.withdrawal(taker, btcChain2, BigDecimal.ZERO, expectedAmount = BigDecimal("0.518726")) // 0.5446623 / 1.05
+        sequencer.withdrawal(taker, btcChain1, BigDecimal.ZERO, expectedAmount = null)
+        sequencer.withdrawal(taker, ethChain1, BigDecimal.ZERO, expectedAmount = null)
+
+        sequencer.withdrawal(maker, btcChain2, BigDecimal.ZERO, expectedAmount = BigDecimal("0.481274"))
+        sequencer.withdrawal(maker, btcChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("0.99455338")) // 1 - 0.00544662
+        sequencer.withdrawal(maker, ethChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("9.705882186")) // 18 * 0.5446623 - 0.098039214 (fee)
+    }
+
+    @ParameterizedTest
+    @MethodSource("orderAmounts")
+    fun `Test market buy - partial fill`(order1Amount: String, order2Amount: String, order1Disposition: OrderDisposition, order2Disposition: OrderDisposition) {
+        val sequencer = SequencerClient(mockClock)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
+
+        val market1 = sequencer.createMarket(MarketId("BTC:CHAIN2/BTC:CHAIN1"), quoteDecimals = 8, baseDecimals = 8)
+        val market2 = sequencer.createMarket(MarketId("BTC:CHAIN1/ETH:CHAIN1"))
+        val btcChain2 = market1.baseAsset
+        val btcChain1 = market1.quoteAsset
+        val ethChain1 = market2.quoteAsset
+
+        val maker = generateWalletAddress()
+        sequencer.deposit(maker, btcChain2, BigDecimal("1"))
+        sequencer.deposit(maker, btcChain1, BigDecimal("1"))
+
+        // place a limit sell
+        val makerSellOrder1Guid = sequencer.addOrderAndVerifyAccepted(market1, BigDecimal(order1Amount), BigDecimal("1.000"), maker, Order.Type.LimitSell).guid
+
+        // place a limit sell
+        val makerSellOrder2Guid = sequencer.addOrderAndVerifyAccepted(market2, BigDecimal(order2Amount), BigDecimal("18.000"), maker, Order.Type.LimitSell).guid
+
+        val taker = generateWalletAddress()
+        sequencer.deposit(taker, ethChain1, BigDecimal("10"))
+
+        // swap ETH:CHAIN1 for BTC:CHAIN2
+        val backToBackOrderGuid = Random.nextLong()
+        sequencer.addBackToBackOrder(backToBackOrderGuid, market1, market2, BigDecimal("0.5"), taker, Order.Type.MarketBuy).also { response ->
+            assertEquals(3, response.ordersChangedCount)
+
+            val takerOrder = response.ordersChangedList.first { it.guid == backToBackOrderGuid }
+            assertEquals(OrderDisposition.PartiallyFilled, takerOrder.disposition)
+
+            val makerOrder1 = response.ordersChangedList.first { it.guid == makerSellOrder1Guid }
+            assertEquals(order1Disposition, makerOrder1.disposition)
+
+            val makerOrder2 = response.ordersChangedList.first { it.guid == makerSellOrder2Guid }
+            assertEquals(order2Disposition, makerOrder2.disposition)
+
+            assertEquals(2, response.tradesCreatedCount)
+
+            // first trade is buying the bridge asset
+            response.assertTrade(
+                market2,
+                ExpectedTrade(
+                    buyOrderGuid = backToBackOrderGuid,
+                    sellOrderGuid = makerSellOrder2Guid,
+                    price = BigDecimal("18.00"),
+                    amount = BigDecimal("0.4"),
+                    buyerFee = BigDecimal("0.144"),
+                    sellerFee = BigDecimal("0.072"),
+                ),
+                0,
+            )
+
+            response.assertTrade(
+                market1,
+                ExpectedTrade(
+                    buyOrderGuid = backToBackOrderGuid,
+                    sellOrderGuid = makerSellOrder1Guid,
+                    price = BigDecimal("1.00"),
+                    amount = BigDecimal("0.4"),
+                    buyerFee = BigDecimal.ZERO,
+                    sellerFee = BigDecimal("0.004"),
+                ),
+                1,
+            )
+        }
+
+        sequencer.withdrawal(taker, btcChain2, BigDecimal.ZERO, expectedAmount = BigDecimal("0.4"))
+        sequencer.withdrawal(taker, btcChain1, BigDecimal.ZERO, expectedAmount = null)
+        sequencer.withdrawal(taker, ethChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("2.656")) // 10 - 0.4 * 18 - 0.144 (fee)
+
+        sequencer.withdrawal(maker, btcChain2, BigDecimal.ZERO, expectedAmount = BigDecimal("0.6"))
+        sequencer.withdrawal(maker, btcChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("0.996")) // 1 - 0.004
+        sequencer.withdrawal(maker, ethChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("7.128")) // 18 * 0.4 - 0.072 (fee)
+    }
+
+    @Test
+    fun `Test market buy - errors`() {
+        val sequencer = SequencerClient(mockClock)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
+
+        val market1 = sequencer.createMarket(MarketId("BTC:CHAIN2/BTC:CHAIN1"), quoteDecimals = 8, baseDecimals = 8)
+        val market2 = sequencer.createMarket(MarketId("BTC:CHAIN1/ETH:CHAIN1"), minFee = BigDecimal("0.0001"))
+        val market3 = sequencer.createMarket(MarketId("USDC:CHAIN1/ETH:CHAIN1"))
+        val market4 = sequencer.createMarket(MarketId("BTC:CHAIN1/BTC:CHAIN2"))
+        val btcChain2 = market1.baseAsset
+        val btcChain1 = market1.quoteAsset
+        val ethChain1 = market2.quoteAsset
+
+        val maker = generateWalletAddress()
+        sequencer.deposit(maker, btcChain2, BigDecimal("1"))
+        sequencer.deposit(maker, btcChain1, BigDecimal("1"))
+
+        // place a limit sell
+        sequencer.addOrderAndVerifyAccepted(market1, BigDecimal("0.4"), BigDecimal("1.000"), maker, Order.Type.LimitSell).guid
+
+        // place a limit sell
+        sequencer.addOrderAndVerifyAccepted(market2, BigDecimal("1"), BigDecimal("18.000"), maker, Order.Type.LimitSell).guid
+
+        val taker = generateWalletAddress()
+        sequencer.deposit(taker, ethChain1, BigDecimal("5"))
+
+        // place a market buy that exceeds the limit
+        val backToBackOrderGuid = Random.nextLong()
+        sequencer.addBackToBackOrder(backToBackOrderGuid, market1, market2, BigDecimal("0.5"), taker, Order.Type.MarketBuy).also { response ->
+            assertEquals(SequencerError.ExceedsLimit, response.error)
+        }
+
+        // different bridge assets
+        sequencer.addBackToBackOrder(backToBackOrderGuid, market1, market3, BigDecimal("0.5"), taker, Order.Type.MarketBuy).also { response ->
+            assertEquals(SequencerError.InvalidBackToBackOrder, response.error)
+        }
+
+        // base/quote the same
+        sequencer.addBackToBackOrder(backToBackOrderGuid, market1, market4, BigDecimal("0.5"), taker, Order.Type.MarketBuy).also { response ->
+            assertEquals(SequencerError.InvalidBackToBackOrder, response.error)
+        }
+
+        // place one where order is below min fee
+        sequencer.addBackToBackOrder(backToBackOrderGuid, market1, market2, BigDecimal("0.00001"), taker, Order.Type.MarketBuy).also { response ->
+            assertEquals(SequencerError.None, response.error)
+            assertEquals(response.ordersChangedList[0].disposition, OrderDisposition.Rejected)
+        }
+
+        sequencer.withdrawal(taker, btcChain2, BigDecimal.ZERO, null)
+        sequencer.withdrawal(taker, btcChain1, BigDecimal.ZERO, expectedAmount = null)
+        sequencer.withdrawal(taker, ethChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("5"))
+
+        sequencer.withdrawal(maker, btcChain2, BigDecimal.ZERO, expectedAmount = BigDecimal("1"))
+        sequencer.withdrawal(maker, btcChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("1"))
+        sequencer.withdrawal(maker, ethChain1, BigDecimal.ZERO, expectedAmount = null)
+    }
+
+    @Test
+    fun `Test market sell`() {
+        val sequencer = SequencerClient(mockClock)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
+
+        val market1 = sequencer.createMarket(MarketId("btcChain2/btcChain1"), quoteDecimals = 8, baseDecimals = 8)
+        val market2 = sequencer.createMarket(MarketId("btcChain1/ethChain1"))
+        val btcChain2 = market1.baseAsset
+        val btcChain1 = market1.quoteAsset
+        val ethChain1 = market2.quoteAsset
+
+        val maker = generateWalletAddress()
+        sequencer.deposit(maker, btcChain1, BigDecimal("2"))
+        sequencer.deposit(maker, ethChain1, BigDecimal("20"))
+
+        // place a limit buy
+        val makerBuyOrder1Guid = sequencer.addOrderAndVerifyAccepted(market1, BigDecimal("1"), BigDecimal("0.950"), maker, Order.Type.LimitBuy).guid
+
+        // place a limit buy
+        val makerBuyOrder2Guid = sequencer.addOrderAndVerifyAccepted(market2, BigDecimal("1"), BigDecimal("18.000"), maker, Order.Type.LimitBuy).guid
+
+        val taker = generateWalletAddress()
+        sequencer.deposit(taker, btcChain2, BigDecimal("0.6"))
+
+        // swap BTC:CHAIN2 for ETH:CHAIN1
+        val backToBackOrderGuid = Random.nextLong()
+        sequencer.addBackToBackOrder(backToBackOrderGuid, market1, market2, BigDecimal("0.5"), taker, Order.Type.MarketSell).also { response ->
+            assertEquals(3, response.ordersChangedCount)
+
+            val takerOrder = response.ordersChangedList.first { it.guid == backToBackOrderGuid }
+            assertEquals(OrderDisposition.Filled, takerOrder.disposition)
+
+            val makerOrder1 = response.ordersChangedList.first { it.guid == makerBuyOrder1Guid }
+            assertEquals(OrderDisposition.PartiallyFilled, makerOrder1.disposition)
+
+            val makerOrder2 = response.ordersChangedList.first { it.guid == makerBuyOrder2Guid }
+            assertEquals(OrderDisposition.PartiallyFilled, makerOrder2.disposition)
+
+            assertEquals(5, response.balancesChangedCount)
+            // taker balance deltas
+            assertEquals(
+                BigDecimal("0.5").toFundamentalUnits(btcChain2.decimals).negate(),
+                response.balancesChangedList.first { it.wallet == taker.value && it.asset == btcChain2.name }.delta.toBigInteger(),
+            )
+            // 0.5 * 0.95 * 18 - 0.171 (fee)
+            assertEquals(
+                BigDecimal("8.379").toFundamentalUnits(ethChain1.decimals),
+                response.balancesChangedList.first { it.wallet == taker.value && it.asset == ethChain1.name }.delta.toBigInteger(),
+            )
+
+            // maker balance deltas
+            assertEquals(
+                BigDecimal("0.5").toFundamentalUnits(btcChain2.decimals),
+                response.balancesChangedList.first { it.wallet == maker.value && it.asset == btcChain2.name }.delta.toBigInteger(),
+            )
+            // fee 0.00475
+            assertEquals(
+                BigDecimal("0.00475").toFundamentalUnits(btcChain1.decimals).negate(),
+                response.balancesChangedList.first { it.wallet == maker.value && it.asset == btcChain1.name }.delta.toBigInteger(),
+            )
+            // 0.5 * 18 * 0.95 + 0.0855
+            assertEquals(
+                BigDecimal("8.6355").toFundamentalUnits(ethChain1.decimals).negate(),
+                response.balancesChangedList.first { it.wallet == maker.value && it.asset == ethChain1.name }.delta.toBigInteger(),
+            )
+
+            assertEquals(2, response.tradesCreatedCount)
+
+            // first trade is selling base for bridge asset
+            response.assertTrade(
+                market1,
+                ExpectedTrade(
+                    buyOrderGuid = makerBuyOrder1Guid,
+                    sellOrderGuid = backToBackOrderGuid,
+                    price = BigDecimal("0.95"),
+                    amount = BigDecimal("0.5"),
+                    buyerFee = BigDecimal("0.00475"),
+                    sellerFee = BigDecimal.ZERO,
+                ),
+                0,
+            )
+
+            response.assertTrade(
+                market2,
+                ExpectedTrade(
+                    buyOrderGuid = makerBuyOrder2Guid,
+                    sellOrderGuid = backToBackOrderGuid,
+                    price = BigDecimal("18.00"),
+                    amount = BigDecimal("0.475"),
+                    buyerFee = BigDecimal("0.0855"),
+                    sellerFee = BigDecimal("0.171"),
+                ),
+                1,
+            )
+        }
+
+        sequencer.withdrawal(taker, btcChain2, BigDecimal.ZERO, expectedAmount = BigDecimal("0.1")) // 0.6 - 0.5
+        sequencer.withdrawal(taker, btcChain1, BigDecimal.ZERO, expectedAmount = null)
+        sequencer.withdrawal(taker, ethChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("8.379")) // 0.5 * 0.95 * 18 - 0.171 (fee)
+
+        sequencer.withdrawal(maker, btcChain2, BigDecimal.ZERO, expectedAmount = BigDecimal("0.5"))
+        sequencer.withdrawal(maker, btcChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("1.99525")) // 2 - 0.00475
+        sequencer.withdrawal(maker, ethChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("11.3645")) // 20 - 0.5 * 18 * 0.95 - 0.0855 (fee)
+    }
+
+    @Test
+    fun `Test market sell - max swap (100 percent)`() {
+        val sequencer = SequencerClient(mockClock)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
+
+        val market1 = sequencer.createMarket(MarketId("BTC:CHAIN2/BTC:CHAIN1"), quoteDecimals = 8, baseDecimals = 8)
+        val market2 = sequencer.createMarket(MarketId("BTC:CHAIN1/ETH:CHAIN1"))
+        val btcChain2 = market1.baseAsset
+        val btcChain1 = market1.quoteAsset
+        val ethChain1 = market2.quoteAsset
+
+        val maker = generateWalletAddress()
+        sequencer.deposit(maker, btcChain1, BigDecimal("2"))
+        sequencer.deposit(maker, ethChain1, BigDecimal("20"))
+
+        // place a limit buy
+        val makerBuyOrder1Guid = sequencer.addOrderAndVerifyAccepted(market1, BigDecimal("1"), BigDecimal("0.950"), maker, Order.Type.LimitBuy).guid
+
+        // place a limit buy
+        val makerBuyOrder2Guid = sequencer.addOrderAndVerifyAccepted(market2, BigDecimal("1"), BigDecimal("18.000"), maker, Order.Type.LimitBuy).guid
+
+        val taker = generateWalletAddress()
+        sequencer.deposit(taker, btcChain2, BigDecimal("0.6"))
+
+        // swap BTC:CHAIN2 for ETH:CHAIN1
+        val backToBackOrderGuid = Random.nextLong()
+        sequencer.addBackToBackOrder(backToBackOrderGuid, market1, market2, BigDecimal.ZERO, taker, Order.Type.MarketSell, Percentage.MAX_VALUE).also { response ->
+            assertEquals(3, response.ordersChangedCount)
+
+            val takerOrder = response.ordersChangedList.first { it.guid == backToBackOrderGuid }
+            assertEquals(OrderDisposition.Filled, takerOrder.disposition)
+
+            val makerOrder1 = response.ordersChangedList.first { it.guid == makerBuyOrder1Guid }
+            assertEquals(OrderDisposition.PartiallyFilled, makerOrder1.disposition)
+
+            val makerOrder2 = response.ordersChangedList.first { it.guid == makerBuyOrder2Guid }
+            assertEquals(OrderDisposition.PartiallyFilled, makerOrder2.disposition)
+
+            assertEquals(5, response.balancesChangedCount)
+            // taker balance deltas
+            assertEquals(
+                BigDecimal("0.6").toFundamentalUnits(btcChain2.decimals).negate(),
+                response.balancesChangedList.first { it.wallet == taker.value && it.asset == btcChain2.name }.delta.toBigInteger(),
+            )
+            // 0.6 * 0.95 * 18 - 0.2052 (fee)
+            assertEquals(
+                BigDecimal("10.0548").toFundamentalUnits(ethChain1.decimals),
+                response.balancesChangedList.first { it.wallet == taker.value && it.asset == ethChain1.name }.delta.toBigInteger(),
+            )
+
+            // maker balance deltas
+            assertEquals(
+                BigDecimal("0.6").toFundamentalUnits(btcChain2.decimals),
+                response.balancesChangedList.first { it.wallet == maker.value && it.asset == btcChain2.name }.delta.toBigInteger(),
+            )
+            // fee for trade 1 was 0.0057
+            assertEquals(
+                BigDecimal("0.0057").toFundamentalUnits(btcChain1.decimals).negate(),
+                response.balancesChangedList.first { it.wallet == maker.value && it.asset == btcChain1.name }.delta.toBigInteger(),
+            )
+            // 0.6 * 18 * 0.95 + 0.1026
+            assertEquals(
+                BigDecimal("10.3626").toFundamentalUnits(ethChain1.decimals).negate(),
+                response.balancesChangedList.first { it.wallet == maker.value && it.asset == ethChain1.name }.delta.toBigInteger(),
+            )
+
+            assertEquals(2, response.tradesCreatedCount)
+
+            // first trade is selling base for bridge asset
+            response.assertTrade(
+                market1,
+                ExpectedTrade(
+                    buyOrderGuid = makerBuyOrder1Guid,
+                    sellOrderGuid = backToBackOrderGuid,
+                    price = BigDecimal("0.95"),
+                    amount = BigDecimal("0.6"),
+                    buyerFee = BigDecimal("0.0057"),
+                    sellerFee = BigDecimal.ZERO,
+                ),
+                0,
+            )
+
+            response.assertTrade(
+                market2,
+                ExpectedTrade(
+                    buyOrderGuid = makerBuyOrder2Guid,
+                    sellOrderGuid = backToBackOrderGuid,
+                    price = BigDecimal("18.00"),
+                    // 0.6 * 0.95
+                    amount = BigDecimal("0.57"),
+                    buyerFee = BigDecimal("0.1026"),
+                    sellerFee = BigDecimal("0.2052"),
+                ),
+                1,
+            )
+        }
+
+        sequencer.withdrawal(taker, btcChain2, BigDecimal.ZERO, expectedAmount = null) // 0.6 - 0.5
+        sequencer.withdrawal(taker, btcChain1, BigDecimal.ZERO, expectedAmount = null)
+        sequencer.withdrawal(taker, ethChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("10.0548")) // 0.6 * 0.95 * 18 - 0.2052 (fee)
+
+        sequencer.withdrawal(maker, btcChain2, BigDecimal.ZERO, expectedAmount = BigDecimal("0.6"))
+        sequencer.withdrawal(maker, btcChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("1.9943")) // 2 - 0.0057
+        sequencer.withdrawal(maker, ethChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("9.6374")) // 20 - 0.6 * 18 * 0.95 - 0.1026 (fee)
+    }
+
+    @ParameterizedTest
+    @MethodSource("orderAmounts")
+    fun `Test market sell - partial fill`(order1Amount: String, order2Amount: String, order1Disposition: OrderDisposition, order2Disposition: OrderDisposition) {
+        val sequencer = SequencerClient(mockClock)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
+
+        val market1 = sequencer.createMarket(MarketId("BTC:CHAIN2/BTC:CHAIN1"), quoteDecimals = 8, baseDecimals = 8)
+        val market2 = sequencer.createMarket(MarketId("BTC:CHAIN1/ETH:CHAIN1"))
+        val btcChain2 = market1.baseAsset
+        val btcChain1 = market1.quoteAsset
+        val ethChain1 = market2.quoteAsset
+
+        val maker = generateWalletAddress()
+        sequencer.deposit(maker, btcChain1, BigDecimal("2"))
+        sequencer.deposit(maker, ethChain1, BigDecimal("20"))
+
+        // place a limit buy
+        val makerBuyOrder1Guid = sequencer.addOrderAndVerifyAccepted(market1, BigDecimal(order1Amount), BigDecimal("1.000"), maker, Order.Type.LimitBuy).guid
+
+        // place a limit buy
+        val makerBuyOrder2Guid = sequencer.addOrderAndVerifyAccepted(market2, BigDecimal(order2Amount), BigDecimal("18.000"), maker, Order.Type.LimitBuy).guid
+
+        val taker = generateWalletAddress()
+        sequencer.deposit(taker, btcChain2, BigDecimal("0.6"))
+
+        // swap BTC:CHAIN2 for ETH:CHAIN1
+        val backToBackOrderGuid = Random.nextLong()
+        sequencer.addBackToBackOrder(backToBackOrderGuid, market1, market2, BigDecimal("0.5"), taker, Order.Type.MarketSell).also { response ->
+            assertEquals(3, response.ordersChangedCount)
+
+            val takerOrder = response.ordersChangedList.first { it.guid == backToBackOrderGuid }
+            assertEquals(OrderDisposition.PartiallyFilled, takerOrder.disposition)
+
+            val makerOrder1 = response.ordersChangedList.first { it.guid == makerBuyOrder1Guid }
+            assertEquals(order1Disposition, makerOrder1.disposition)
+
+            val makerOrder2 = response.ordersChangedList.first { it.guid == makerBuyOrder2Guid }
+            assertEquals(order2Disposition, makerOrder2.disposition)
+
+            assertEquals(2, response.tradesCreatedCount)
+
+            // first trade is selling base for bridge asset
+            response.assertTrade(
+                market1,
+                ExpectedTrade(
+                    buyOrderGuid = makerBuyOrder1Guid,
+                    sellOrderGuid = backToBackOrderGuid,
+                    price = BigDecimal("1.00"),
+                    amount = BigDecimal("0.4"),
+                    buyerFee = BigDecimal("0.004"),
+                    sellerFee = BigDecimal.ZERO,
+                ),
+                0,
+            )
+
+            response.assertTrade(
+                market2,
+                ExpectedTrade(
+                    buyOrderGuid = makerBuyOrder2Guid,
+                    sellOrderGuid = backToBackOrderGuid,
+                    price = BigDecimal("18.00"),
+                    amount = BigDecimal("0.4"),
+                    buyerFee = BigDecimal("0.072"),
+                    sellerFee = BigDecimal("0.144"),
+                ),
+                1,
+            )
+        }
+
+        sequencer.withdrawal(taker, btcChain2, BigDecimal.ZERO, expectedAmount = BigDecimal("0.2")) // 0.6 - 0.4
+        sequencer.withdrawal(taker, btcChain1, BigDecimal.ZERO, expectedAmount = null)
+        sequencer.withdrawal(taker, ethChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("7.056")) // 0.4 * 18 - 0.144 (fee)
+
+        sequencer.withdrawal(maker, btcChain2, BigDecimal.ZERO, expectedAmount = BigDecimal("0.4"))
+        sequencer.withdrawal(maker, btcChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("1.996")) // 2 - 0.004
+        sequencer.withdrawal(maker, ethChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("12.728")) // 20 - 0.4 * 18 * 1.0 - 0.072 (fee)
+    }
+
+    @Test
+    fun `Test market sell - errors`() {
+        val sequencer = SequencerClient(mockClock)
+        sequencer.setFeeRates(FeeRates.fromPercents(maker = 1.0, taker = 2.0))
+
+        val market1 = sequencer.createMarket(MarketId("BTC:CHAIN2/BTC:CHAIN1"), quoteDecimals = 8, baseDecimals = 8)
+        val market2 = sequencer.createMarket(MarketId("BTC:CHAIN1/ETH:CHAIN1"), minFee = BigDecimal("0.01"))
+        val btcChain2 = market1.baseAsset
+        val btcChain1 = market1.quoteAsset
+        val ethChain1 = market2.quoteAsset
+
+        val maker = generateWalletAddress()
+        sequencer.deposit(maker, btcChain1, BigDecimal("2"))
+        sequencer.deposit(maker, ethChain1, BigDecimal("20"))
+
+        // place a limit buy on first market
+        sequencer.addOrderAndVerifyAccepted(market1, BigDecimal("1"), BigDecimal("1.000"), maker, Order.Type.LimitBuy).guid
+
+        // place a limit buy on 2nd market
+        sequencer.addOrderAndVerifyAccepted(market2, BigDecimal("1"), BigDecimal("18.000"), maker, Order.Type.LimitBuy).guid
+
+        val taker = generateWalletAddress()
+        sequencer.deposit(taker, btcChain2, BigDecimal("0.4"))
+
+        // swap BTC:CHAIN2 for ETH:CHAIN1
+        val backToBackOrderGuid = Random.nextLong()
+        sequencer.addBackToBackOrder(backToBackOrderGuid, market1, market2, BigDecimal("0.5"), taker, Order.Type.MarketSell).also { response ->
+            assertEquals(SequencerError.ExceedsLimit, response.error)
+        }
+        // place one where order is below min fee
+        sequencer.addBackToBackOrder(backToBackOrderGuid, market1, market2, BigDecimal("0.00001"), taker, Order.Type.MarketSell).also { response ->
+            assertEquals(SequencerError.None, response.error)
+            assertEquals(response.ordersChangedList[0].disposition, OrderDisposition.Rejected)
+        }
+
+        // verify the remaining balances for taker
+        sequencer.withdrawal(taker, btcChain2, BigDecimal.ZERO, expectedAmount = BigDecimal("0.4"))
+        sequencer.withdrawal(taker, btcChain1, BigDecimal.ZERO, expectedAmount = null)
+        sequencer.withdrawal(taker, ethChain1, BigDecimal.ZERO, expectedAmount = null)
+
+        sequencer.withdrawal(maker, btcChain2, BigDecimal.ZERO, expectedAmount = null)
+        sequencer.withdrawal(maker, btcChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("2"))
+        sequencer.withdrawal(maker, ethChain1, BigDecimal.ZERO, expectedAmount = BigDecimal("20"))
+    }
+
+    private val rnd = Random(0)
+
+    private fun generateWalletAddress(): WalletAddress =
+        rnd.nextLong().toWalletAddress()
+}

--- a/sequencer/src/test/kotlin/co/chainring/testutils/Assertions.kt
+++ b/sequencer/src/test/kotlin/co/chainring/testutils/Assertions.kt
@@ -13,6 +13,7 @@ data class ExpectedTrade(
     val amount: BigDecimal,
     val buyerFee: BigDecimal,
     val sellerFee: BigDecimal,
+    val marketId: String? = null,
 )
 
 fun SequencerResponse.assertTrades(
@@ -25,6 +26,7 @@ fun SequencerResponse.assertTrades(
                 amount = it.amount.setScale(market.baseDecimals),
                 buyerFee = it.buyerFee.setScale(market.quoteDecimals),
                 sellerFee = it.sellerFee.setScale(market.quoteDecimals),
+                marketId = market.id.value,
             )
         },
         tradesCreatedList.map {
@@ -35,8 +37,33 @@ fun SequencerResponse.assertTrades(
                 amount = it.amount.fromFundamentalUnits(market.baseDecimals),
                 buyerFee = it.buyerFee.fromFundamentalUnits(market.quoteDecimals),
                 sellerFee = it.sellerFee.fromFundamentalUnits(market.quoteDecimals),
+                marketId = it.marketId,
             )
         },
+    )
+}
+
+fun SequencerResponse.assertTrade(
+    market: SequencerClient.Market,
+    expectedTrade: ExpectedTrade,
+    index: Int,
+) {
+    assertEquals(
+        expectedTrade.copy(
+            amount = expectedTrade.amount.setScale(market.baseDecimals),
+            buyerFee = expectedTrade.buyerFee.setScale(market.quoteDecimals),
+            sellerFee = expectedTrade.sellerFee.setScale(market.quoteDecimals),
+            marketId = market.id.value,
+        ),
+        ExpectedTrade(
+            buyOrderGuid = tradesCreatedList[index].buyOrderGuid,
+            sellOrderGuid = tradesCreatedList[index].sellOrderGuid,
+            price = market.tickSize.multiply(tradesCreatedList[index].levelIx.toBigDecimal()),
+            amount = tradesCreatedList[index].amount.fromFundamentalUnits(market.baseDecimals),
+            buyerFee = tradesCreatedList[index].buyerFee.fromFundamentalUnits(market.quoteDecimals),
+            sellerFee = tradesCreatedList[index].sellerFee.fromFundamentalUnits(market.quoteDecimals),
+            marketId = tradesCreatedList[index].marketId,
+        ),
     )
 }
 

--- a/sequencercommon/src/main/proto/gateway.proto
+++ b/sequencercommon/src/main/proto/gateway.proto
@@ -39,6 +39,11 @@ message SetMarketMinFeesRequest {
   repeated MarketMinFee marketMinFees = 2;
 }
 
+message BackToBackOrderRequest {
+  string guid = 1;
+  BackToBackOrder order = 2;
+}
+
 service Gateway {
   rpc AddMarket (Market) returns (GatewayResponse);
   rpc SetFeeRates (SetFeeRatesRequest) returns (GatewayResponse);
@@ -48,4 +53,5 @@ service Gateway {
   rpc GetState (GetStateRequest) returns (GatewayResponse);
   rpc SetWithdrawalFees (SetWithdrawalFeesRequest) returns (GatewayResponse);
   rpc SetMarketMinFees (SetMarketMinFeesRequest) returns (GatewayResponse);
+  rpc ApplyBackToBackOrder (BackToBackOrderRequest) returns (GatewayResponse);
 }

--- a/sequencercommon/src/main/proto/order.proto
+++ b/sequencercommon/src/main/proto/order.proto
@@ -51,3 +51,10 @@ enum OrderDisposition {
   Canceled = 5;
   AutoReduced = 6;
 }
+
+message BackToBackOrder {
+  string guid = 1;
+  uint64 wallet = 2;
+  repeated string marketIds = 3;
+  Order order = 4;
+}

--- a/sequencercommon/src/main/proto/sequencer.proto
+++ b/sequencercommon/src/main/proto/sequencer.proto
@@ -63,6 +63,7 @@ message SequencerRequest {
     SetFeeRates = 5;
     SetWithdrawalFees = 6;
     SetMarketMinFees = 7;
+    ApplyBackToBackOrder = 8;
   }
   string guid = 1;
   Type type = 2;
@@ -72,6 +73,7 @@ message SequencerRequest {
   optional FeeRates feeRates = 6;
   repeated WithdrawalFee withdrawalFees = 7;
   repeated MarketMinFee marketMinFees = 8;
+  optional BackToBackOrder backToBackOrder = 9;
 }
 
 enum SequencerError {
@@ -83,6 +85,7 @@ enum SequencerError {
   InvalidFeeRate = 5;
   InvalidWithdrawalFee = 6;
   InvalidMarketMinFee = 7;
+  InvalidBackToBackOrder = 8;
 }
 
 message StateDump {

--- a/sequencercommon/src/main/proto/trade.proto
+++ b/sequencercommon/src/main/proto/trade.proto
@@ -13,4 +13,5 @@ message TradeCreated {
   int32 levelIx = 4;
   IntegerValue buyerFee = 5;
   IntegerValue sellerFee = 6;
+  string marketId = 7;
 }


### PR DESCRIPTION
The implementation currently supports 1 hop. The way it works is as follows:

1) For a sell order (sell base to receive quote), the 2 markets would be base:bridge and bridge:quote. So it sells base amount and receives some amount of bridge assets on the base:bridge market, then 2nd order sells all the received bridge assets for quote assets. on the bridge:quote market. Taker only pays fee on 2nd order using the quote assets

2) For a buy order (buy base with quote assets), the 2 markets would be base:bridge and bridge:quote. It first buys bridge assets for quote assets on the bridge:quote market and then the second order buys base assets using the received bridge assets on the base:bridge market. Taker only pays fee on 1st order using the quote assets

The taker would see both trades for the base:bridge and bridge:quote markets - there is no rolling up of trades yet.

There is no changes to the limits - currently limits are reported for the actual markets.