### PR TITLE
Market trades broadacsting over webscocket

### DIFF
--- a/backend/src/main/kotlin/co/chainring/apps/api/model/websocket/IncomingWSMessage.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/model/websocket/IncomingWSMessage.kt
@@ -37,12 +37,16 @@ sealed class SubscriptionTopic {
     data class Prices(val marketId: MarketId, val duration: OHLCDuration) : SubscriptionTopic()
 
     @Serializable
-    @SerialName("Trades")
-    data object Trades : SubscriptionTopic()
+    @SerialName("MyTrades")
+    data object MyTrades : SubscriptionTopic()
 
     @Serializable
-    @SerialName("Orders")
-    data object Orders : SubscriptionTopic()
+    @SerialName("MarketTrades")
+    data class MarketTrades(val marketId: MarketId) : SubscriptionTopic()
+
+    @Serializable
+    @SerialName("MyOrders")
+    data object MyOrders : SubscriptionTopic()
 
     @Serializable
     @SerialName("Balances")

--- a/backend/src/main/kotlin/co/chainring/apps/api/model/websocket/OutgoingWSMessage.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/model/websocket/OutgoingWSMessage.kt
@@ -2,16 +2,36 @@ package co.chainring.apps.api.model.websocket
 
 import co.chainring.apps.api.model.Balance
 import co.chainring.apps.api.model.BigDecimalJson
+import co.chainring.apps.api.model.BigDecimalSerializer
+import co.chainring.apps.api.model.BigIntegerJson
+import co.chainring.apps.api.model.BigIntegerSerializer
 import co.chainring.apps.api.model.MarketLimits
 import co.chainring.apps.api.model.Order
 import co.chainring.apps.api.model.Trade
 import co.chainring.core.model.db.MarketId
 import co.chainring.core.model.db.OHLCDuration
+import co.chainring.core.model.db.OrderExecutionEntity
+import co.chainring.core.model.db.OrderSide
+import co.chainring.core.model.db.TradeId
 import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.descriptors.buildSerialDescriptor
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.decodeStructure
+import kotlinx.serialization.encoding.encodeCollection
 import kotlinx.serialization.json.JsonClassDiscriminator
+import kotlinx.serialization.serializer
+import java.math.BigDecimal
+import java.math.BigInteger
 
 @OptIn(ExperimentalSerializationApi::class)
 @JsonClassDiscriminator("type")
@@ -79,26 +99,105 @@ data class OHLC(
 )
 
 @Serializable
-@SerialName("Trades")
-data class Trades(
+@SerialName("MyTrades")
+data class MyTrades(
     val trades: List<Trade>,
 ) : Publishable()
 
 @Serializable
-@SerialName("TradesCreated")
-data class TradesCreated(
+@SerialName("MyTradesCreated")
+data class MyTradesCreated(
     val trades: List<Trade>,
 ) : Publishable()
 
 @Serializable
-@SerialName("TradesUpdated")
-data class TradesUpdated(
+@SerialName("MarketTradesCreated")
+data class MarketTradesCreated(
+    val marketId: MarketId,
+    val trades: List<Trade>,
+) : Publishable() {
+    @Serializable(with = Trade.AsArraySerializer::class)
+    data class Trade(
+        val id: TradeId,
+        val type: OrderSide,
+        val amount: BigIntegerJson,
+        val price: BigDecimalJson,
+        val timestamp: Instant,
+    ) {
+        constructor(takerOrderExecution: OrderExecutionEntity) :
+            this(
+                takerOrderExecution.tradeGuid.value,
+                takerOrderExecution.order.side,
+                takerOrderExecution.trade.amount,
+                takerOrderExecution.trade.price,
+                takerOrderExecution.timestamp,
+            )
+
+        object AsArraySerializer : KSerializer<Trade> {
+            private val tradeIdSerializer = serializer(TradeId::class.javaObjectType)
+            private val orderSideSerializer = serializer(OrderSide::class.javaObjectType)
+            private val amountSerializer = BigIntegerSerializer
+            private val priceSerializer = BigDecimalSerializer
+            private val timestampSerializer = serializer<Long>()
+
+            @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
+            override val descriptor: SerialDescriptor = buildSerialDescriptor("MarketTradesCreated.Trade", StructureKind.LIST) {
+                element("id", tradeIdSerializer.descriptor)
+                element("type", orderSideSerializer.descriptor)
+                element("amount", amountSerializer.descriptor)
+                element("price", priceSerializer.descriptor)
+                element("timestamp", timestampSerializer.descriptor)
+            }
+
+            override fun serialize(encoder: Encoder, value: Trade) =
+                encoder.encodeCollection(descriptor, 5) {
+                    encodeSerializableElement(tradeIdSerializer.descriptor, 0, tradeIdSerializer, value.id)
+                    encodeSerializableElement(orderSideSerializer.descriptor, 1, orderSideSerializer, value.type)
+                    encodeSerializableElement(amountSerializer.descriptor, 2, amountSerializer, value.amount)
+                    encodeSerializableElement(priceSerializer.descriptor, 3, priceSerializer, value.price)
+                    encodeSerializableElement(timestampSerializer.descriptor, 4, timestampSerializer, value.timestamp.toEpochMilliseconds())
+                }
+
+            override fun deserialize(decoder: Decoder): Trade =
+                decoder.decodeStructure(descriptor) {
+                    var id: TradeId? = null
+                    var type: OrderSide? = null
+                    var amount: BigInteger? = null
+                    var price: BigDecimal? = null
+                    var timestamp: Instant? = null
+
+                    while (true) {
+                        when (val index = decodeElementIndex(descriptor)) {
+                            0 -> id = decodeSerializableElement(tradeIdSerializer.descriptor, 0, tradeIdSerializer) as TradeId
+                            1 -> type = decodeSerializableElement(orderSideSerializer.descriptor, 1, orderSideSerializer) as OrderSide
+                            2 -> amount = decodeSerializableElement(amountSerializer.descriptor, 2, amountSerializer)
+                            3 -> price = decodeSerializableElement(priceSerializer.descriptor, 3, priceSerializer)
+                            4 -> timestamp = Instant.fromEpochMilliseconds(decodeSerializableElement(timestampSerializer.descriptor, 4, timestampSerializer))
+                            CompositeDecoder.DECODE_DONE -> break
+                            else -> error("Unexpected index: $index")
+                        }
+                    }
+                    Trade(
+                        id ?: throw SerializationException("Trade id is missing in json array"),
+                        type = type ?: throw SerializationException("Trade type is missing in json array"),
+                        amount = amount ?: throw SerializationException("Trade amount is missing in json array"),
+                        price = price ?: throw SerializationException("Trade price is missing in json array"),
+                        timestamp = timestamp ?: throw SerializationException("Trade timestamp is missing in json array"),
+                    )
+                }
+        }
+    }
+}
+
+@Serializable
+@SerialName("MyTradesUpdated")
+data class MyTradesUpdated(
     val trades: List<Trade>,
 ) : Publishable()
 
 @Serializable
-@SerialName("Orders")
-data class Orders(
+@SerialName("MyOrders")
+data class MyOrders(
     val orders: List<Order>,
 ) : Publishable()
 
@@ -109,14 +208,14 @@ data class Balances(
 ) : Publishable()
 
 @Serializable
-@SerialName("OrderCreated")
-data class OrderCreated(
+@SerialName("MyOrderCreated")
+data class MyOrderCreated(
     val order: Order,
 ) : Publishable()
 
 @Serializable
-@SerialName("OrderUpdated")
-data class OrderUpdated(
+@SerialName("MyOrderUpdated")
+data class MyOrderUpdated(
     val order: Order,
 ) : Publishable()
 

--- a/backend/src/main/kotlin/co/chainring/apps/ring/SettlementCoordinator.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/ring/SettlementCoordinator.kt
@@ -1,6 +1,6 @@
 package co.chainring.apps.ring
 
-import co.chainring.apps.api.model.websocket.TradesUpdated
+import co.chainring.apps.api.model.websocket.MyTradesUpdated
 import co.chainring.core.blockchain.BlockchainClient
 import co.chainring.core.blockchain.DefaultBlockParam
 import co.chainring.core.evm.Adjustment
@@ -469,7 +469,7 @@ class SettlementCoordinator(
             .forEach { (walletAddress, executions) ->
                 broadcasterNotifications.add(
                     BroadcasterNotification(
-                        TradesUpdated(executions.map { it.toTradeResponse() }),
+                        MyTradesUpdated(executions.map { it.toTradeResponse() }),
                         recipient = walletAddress,
                     ),
                 )

--- a/backend/src/test/kotlin/co/chainring/apps/api/model/MarketTradesCreatedWsMessageSerializationTest.kt
+++ b/backend/src/test/kotlin/co/chainring/apps/api/model/MarketTradesCreatedWsMessageSerializationTest.kt
@@ -1,0 +1,34 @@
+package co.chainring.apps.api.model
+
+import co.chainring.apps.api.model.websocket.MarketTradesCreated
+import co.chainring.core.model.db.MarketId
+import co.chainring.core.model.db.OrderSide
+import co.chainring.core.model.db.TradeId
+import kotlinx.datetime.Instant
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.math.BigInteger
+
+class MarketTradesCreatedWsMessageSerializationTest {
+    @Test
+    fun `test market trades are serialized into array`() {
+        val message = MarketTradesCreated(
+            MarketId("BTC/ETH"),
+            listOf(
+                MarketTradesCreated.Trade(
+                    TradeId("t1"),
+                    OrderSide.Buy,
+                    amount = BigInteger.ONE,
+                    price = BigDecimal.TEN,
+                    timestamp = Instant.fromEpochMilliseconds(1722001494355),
+                ),
+            ),
+        )
+        val str = Json.encodeToString(message)
+        assertEquals("{\"marketId\":\"BTC/ETH\",\"trades\":[[\"t1\",\"Buy\",\"1\",\"10\",1722001494355]]}", str)
+        assertEquals(message, Json.decodeFromString<MarketTradesCreated>(str))
+    }
+}

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/BackToBackOrderTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/BackToBackOrderTest.kt
@@ -18,9 +18,9 @@ import co.chainring.integrationtests.utils.ExpectedBalance
 import co.chainring.integrationtests.utils.assertBalances
 import co.chainring.integrationtests.utils.assertBalancesMessageReceived
 import co.chainring.integrationtests.utils.assertLimitsMessageReceived
-import co.chainring.integrationtests.utils.assertOrderCreatedMessageReceived
-import co.chainring.integrationtests.utils.assertOrderUpdatedMessageReceived
-import co.chainring.integrationtests.utils.assertTradesCreatedMessageReceived
+import co.chainring.integrationtests.utils.assertMyOrderCreatedMessageReceived
+import co.chainring.integrationtests.utils.assertMyOrderUpdatedMessageReceived
+import co.chainring.integrationtests.utils.assertMyTradesCreatedMessageReceived
 import co.chainring.integrationtests.utils.ofAsset
 import co.chainring.sequencer.core.notional
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -48,7 +48,7 @@ class BackToBackOrderTest : OrderBaseTest() {
                 AssetAmount(quoteSymbol, "20"),
             ),
             subscribeToOrderBook = false,
-            subscribeToOrderPrices = false,
+            subscribeToPrices = false,
         )
 
         val (takerApiClient, takerWallet, takerWsClient) = setupTrader(
@@ -60,7 +60,7 @@ class BackToBackOrderTest : OrderBaseTest() {
                 AssetAmount(baseSymbol, "0.6"),
             ),
             subscribeToOrderBook = false,
-            subscribeToOrderPrices = false,
+            subscribeToPrices = false,
         )
 
         // starting onchain balances
@@ -113,7 +113,7 @@ class BackToBackOrderTest : OrderBaseTest() {
         assertEquals(1, limitBuyOrder2.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
 
         repeat(2) {
-            makerWsClient.assertOrderCreatedMessageReceived()
+            makerWsClient.assertMyOrderCreatedMessageReceived()
             makerWsClient.assertLimitsMessageReceived()
         }
 
@@ -128,8 +128,8 @@ class BackToBackOrderTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertOrderCreatedMessageReceived()
-            assertTradesCreatedMessageReceived {
+            assertMyOrderCreatedMessageReceived()
+            assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
 
                 assertEquals(btcbtc2Market.id, it.trades[0].marketId)
@@ -146,7 +146,7 @@ class BackToBackOrderTest : OrderBaseTest() {
                 assertEquals(BigDecimal("0.2052").toFundamentalUnits(eth2.decimals), it.trades[1].feeAmount)
                 assertEquals(eth2.name, it.trades[1].feeSymbol.value)
             }
-            assertOrderUpdatedMessageReceived {
+            assertMyOrderUpdatedMessageReceived {
                 assertEquals(BigDecimal("0.6").toFundamentalUnits(market.baseDecimals), it.order.amount)
                 assertEquals(it.order.status, OrderStatus.Filled)
             }
@@ -160,10 +160,10 @@ class BackToBackOrderTest : OrderBaseTest() {
         }
 
         makerWsClient.apply {
-            assertTradesCreatedMessageReceived {
+            assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
             }
-            repeat(2) { assertOrderUpdatedMessageReceived() }
+            repeat(2) { assertMyOrderUpdatedMessageReceived() }
             assertBalancesMessageReceived()
             assertLimitsMessageReceived()
         }
@@ -234,7 +234,7 @@ class BackToBackOrderTest : OrderBaseTest() {
                 AssetAmount(quoteSymbol, "400000"),
             ),
             subscribeToOrderBook = false,
-            subscribeToOrderPrices = false,
+            subscribeToPrices = false,
         )
 
         val (takerApiClient, takerWallet, takerWsClient) = setupTrader(
@@ -246,7 +246,7 @@ class BackToBackOrderTest : OrderBaseTest() {
                 AssetAmount(baseSymbol, "4.9"),
             ),
             subscribeToOrderBook = false,
-            subscribeToOrderPrices = false,
+            subscribeToPrices = false,
         )
 
         // starting onchain balances
@@ -299,7 +299,7 @@ class BackToBackOrderTest : OrderBaseTest() {
         assertEquals(1, limitBuyOrder2.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
 
         repeat(2) {
-            makerWsClient.assertOrderCreatedMessageReceived()
+            makerWsClient.assertMyOrderCreatedMessageReceived()
             makerWsClient.assertLimitsMessageReceived()
         }
 
@@ -314,8 +314,8 @@ class BackToBackOrderTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertOrderCreatedMessageReceived()
-            assertTradesCreatedMessageReceived {
+            assertMyOrderCreatedMessageReceived()
+            assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
 
                 assertEquals(btcbtc2Market.id, it.trades[0].marketId)
@@ -332,7 +332,7 @@ class BackToBackOrderTest : OrderBaseTest() {
                 assertEquals(BigDecimal("3959.999999").toFundamentalUnits(usdc2.decimals), it.trades[1].feeAmount)
                 assertEquals(usdc2.name, it.trades[1].feeSymbol.value)
             }
-            assertOrderUpdatedMessageReceived {
+            assertMyOrderUpdatedMessageReceived {
                 assertEquals(BigDecimal("3.9").toFundamentalUnits(market.baseDecimals), it.order.amount)
                 assertEquals(it.order.status, OrderStatus.Partial)
             }
@@ -346,10 +346,10 @@ class BackToBackOrderTest : OrderBaseTest() {
         }
 
         makerWsClient.apply {
-            assertTradesCreatedMessageReceived {
+            assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
             }
-            repeat(2) { assertOrderUpdatedMessageReceived() }
+            repeat(2) { assertMyOrderUpdatedMessageReceived() }
             assertBalancesMessageReceived()
             assertLimitsMessageReceived()
         }
@@ -420,7 +420,7 @@ class BackToBackOrderTest : OrderBaseTest() {
                 AssetAmount(baseSymbol, "0.9"),
             ),
             subscribeToOrderBook = false,
-            subscribeToOrderPrices = false,
+            subscribeToPrices = false,
         )
 
         val (takerApiClient, takerWallet, takerWsClient) = setupTrader(
@@ -433,7 +433,7 @@ class BackToBackOrderTest : OrderBaseTest() {
                 AssetAmount(quoteSymbol, "10"),
             ),
             subscribeToOrderBook = false,
-            subscribeToOrderPrices = false,
+            subscribeToPrices = false,
         )
 
         // starting onchain balances
@@ -491,7 +491,7 @@ class BackToBackOrderTest : OrderBaseTest() {
         assertEquals(1, limitSellOrder2.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
 
         repeat(2) {
-            makerWsClient.assertOrderCreatedMessageReceived()
+            makerWsClient.assertMyOrderCreatedMessageReceived()
             makerWsClient.assertLimitsMessageReceived()
         }
 
@@ -505,8 +505,8 @@ class BackToBackOrderTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertOrderCreatedMessageReceived()
-            assertTradesCreatedMessageReceived {
+            assertMyOrderCreatedMessageReceived()
+            assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
 
                 assertEquals(btc2Eth2Market.id, it.trades[0].marketId)
@@ -523,7 +523,7 @@ class BackToBackOrderTest : OrderBaseTest() {
                 assertEquals(BigInteger.ZERO, it.trades[1].feeAmount)
                 assertEquals(btc2.name, it.trades[1].feeSymbol.value)
             }
-            assertOrderUpdatedMessageReceived {
+            assertMyOrderUpdatedMessageReceived {
                 assertEquals(baseOrderAmount.inFundamentalUnits, it.order.amount)
                 assertEquals(it.order.status, OrderStatus.Filled)
             }
@@ -537,10 +537,10 @@ class BackToBackOrderTest : OrderBaseTest() {
         }
 
         makerWsClient.apply {
-            assertTradesCreatedMessageReceived {
+            assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
             }
-            repeat(2) { assertOrderUpdatedMessageReceived() }
+            repeat(2) { assertMyOrderUpdatedMessageReceived() }
             assertBalancesMessageReceived()
             assertLimitsMessageReceived()
         }
@@ -611,7 +611,7 @@ class BackToBackOrderTest : OrderBaseTest() {
                 AssetAmount(baseSymbol, "1.1"),
             ),
             subscribeToOrderBook = false,
-            subscribeToOrderPrices = false,
+            subscribeToPrices = false,
         )
 
         val (takerApiClient, takerWallet, takerWsClient) = setupTrader(
@@ -624,7 +624,7 @@ class BackToBackOrderTest : OrderBaseTest() {
                 AssetAmount(quoteSymbol, "30"),
             ),
             subscribeToOrderBook = false,
-            subscribeToOrderPrices = false,
+            subscribeToPrices = false,
         )
 
         // starting onchain balances
@@ -683,7 +683,7 @@ class BackToBackOrderTest : OrderBaseTest() {
         assertEquals(1, limitSellOrder2.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
 
         repeat(2) {
-            makerWsClient.assertOrderCreatedMessageReceived()
+            makerWsClient.assertMyOrderCreatedMessageReceived()
             makerWsClient.assertLimitsMessageReceived()
         }
 
@@ -697,8 +697,8 @@ class BackToBackOrderTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertOrderCreatedMessageReceived()
-            assertTradesCreatedMessageReceived {
+            assertMyOrderCreatedMessageReceived()
+            assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
 
                 assertEquals(btc2Eth2Market.id, it.trades[0].marketId)
@@ -715,7 +715,7 @@ class BackToBackOrderTest : OrderBaseTest() {
                 assertEquals(BigInteger.ZERO, it.trades[1].feeAmount)
                 assertEquals(btc2.name, it.trades[1].feeSymbol.value)
             }
-            assertOrderUpdatedMessageReceived {
+            assertMyOrderUpdatedMessageReceived {
                 assertEquals(it.order.status, OrderStatus.Partial)
             }
             assertBalancesMessageReceived(
@@ -728,10 +728,10 @@ class BackToBackOrderTest : OrderBaseTest() {
         }
 
         makerWsClient.apply {
-            assertTradesCreatedMessageReceived {
+            assertMyTradesCreatedMessageReceived {
                 assertEquals(2, it.trades.size)
             }
-            repeat(2) { assertOrderUpdatedMessageReceived() }
+            repeat(2) { assertMyOrderUpdatedMessageReceived() }
             assertBalancesMessageReceived()
             assertLimitsMessageReceived()
         }

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/OrderPercentageSwapTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/OrderPercentageSwapTest.kt
@@ -20,9 +20,9 @@ import co.chainring.integrationtests.utils.ExpectedBalance
 import co.chainring.integrationtests.utils.assertBalances
 import co.chainring.integrationtests.utils.assertBalancesMessageReceived
 import co.chainring.integrationtests.utils.assertLimitsMessageReceived
-import co.chainring.integrationtests.utils.assertOrderCreatedMessageReceived
-import co.chainring.integrationtests.utils.assertOrderUpdatedMessageReceived
-import co.chainring.integrationtests.utils.assertTradesCreatedMessageReceived
+import co.chainring.integrationtests.utils.assertMyOrderCreatedMessageReceived
+import co.chainring.integrationtests.utils.assertMyOrderUpdatedMessageReceived
+import co.chainring.integrationtests.utils.assertMyTradesCreatedMessageReceived
 import co.chainring.integrationtests.utils.ofAsset
 import co.chainring.integrationtests.utils.sum
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -50,7 +50,7 @@ class OrderPercentageSwapTest : OrderBaseTest() {
                 AssetAmount(quoteSymbol, "20000"),
             ),
             subscribeToOrderBook = false,
-            subscribeToOrderPrices = false,
+            subscribeToPrices = false,
         )
 
         val (takerApiClient, takerWallet, takerWsClient) = setupTrader(
@@ -62,7 +62,7 @@ class OrderPercentageSwapTest : OrderBaseTest() {
                 AssetAmount(baseSymbol, "0.1"),
             ),
             subscribeToOrderBook = false,
-            subscribeToOrderPrices = false,
+            subscribeToPrices = false,
         )
 
         // starting onchain balances
@@ -94,7 +94,7 @@ class OrderPercentageSwapTest : OrderBaseTest() {
 
         assertEquals(4, createBatchLimitOrders.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
 
-        repeat(4) { makerWsClient.assertOrderCreatedMessageReceived() }
+        repeat(4) { makerWsClient.assertMyOrderCreatedMessageReceived() }
         makerWsClient.assertLimitsMessageReceived(market, base = BigDecimal.ZERO, quote = BigDecimal("10314.1"))
 
         assertEquals(4, makerApiClient.listOrders(listOf(OrderStatus.Open), null).orders.size)
@@ -110,11 +110,11 @@ class OrderPercentageSwapTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertOrderCreatedMessageReceived()
-            assertTradesCreatedMessageReceived { msg ->
+            assertMyOrderCreatedMessageReceived()
+            assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(4, msg.trades.size)
             }
-            assertOrderUpdatedMessageReceived {
+            assertMyOrderUpdatedMessageReceived {
                 assertEquals(BigDecimal("0.1").toFundamentalUnits(market.baseDecimals), it.order.amount)
             }
             assertBalancesMessageReceived {
@@ -127,10 +127,10 @@ class OrderPercentageSwapTest : OrderBaseTest() {
         }
 
         makerWsClient.apply {
-            assertTradesCreatedMessageReceived { msg ->
+            assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(4, msg.trades.size)
             }
-            repeat(4) { assertOrderUpdatedMessageReceived() }
+            repeat(4) { assertMyOrderUpdatedMessageReceived() }
             assertBalancesMessageReceived()
             assertLimitsMessageReceived(market, base = BigDecimal("0.1"), quote = BigDecimal("10314.1"))
         }
@@ -190,7 +190,7 @@ class OrderPercentageSwapTest : OrderBaseTest() {
                 AssetAmount(baseSymbol, "0.2"),
             ),
             subscribeToOrderBook = false,
-            subscribeToOrderPrices = false,
+            subscribeToPrices = false,
         )
 
         val (takerApiClient, takerWallet, takerWsClient) = setupTrader(
@@ -203,7 +203,7 @@ class OrderPercentageSwapTest : OrderBaseTest() {
                 AssetAmount(quoteSymbol, "6987"),
             ),
             subscribeToOrderBook = false,
-            subscribeToOrderPrices = false,
+            subscribeToPrices = false,
         )
 
         // starting onchain balances
@@ -235,7 +235,7 @@ class OrderPercentageSwapTest : OrderBaseTest() {
 
         assertEquals(4, createBatchLimitOrders.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
 
-        repeat(4) { makerWsClient.assertOrderCreatedMessageReceived() }
+        repeat(4) { makerWsClient.assertMyOrderCreatedMessageReceived() }
         makerWsClient.assertLimitsMessageReceived(market, base = BigDecimal("0.06"), quote = BigDecimal("0"))
 
         assertEquals(4, makerApiClient.listOrders(listOf(OrderStatus.Open), null).orders.size)
@@ -252,20 +252,20 @@ class OrderPercentageSwapTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertOrderCreatedMessageReceived()
-            assertTradesCreatedMessageReceived { msg ->
+            assertMyOrderCreatedMessageReceived()
+            assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(4, msg.trades.size)
             }
-            assertOrderUpdatedMessageReceived()
+            assertMyOrderUpdatedMessageReceived()
             assertBalancesMessageReceived()
             assertLimitsMessageReceived(market, base = BigDecimal("0.1"), quote = BigDecimal("0"))
         }
 
         makerWsClient.apply {
-            assertTradesCreatedMessageReceived { msg ->
+            assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(4, msg.trades.size)
             }
-            repeat(4) { assertOrderUpdatedMessageReceived() }
+            repeat(4) { assertMyOrderUpdatedMessageReceived() }
             assertBalancesMessageReceived()
             assertLimitsMessageReceived(market, base = BigDecimal("0.06"), quote = BigDecimal("6781.5"))
         }
@@ -334,7 +334,7 @@ class OrderPercentageSwapTest : OrderBaseTest() {
                 AssetAmount(baseSymbol, "0.2"),
             ),
             subscribeToOrderBook = false,
-            subscribeToOrderPrices = false,
+            subscribeToPrices = false,
         )
 
         val (takerApiClient, takerWallet, takerWsClient) = setupTrader(
@@ -347,7 +347,7 @@ class OrderPercentageSwapTest : OrderBaseTest() {
                 AssetAmount(quoteSymbol, quoteSymbolDeposit),
             ),
             subscribeToOrderBook = false,
-            subscribeToOrderPrices = false,
+            subscribeToPrices = false,
         )
 
         makerApiClient.batchOrders(
@@ -370,7 +370,7 @@ class OrderPercentageSwapTest : OrderBaseTest() {
             ),
         )
 
-        repeat(limitOrders.size) { makerWsClient.assertOrderCreatedMessageReceived() }
+        repeat(limitOrders.size) { makerWsClient.assertMyOrderCreatedMessageReceived() }
         makerWsClient.assertLimitsMessageReceived()
 
         assertEquals(limitOrders.size, makerApiClient.listOrders(listOf(OrderStatus.Open), null).orders.size)
@@ -384,20 +384,20 @@ class OrderPercentageSwapTest : OrderBaseTest() {
         )
 
         takerWsClient.apply {
-            assertOrderCreatedMessageReceived()
-            assertTradesCreatedMessageReceived { msg ->
+            assertMyOrderCreatedMessageReceived()
+            assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(limitOrders.size, msg.trades.size)
             }
-            assertOrderUpdatedMessageReceived()
+            assertMyOrderUpdatedMessageReceived()
             assertBalancesMessageReceived()
             assertLimitsMessageReceived()
         }
 
         makerWsClient.apply {
-            assertTradesCreatedMessageReceived { msg ->
+            assertMyTradesCreatedMessageReceived { msg ->
                 assertEquals(limitOrders.size, msg.trades.size)
             }
-            repeat(limitOrders.size) { assertOrderUpdatedMessageReceived() }
+            repeat(limitOrders.size) { assertMyOrderUpdatedMessageReceived() }
             assertBalancesMessageReceived()
             assertLimitsMessageReceived()
         }

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/exchange/MarketTradesBroadcastingTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/exchange/MarketTradesBroadcastingTest.kt
@@ -1,0 +1,260 @@
+package co.chainring.integrationtests.exchange
+
+import co.chainring.apps.api.model.BatchOrdersApiRequest
+import co.chainring.apps.api.model.CancelOrderApiRequest
+import co.chainring.apps.api.model.CreateOrderApiRequest
+import co.chainring.apps.api.model.OrderAmount
+import co.chainring.apps.api.model.RequestStatus
+import co.chainring.apps.api.model.websocket.MarketTradesCreated
+import co.chainring.core.model.EvmSignature
+import co.chainring.core.model.db.ChainId
+import co.chainring.core.model.db.OrderId
+import co.chainring.core.model.db.OrderSide
+import co.chainring.core.model.db.OrderStatus
+import co.chainring.core.utils.generateOrderNonce
+import co.chainring.integrationtests.testutils.AppUnderTestRunner
+import co.chainring.integrationtests.testutils.OrderBaseTest
+import co.chainring.integrationtests.utils.AssetAmount
+import co.chainring.integrationtests.utils.TestApiClient
+import co.chainring.integrationtests.utils.assertBalancesMessageReceived
+import co.chainring.integrationtests.utils.assertMarketTradesCreatedMessageReceived
+import co.chainring.integrationtests.utils.assertMyOrderCreatedMessageReceived
+import co.chainring.integrationtests.utils.assertMyOrderUpdatedMessageReceived
+import co.chainring.integrationtests.utils.assertMyTradesCreatedMessageReceived
+import co.chainring.integrationtests.utils.blocking
+import co.chainring.integrationtests.utils.subscribeToMarketTrades
+import co.chainring.integrationtests.utils.toCancelOrderRequest
+import org.http4k.client.WebsocketClient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.math.BigInteger
+
+@ExtendWith(AppUnderTestRunner::class)
+class MarketTradesBroadcastingTest : OrderBaseTest() {
+    @Test
+    fun `market trades are broadcasted to subscribers`() {
+        val market = btcUsdcMarket
+        val baseSymbol = btc
+        val quoteSymbol = usdc
+
+        val (makerApiClient, makerWallet, makerWsClient) = setupTrader(
+            market.id,
+            airdrops = listOf(
+                AssetAmount(baseSymbol, "0.5"),
+                AssetAmount(quoteSymbol, "500"),
+            ),
+            deposits = listOf(
+                AssetAmount(baseSymbol, "0.2"),
+                AssetAmount(quoteSymbol, "500"),
+            ),
+            subscribeToOrderBook = false,
+            subscribeToPrices = false,
+            subscribeToLimits = false,
+        )
+
+        val (takerApiClient, takerWallet, takerWsClient) = setupTrader(
+            market.id,
+            airdrops = listOf(
+                AssetAmount(baseSymbol, "0.5"),
+                AssetAmount(quoteSymbol, "5000"),
+            ),
+            deposits = listOf(
+                AssetAmount(quoteSymbol, "5000"),
+            ),
+            subscribeToOrderBook = false,
+            subscribeToPrices = false,
+            subscribeToLimits = false,
+        )
+
+        val marketTradesObserver = WebsocketClient.blocking(TestApiClient().authToken).apply {
+            subscribeToMarketTrades(market.id)
+        }
+
+        // place 3 orders
+        val createBatchLimitOrders = makerApiClient.batchOrders(
+            BatchOrdersApiRequest(
+                marketId = market.id,
+                createOrders = listOf("0.001", "0.002", "0.003").map {
+                    makerWallet.signOrder(
+                        CreateOrderApiRequest.Limit(
+                            nonce = generateOrderNonce(),
+                            marketId = market.id,
+                            side = OrderSide.Sell,
+                            amount = OrderAmount.Fixed(AssetAmount(baseSymbol, it).inFundamentalUnits),
+                            price = BigDecimal("68400.000"),
+                            signature = EvmSignature.emptySignature(),
+                            verifyingChainId = ChainId.empty,
+                        ),
+                    )
+                },
+                cancelOrders = listOf(),
+            ),
+        )
+
+        assertEquals(3, createBatchLimitOrders.createdOrders.count())
+        repeat(3) { makerWsClient.assertMyOrderCreatedMessageReceived() }
+
+        val batchOrderResponse = makerApiClient.batchOrders(
+            BatchOrdersApiRequest(
+                marketId = market.id,
+                createOrders = listOf("0.004", "0.005", "0.006").map {
+                    makerWallet.signOrder(
+                        CreateOrderApiRequest.Limit(
+                            nonce = generateOrderNonce(),
+                            marketId = market.id,
+                            side = OrderSide.Sell,
+                            amount = OrderAmount.Fixed(AssetAmount(baseSymbol, it).inFundamentalUnits),
+                            price = BigDecimal("68400.000"),
+                            signature = EvmSignature.emptySignature(),
+                            verifyingChainId = ChainId.empty,
+                        ),
+                    )
+                },
+                cancelOrders = listOf(
+                    createBatchLimitOrders.createdOrders[2].toCancelOrderRequest(makerWallet),
+                    makerWallet.signCancelOrder(
+                        CancelOrderApiRequest(
+                            orderId = OrderId.generate(),
+                            marketId = market.id,
+                            amount = BigInteger.ZERO,
+                            side = OrderSide.Buy,
+                            nonce = generateOrderNonce(),
+                            signature = EvmSignature.emptySignature(),
+                            verifyingChainId = ChainId.empty,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals(3, batchOrderResponse.createdOrders.count { it.requestStatus == RequestStatus.Accepted })
+        assertEquals(1, batchOrderResponse.canceledOrders.count { it.requestStatus == RequestStatus.Accepted })
+        assertEquals(1, batchOrderResponse.canceledOrders.count { it.requestStatus == RequestStatus.Rejected })
+
+        repeat(3) { makerWsClient.assertMyOrderCreatedMessageReceived() }
+        makerWsClient.assertMyOrderUpdatedMessageReceived()
+
+        assertEquals(5, makerApiClient.listOrders(listOf(OrderStatus.Open), null).orders.size)
+
+        // total BTC available is 0.001 + 0.002 + 0.004 + 0.005 + 0.006 = 0.018
+        val takerOrderAmount = AssetAmount(baseSymbol, "0.018")
+        // create a market orders that should match against the 5 limit orders
+        takerApiClient.createMarketOrder(
+            market,
+            OrderSide.Buy,
+            amount = takerOrderAmount.amount,
+            takerWallet,
+        )
+
+        takerWsClient.apply {
+            assertMyOrderCreatedMessageReceived()
+            assertMyTradesCreatedMessageReceived { msg ->
+                assertEquals(5, msg.trades.size)
+            }
+            assertMyOrderUpdatedMessageReceived()
+            assertBalancesMessageReceived()
+        }
+
+        makerWsClient.apply {
+            assertMyTradesCreatedMessageReceived { msg ->
+                assertEquals(5, msg.trades.size)
+            }
+            repeat(5) { assertMyOrderUpdatedMessageReceived() }
+            assertBalancesMessageReceived()
+        }
+
+        val takerBuyOrders = takerApiClient.listOrders(emptyList(), market.id).orders
+        assertEquals(1, takerBuyOrders.count { it.status == OrderStatus.Filled })
+        assertEquals(5, makerApiClient.listOrders(listOf(OrderStatus.Filled), market.id).orders.size)
+
+        val buyTrades = getTradesForOrders(takerBuyOrders.map { it.id })
+        assertEquals(5, buyTrades.size)
+
+        marketTradesObserver.assertMarketTradesCreatedMessageReceived(market.id) { msg ->
+            assertEquals(5, msg.trades.size)
+            assertEquals(
+                buyTrades.map {
+                    MarketTradesCreated.Trade(
+                        it.id.value,
+                        OrderSide.Buy,
+                        price = it.price,
+                        amount = it.amount,
+                        timestamp = it.timestamp,
+                    )
+                },
+                msg.trades,
+            )
+        }
+
+        makerApiClient.batchOrders(
+            BatchOrdersApiRequest(
+                marketId = market.id,
+                createOrders = listOf("0.001", "0.002").map {
+                    makerWallet.signOrder(
+                        CreateOrderApiRequest.Limit(
+                            nonce = generateOrderNonce(),
+                            marketId = market.id,
+                            side = OrderSide.Buy,
+                            amount = OrderAmount.Fixed(AssetAmount(baseSymbol, it).inFundamentalUnits),
+                            price = BigDecimal("68500.000"),
+                            signature = EvmSignature.emptySignature(),
+                            verifyingChainId = ChainId.empty,
+                        ),
+                    )
+                },
+                cancelOrders = listOf(),
+            ),
+        )
+
+        repeat(2) { makerWsClient.assertMyOrderCreatedMessageReceived() }
+
+        takerApiClient.createMarketOrder(
+            market,
+            OrderSide.Sell,
+            amount = BigDecimal("0.003"),
+            takerWallet,
+        )
+
+        takerWsClient.apply {
+            assertMyOrderCreatedMessageReceived()
+            assertMyTradesCreatedMessageReceived { msg ->
+                assertEquals(2, msg.trades.size)
+            }
+            assertMyOrderUpdatedMessageReceived()
+            assertBalancesMessageReceived()
+        }
+
+        makerWsClient.apply {
+            assertMyTradesCreatedMessageReceived { msg ->
+                assertEquals(2, msg.trades.size)
+            }
+            repeat(2) { assertMyOrderUpdatedMessageReceived() }
+            assertBalancesMessageReceived()
+        }
+
+        val takerSellOrders = takerApiClient.listOrders(emptyList(), market.id).orders
+        val sellTrades = getTradesForOrders(takerSellOrders.map { it.id }).takeLast(2)
+
+        marketTradesObserver.assertMarketTradesCreatedMessageReceived(market.id) { msg ->
+            assertEquals(2, msg.trades.size)
+            assertEquals(
+                sellTrades.map {
+                    MarketTradesCreated.Trade(
+                        it.id.value,
+                        OrderSide.Sell,
+                        price = it.price,
+                        amount = it.amount,
+                        timestamp = it.timestamp,
+                    )
+                },
+                msg.trades,
+            )
+        }
+
+        makerWsClient.close()
+        takerWsClient.close()
+        marketTradesObserver.close()
+    }
+}

--- a/mocker/src/main/kotlin/co/chainring/mocker/core/Taker.kt
+++ b/mocker/src/main/kotlin/co/chainring/mocker/core/Taker.kt
@@ -5,15 +5,15 @@ import co.chainring.apps.api.model.Market
 import co.chainring.apps.api.model.Order
 import co.chainring.apps.api.model.OrderAmount
 import co.chainring.apps.api.model.websocket.Balances
-import co.chainring.apps.api.model.websocket.OrderCreated
-import co.chainring.apps.api.model.websocket.OrderUpdated
-import co.chainring.apps.api.model.websocket.Orders
+import co.chainring.apps.api.model.websocket.MyOrderCreated
+import co.chainring.apps.api.model.websocket.MyOrderUpdated
+import co.chainring.apps.api.model.websocket.MyOrders
 import co.chainring.apps.api.model.websocket.Prices
 import co.chainring.apps.api.model.websocket.Publishable
 import co.chainring.apps.api.model.websocket.SubscriptionTopic
-import co.chainring.apps.api.model.websocket.TradesCreated
-import co.chainring.apps.api.model.websocket.TradesUpdated
-import co.chainring.apps.api.model.websocket.Trades
+import co.chainring.apps.api.model.websocket.MyTradesCreated
+import co.chainring.apps.api.model.websocket.MyTradesUpdated
+import co.chainring.apps.api.model.websocket.MyTrades
 import co.chainring.core.model.Address
 import co.chainring.core.model.EvmSignature
 import co.chainring.core.model.db.MarketId
@@ -56,8 +56,8 @@ class Taker(
         marketIds
             .map { SubscriptionTopic.Prices(it, OHLCDuration.P5M) } +
             listOf(
-                SubscriptionTopic.Trades,
-                SubscriptionTopic.Orders,
+                SubscriptionTopic.MyTrades,
+                SubscriptionTopic.MyOrders,
                 SubscriptionTopic.Balances
             )
 
@@ -91,7 +91,7 @@ class Taker(
 
     override fun handleWebsocketMessage(message: Publishable) {
         when (message) {
-            is TradesCreated -> {
+            is MyTradesCreated -> {
                 logger.info { "$id: received trades created" }
                 message.trades.forEach { trade ->
                     TraceRecorder.full.finishWSRecording(trade.orderId.value, WSSpans.tradeCreated)
@@ -99,7 +99,7 @@ class Taker(
                 pendingTrades.addAll(message.trades)
             }
 
-            is TradesUpdated -> {
+            is MyTradesUpdated -> {
                 logger.info { "$id: received trades update" }
                 message.trades.forEach { trade ->
                     if (trade.settlementStatus == SettlementStatus.Pending) {
@@ -113,7 +113,7 @@ class Taker(
                 }
             }
 
-            is Trades -> {
+            is MyTrades -> {
                 logger.info { "$id: received ${message.trades.size} trade updates" }
                 message.trades.forEach { trade ->
                     if (trade.settlementStatus == SettlementStatus.Pending) {
@@ -134,11 +134,11 @@ class Taker(
                 logger.info { "$id: received balance update ${message.balances}" }
             }
 
-            is Orders, is OrderCreated, is OrderUpdated -> {
+            is MyOrders, is MyOrderCreated, is MyOrderUpdated -> {
                 val orders = when (message) {
-                    is Orders -> message.orders
-                    is OrderCreated -> listOf(message.order)
-                    is OrderUpdated -> listOf(message.order)
+                    is MyOrders -> message.orders
+                    is MyOrderCreated -> listOf(message.order)
+                    is MyOrderUpdated -> listOf(message.order)
                     else -> emptyList()
                 }
                 orders.forEach { order ->

--- a/web-ui/src/components/Screens/HomeScreen/OrdersAndTradesWidget/OrdersAndTradesWidget.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/OrdersAndTradesWidget/OrdersAndTradesWidget.tsx
@@ -7,7 +7,7 @@ import { produce } from 'immer'
 import { calculateNotional, classNames } from 'utils'
 import Markets, { Market } from 'markets'
 import { useWebsocketSubscription } from 'contexts/websocket'
-import { ordersTopic, Publishable, tradesTopic } from 'websocketMessages'
+import { myOrdersTopic, Publishable, myTradesTopic } from 'websocketMessages'
 import { CancelOrderModal } from 'components/Screens/HomeScreen/CancelOrderModal'
 import { Status } from 'components/common/Status'
 import Trash from 'assets/Trash.svg'
@@ -45,18 +45,18 @@ export default function OrdersAndTradesWidget({
   const switchToEthChain = useSwitchToEthChain()
 
   useWebsocketSubscription({
-    topics: useMemo(() => [ordersTopic, tradesTopic], []),
+    topics: useMemo(() => [myOrdersTopic, myTradesTopic], []),
     handler: useCallback(
       (message: Publishable) => {
-        if (message.type === 'Orders') {
+        if (message.type === 'MyOrders') {
           setOrders(message.orders)
-        } else if (message.type === 'OrderCreated') {
+        } else if (message.type === 'MyOrderCreated') {
           setOrders(
             produce((draft) => {
               draft.unshift(message.order)
             })
           )
-        } else if (message.type === 'OrderUpdated') {
+        } else if (message.type === 'MyOrderUpdated') {
           setOrders(
             produce((draft) => {
               const updatedOrder = message.order
@@ -66,7 +66,7 @@ export default function OrdersAndTradesWidget({
               if (index !== -1) draft[index] = updatedOrder
             })
           )
-        } else if (message.type === 'Trades') {
+        } else if (message.type === 'MyTrades') {
           setOrderTradeGroups((prevState) => {
             const expanded = new Set<string>()
             prevState.forEach((orderTradeGroup) => {
@@ -83,7 +83,7 @@ export default function OrdersAndTradesWidget({
 
             return newState
           })
-        } else if (message.type === 'TradesCreated') {
+        } else if (message.type === 'MyTradesCreated') {
           setOrderTradeGroups(
             produce((draft) => {
               rollupTrades(message.trades, markets).forEach(
@@ -91,7 +91,7 @@ export default function OrdersAndTradesWidget({
               )
             })
           )
-        } else if (message.type === 'TradesUpdated') {
+        } else if (message.type === 'MyTradesUpdated') {
           setOrderTradeGroups(
             produce((draft) => {
               rollupTrades(message.trades, markets).forEach(

--- a/web-ui/src/components/Screens/HomeScreen/swap/SwapInternals.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/swap/SwapInternals.tsx
@@ -9,7 +9,7 @@ import {
   limitsTopic,
   OrderBook,
   orderBookTopic,
-  ordersTopic,
+  myOrdersTopic,
   Publishable
 } from 'websocketMessages'
 import { Address, formatUnits } from 'viem'
@@ -241,7 +241,7 @@ export function SwapInternals({
       if (market.isBackToBack()) {
         return [
           balancesTopic,
-          ordersTopic,
+          myOrdersTopic,
           orderBookTopic(market.marketIds[0]),
           orderBookTopic(market.marketIds[1]),
           limitsTopic
@@ -249,7 +249,7 @@ export function SwapInternals({
       } else {
         return [
           balancesTopic,
-          ordersTopic,
+          myOrdersTopic,
           orderBookTopic(market.id),
           limitsTopic
         ]
@@ -291,7 +291,7 @@ export function SwapInternals({
           }
         } else if (message.type === 'Balances') {
           setBalances(message.balances)
-        } else if (message.type === 'OrderUpdated') {
+        } else if (message.type === 'MyOrderUpdated') {
           setLastOrder(message.order)
         }
       },

--- a/web-ui/src/websocketMessages.ts
+++ b/web-ui/src/websocketMessages.ts
@@ -4,8 +4,8 @@ import { BalanceSchema, OrderSchema, TradeSchema } from 'apiClient'
 export type SubscriptionTopic =
   | { type: 'OrderBook'; marketId: string }
   | { type: 'Prices'; marketId: string; duration: string }
-  | { type: 'Trades' }
-  | { type: 'Orders' }
+  | { type: 'MyTrades' }
+  | { type: 'MyOrders' }
   | { type: 'Balances' }
   | { type: 'Limits' }
 
@@ -20,8 +20,8 @@ export function pricesTopic(
   return { type: 'Prices', marketId, duration }
 }
 
-export const tradesTopic: SubscriptionTopic = { type: 'Trades' }
-export const ordersTopic: SubscriptionTopic = { type: 'Orders' }
+export const myTradesTopic: SubscriptionTopic = { type: 'MyTrades' }
+export const myOrdersTopic: SubscriptionTopic = { type: 'MyOrders' }
 export const balancesTopic: SubscriptionTopic = { type: 'Balances' }
 export const limitsTopic: SubscriptionTopic = { type: 'Limits' }
 
@@ -82,29 +82,29 @@ export const PricesSchema = z.object({
 })
 export type Prices = z.infer<typeof PricesSchema>
 
-export const TradesSchema = z.object({
-  type: z.literal('Trades'),
+export const MyTradesSchema = z.object({
+  type: z.literal('MyTrades'),
   trades: z.array(TradeSchema)
 })
-export type Trades = z.infer<typeof TradesSchema>
+export type MyTrades = z.infer<typeof MyTradesSchema>
 
-export const TradesCreatedSchema = z.object({
-  type: z.literal('TradesCreated'),
+export const MyTradesCreatedSchema = z.object({
+  type: z.literal('MyTradesCreated'),
   trades: z.array(TradeSchema)
 })
-export type TradesCreated = z.infer<typeof TradesCreatedSchema>
+export type MyTradesCreated = z.infer<typeof MyTradesCreatedSchema>
 
-export const TradesUpdatedSchema = z.object({
-  type: z.literal('TradesUpdated'),
+export const MyTradesUpdatedSchema = z.object({
+  type: z.literal('MyTradesUpdated'),
   trades: z.array(TradeSchema)
 })
-export type TradesUpdated = z.infer<typeof TradesUpdatedSchema>
+export type MyTradesUpdated = z.infer<typeof MyTradesUpdatedSchema>
 
-export const OrdersSchema = z.object({
-  type: z.literal('Orders'),
+export const MyOrdersSchema = z.object({
+  type: z.literal('MyOrders'),
   orders: z.array(OrderSchema)
 })
-export type Orders = z.infer<typeof OrdersSchema>
+export type MyOrders = z.infer<typeof MyOrdersSchema>
 
 export const BalancesSchema = z.object({
   type: z.literal('Balances'),
@@ -112,17 +112,17 @@ export const BalancesSchema = z.object({
 })
 export type Balances = z.infer<typeof BalancesSchema>
 
-export const OrderCreatedSchema = z.object({
-  type: z.literal('OrderCreated'),
+export const MyOrderCreatedSchema = z.object({
+  type: z.literal('MyOrderCreated'),
   order: OrderSchema
 })
-export type OrderCreated = z.infer<typeof OrderCreatedSchema>
+export type MyOrderCreated = z.infer<typeof MyOrderCreatedSchema>
 
-export const OrderUpdatedSchema = z.object({
-  type: z.literal('OrderUpdated'),
+export const MyOrderUpdatedSchema = z.object({
+  type: z.literal('MyOrderUpdated'),
   order: OrderSchema
 })
-export type OrderUpdated = z.infer<typeof OrderUpdatedSchema>
+export type MyOrderUpdated = z.infer<typeof MyOrderUpdatedSchema>
 
 export const MarketLimitsSchema = z
   .tuple([
@@ -155,13 +155,13 @@ export function limitsForMarket(
 export const PublishableSchema = z.discriminatedUnion('type', [
   OrderBookSchema,
   PricesSchema,
-  TradesSchema,
-  TradesCreatedSchema,
-  TradesUpdatedSchema,
-  OrdersSchema,
+  MyTradesSchema,
+  MyTradesCreatedSchema,
+  MyTradesUpdatedSchema,
+  MyOrdersSchema,
   BalancesSchema,
-  OrderCreatedSchema,
-  OrderUpdatedSchema,
+  MyOrderCreatedSchema,
+  MyOrderUpdatedSchema,
   LimitsSchema
 ])
 export type Publishable = z.infer<typeof PublishableSchema>


### PR DESCRIPTION
- `Trades` subscription topic was renamed to `MyTrades`
- `Trades`, `TradesCreated` and `TradesUpdated` message types were renamed to `MyTrades`, `MyTradesCreated` and `MyTradesUpdated`
- `Orders` subscription topic was renamed to `MyOrders`
- `Orders`, `OrdersCreated` and `OrdersUpdated` message types were renamed to `MyOrders`, `MyOrdersCreated` and `MyOrdersUpdated`
- Added new `MarketTrades` subscription topic and `MarketTradesCreated` message type
- trade record in `MarketTradesCreated` message is serialised into array like this: `[<trade id>, <trade type as "Buy" or "Sell">, <amount>, <price>, <timestamp as milliseconds since epoch>]`