### PR TITLE
add tradeId to order executions

### DIFF
--- a/backend/src/main/kotlin/co/chainring/apps/api/Examples.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/Examples.kt
@@ -24,6 +24,7 @@ import co.chainring.core.model.db.MarketId
 import co.chainring.core.model.db.OrderId
 import co.chainring.core.model.db.OrderSide
 import co.chainring.core.model.db.OrderStatus
+import co.chainring.core.model.db.TradeId
 import co.chainring.core.model.db.WithdrawalId
 import co.chainring.core.model.db.WithdrawalStatus
 import kotlinx.datetime.Clock
@@ -90,6 +91,7 @@ object Examples {
         originalAmount = BigInteger("100"),
         executions = listOf(
             Order.Execution(
+                tradeId = TradeId.generate(),
                 timestamp = Clock.System.now(),
                 amount = BigInteger("50"),
                 price = BigDecimal("500"),
@@ -117,6 +119,7 @@ object Examples {
         originalAmount = BigInteger("100"),
         executions = listOf(
             Order.Execution(
+                tradeId = TradeId.generate(),
                 timestamp = Clock.System.now(),
                 amount = BigInteger("50"),
                 price = BigDecimal("500"),

--- a/backend/src/main/kotlin/co/chainring/apps/api/model/Orders.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/model/Orders.kt
@@ -9,6 +9,7 @@ import co.chainring.core.model.db.MarketId
 import co.chainring.core.model.db.OrderId
 import co.chainring.core.model.db.OrderSide
 import co.chainring.core.model.db.OrderStatus
+import co.chainring.core.model.db.TradeId
 import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
@@ -189,6 +190,7 @@ sealed class Order {
 
     @Serializable
     data class Execution(
+        val tradeId: TradeId,
         val timestamp: Instant,
         val amount: BigIntegerJson,
         val price: BigDecimalJson,

--- a/backend/src/main/kotlin/co/chainring/core/model/db/Order.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/Order.kt
@@ -167,6 +167,7 @@ class OrderEntity(guid: EntityID<OrderId>) : GUIDEntity<OrderId>(guid) {
                 originalAmount = this.originalAmount,
                 executions = executions.map { execution ->
                     Order.Execution(
+                        tradeId = execution.trade.guid.value,
                         timestamp = execution.timestamp,
                         amount = execution.trade.amount,
                         price = execution.trade.price,
@@ -194,6 +195,7 @@ class OrderEntity(guid: EntityID<OrderId>) : GUIDEntity<OrderId>(guid) {
                 originalAmount = this.originalAmount,
                 executions = executions.map { execution ->
                     Order.Execution(
+                        tradeId = execution.trade.guid.value,
                         timestamp = execution.timestamp,
                         amount = execution.trade.amount,
                         price = execution.trade.price,
@@ -221,6 +223,7 @@ class OrderEntity(guid: EntityID<OrderId>) : GUIDEntity<OrderId>(guid) {
                 price = this.price!!,
                 executions = executions.map { execution ->
                     Order.Execution(
+                        tradeId = execution.trade.guid.value,
                         timestamp = execution.timestamp,
                         amount = execution.trade.amount,
                         price = execution.trade.price,

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/OrderRoutesApiTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/OrderRoutesApiTest.kt
@@ -538,6 +538,7 @@ class OrderRoutesApiTest : OrderBaseTest() {
         val trade = getTradesForOrders(listOf(marketBuyOrderApiResponse.orderId)).first().also {
             assertAmount(AssetAmount(baseSymbol, "0.00043210"), it.amount)
             assertAmount(AssetAmount(quoteSymbol, "17.550"), it.price)
+            assertEquals(takerApiClient.getOrder(marketBuyOrderApiResponse.orderId).executions.first().tradeId, it.id.value)
         }
 
         takerWsClient.apply {


### PR DESCRIPTION
in order to reconcile status hummingbot requires a way to fetch all trades for order. Executions already provide enough information, just passing tradeId to avoid filling with timestamp