### PR TITLE
Fix mergeOHLC tests

### DIFF
--- a/web-ui/src/utils/pricesUtils.ts
+++ b/web-ui/src/utils/pricesUtils.ts
@@ -17,7 +17,8 @@ export const ohlcDurationsMs: Record<OHLCDuration, number> = {
 export function mergeOHLC(
   draft: OHLC[],
   incoming: OHLC[],
-  duration: OHLCDuration
+  duration: OHLCDuration,
+  currentTimeMs: number = new Date().getTime()
 ): OHLC[] {
   // merge new data
   incoming.forEach((newItem) => {
@@ -27,22 +28,32 @@ export function mergeOHLC(
     )
     if (index == -1) {
       // fill gaps before pushing new ohlc
-      fillGaps(draft, newItem.start.getTime(), ohlcDurationsMs[duration])
+      fillGaps(
+        draft,
+        newItem.start.getTime(),
+        ohlcDurationsMs[duration],
+        currentTimeMs
+      )
 
       draft.push(newItem)
     } else {
       draft[index] = newItem
     }
   })
-  fillGaps(draft, Date.now(), ohlcDurationsMs[duration])
+  fillGaps(draft, Date.now(), ohlcDurationsMs[duration], currentTimeMs)
   return draft
 }
 
-function fillGaps(draft: OHLC[], untilTime: number, ohlcDuration: number) {
+function fillGaps(
+  draft: OHLC[],
+  untilTime: number,
+  ohlcDuration: number,
+  currentTimeMs: number
+) {
   while (
     draft.length > 0 &&
     untilTime - draft[draft.length - 1].start.getTime() > ohlcDuration &&
-    draft[draft.length - 1].start.getTime() + ohlcDuration < Date.now()
+    draft[draft.length - 1].start.getTime() + ohlcDuration < currentTimeMs
   ) {
     const lastItem = draft[draft.length - 1]
 

--- a/web-ui/src/utils/test.ts
+++ b/web-ui/src/utils/test.ts
@@ -41,30 +41,24 @@ describe('PricesUtils', () => {
     }
   }
 
-  it.skip('should work as a no-op', () => {
-    expect(
-      mergeOHLC(
-        [ohlc(60000, 'P1M', 2, 4, 1, 3)],
-        [ohlc(12000, 'P1M', 2, 4, 1, 3)],
-        'P1M'
-      )
-    ).toStrictEqual([ohlc(1000, 'P1M', 2, 4, 1, 3)])
-  })
-  it.skip('should replace ohlc matched by start', () => {
+  it('should replace ohlc matched by start', () => {
     expect(
       mergeOHLC(
         [ohlc(60000, 'P1M', 2, 4, 1, 3)],
         [ohlc(60000, 'P1M', 2, 5, 1, 5)],
-        'P1M'
+        'P1M',
+        60000
       )
     ).toStrictEqual([ohlc(60000, 'P1M', 2, 5, 1, 5)])
   })
-  it.skip('should replace and add ohlc matched by start', () => {
+
+  it('should replace and add ohlc matched by start', () => {
     expect(
       mergeOHLC(
         [ohlc(60000, 'P1M', 2, 4, 1, 3), ohlc(120000, 'P1M', 2, 4, 1, 3)],
         [ohlc(120000, 'P1M', 2, 5, 1, 5), ohlc(180000, 'P1M', 3, 3, 3, 3)],
-        'P1M'
+        'P1M',
+        180000
       )
     ).toStrictEqual([
       ohlc(60000, 'P1M', 2, 4, 1, 3),
@@ -72,19 +66,22 @@ describe('PricesUtils', () => {
       ohlc(180000, 'P1M', 3, 3, 3, 3)
     ])
   })
-  it.skip('should fill-in any gaps', () => {
+
+  it('should fill-in any gaps', () => {
     expect(
       mergeOHLC(
         [ohlc(60000, 'P1M', 2, 4, 1, 3), ohlc(120000, 'P1M', 3, 5, 0, 4)],
         [ohlc(300000, 'P1M', 2, 5, 1, 5)],
-        'P1M'
+        'P1M',
+        360001
       )
     ).toStrictEqual([
       ohlc(60000, 'P1M', 2, 4, 1, 3),
       ohlc(120000, 'P1M', 3, 5, 0, 4),
       ohlc(180000, 'P1M', 4, 4, 4, 4),
       ohlc(240000, 'P1M', 4, 4, 4, 4),
-      ohlc(300000, 'P1M', 2, 5, 1, 5)
+      ohlc(300000, 'P1M', 2, 5, 1, 5),
+      ohlc(360000, 'P1M', 5, 5, 5, 5)
     ])
   })
 })


### PR DESCRIPTION
Tests were failing with `ERR_WORKER_OUT_OF_MEMORY` because `fillGaps` function was trying to fill the data up to current time and in the tests we were using fixed timestamps from 1970s.