### PR TITLE
Speedup CI build

### DIFF
--- a/.github/workflows/build-push-backend.yml
+++ b/.github/workflows/build-push-backend.yml
@@ -19,12 +19,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup JDK
         uses: ./.github/actions/setup-java-17
-      - name: Build with Gradle Wrapper
-        run: ./gradlew build -x test
+      - name: Setup AWS
+        uses: ./.github/actions/setup-aws
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
       - name: Start Anvil and Postgres containers
         run: |
-          make anvil_image
-          make otterscan_image
           make start_ci_containers
       - name: Check with Gradle Wrapper
         run: ./gradlew check
@@ -35,18 +35,18 @@ jobs:
         uses: dorny/test-reporter@v1.8.0
         if: success() || failure()
         with:
-            name: Unit/Integration Tests
-            path: '**/build/test-results/test/TEST-*.xml'
-            reporter: java-junit
-            fail-on-empty: 'false'
+          name: Unit/Integration Tests
+          path: '**/build/test-results/test/TEST-*.xml'
+          reporter: java-junit
+          fail-on-empty: 'false'
       - name: Store Reports
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-         name: integration-reports
-         path: |
-           **/build/reports/
-           **/build/test-results/
+          name: integration-reports
+          path: |
+            **/build/reports/
+            **/build/test-results/
 
   publish_to_ecr:
     if: ${{ github.event_name == 'push' }}

--- a/docker-compose-ci.yaml
+++ b/docker-compose-ci.yaml
@@ -1,6 +1,6 @@
 services:
   anvil:
-    image: anvil # custom image (./anvil/Dockerfile)
+    image: 851725450525.dkr.ecr.us-east-2.amazonaws.com/anvil:latest
     container_name: anvil
     restart: always
     environment:
@@ -10,7 +10,7 @@ services:
     volumes:
       - anvil-data:/root/.foundry
   anvil-2:
-    image: anvil # custom image (./anvil/Dockerfile)
+    image: 851725450525.dkr.ecr.us-east-2.amazonaws.com/anvil:latest
     container_name: anvil2
     restart: always
     environment:


### PR DESCRIPTION
 - use anvil container from ECR (same as on env)
 - skip otterscan container build

was
<img width="1304" alt="Screenshot 2024-07-12 at 10 28 59 AM" src="https://github.com/user-attachments/assets/187fba51-8fb0-47d7-8662-183923822c2a">


now
<img width="1300" alt="Screenshot 2024-07-12 at 10 29 16 AM" src="https://github.com/user-attachments/assets/e32d20d3-58a1-438a-b734-bcf4dcfe4fde">
