### PR TITLE
API endpoint for getting last price for market

### DIFF
--- a/backend/src/main/kotlin/co/chainring/apps/api/ApiApp.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/ApiApp.kt
@@ -130,6 +130,7 @@ class ApiApp(config: ApiAppConfig = ApiAppConfig()) : BaseApp(config.dbConfig) {
                             withdrawalRoutes.createWithdrawal,
                             withdrawalRoutes.listWithdrawals,
                             LimitsRoutes.getLimits,
+                            PriceRoutes.getLastPriceForMarket,
                         )
 
                         if (enableTestRoutes) {

--- a/backend/src/main/kotlin/co/chainring/apps/api/ConfigRoutes.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/ConfigRoutes.kt
@@ -96,8 +96,6 @@ class ConfigRoutes(private val faucetMode: FaucetMode) {
                                 quoteDecimals = 6,
                                 tickSize = "0.01".toBigDecimal(),
                                 lastPrice = "0.995".toBigDecimal(),
-                                minAllowedBidPrice = "0.01".toBigDecimal(),
-                                maxAllowedOfferPrice = "3.49".toBigDecimal(),
                                 minFee = BigInteger.ONE,
                             ),
                         ),
@@ -147,8 +145,6 @@ class ConfigRoutes(private val faucetMode: FaucetMode) {
                                     quoteDecimals = market.quoteSymbol.decimals.toInt(),
                                     tickSize = market.tickSize,
                                     lastPrice = market.lastPrice,
-                                    minAllowedBidPrice = market.minAllowedBidPrice,
-                                    maxAllowedOfferPrice = market.maxAllowedOfferPrice,
                                     minFee = market.minFee,
                                 )
                             }.sortedWith(compareBy({ it.baseSymbol.value }, { it.quoteSymbol.value })),

--- a/backend/src/main/kotlin/co/chainring/apps/api/PriceRoutes.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/PriceRoutes.kt
@@ -1,0 +1,53 @@
+package co.chainring.apps.api
+
+import co.chainring.apps.api.model.GetLastPriceResponse
+import co.chainring.apps.api.model.ReasonCode
+import co.chainring.apps.api.model.notFoundError
+import co.chainring.core.model.db.MarketEntity
+import co.chainring.core.model.db.MarketId
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.http4k.contract.ContractRoute
+import org.http4k.contract.Tag
+import org.http4k.contract.div
+import org.http4k.contract.meta
+import org.http4k.core.Body
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.core.with
+import org.http4k.format.KotlinxSerialization.auto
+import org.http4k.lens.Path
+import org.jetbrains.exposed.sql.transactions.transaction
+
+object PriceRoutes {
+    private val logger = KotlinLogging.logger {}
+
+    val getLastPriceForMarket: ContractRoute = run {
+        val marketIdPathParam = Path.map(::MarketId, MarketId::value).of("marketId", "Market Id")
+        val responseBody = Body.auto<GetLastPriceResponse>().toLens()
+
+        "last-price" / marketIdPathParam meta {
+            operationId = "config"
+            summary = "Get last price for market"
+            tags += listOf(Tag("price"))
+            returning(
+                Status.OK,
+                responseBody to
+                    GetLastPriceResponse(
+                        lastPrice = "0.995".toBigDecimal(),
+                    ),
+            )
+        } bindContract Method.GET to { marketId ->
+            { _: Request ->
+                transaction {
+                    MarketEntity.findById(marketId)?.let { market ->
+                        Response(Status.OK).with(
+                            responseBody of GetLastPriceResponse(market.lastPrice),
+                        )
+                    } ?: notFoundError(ReasonCode.MarketNotFound, "Unknown market")
+                }
+            }
+        }
+    }
+}

--- a/backend/src/main/kotlin/co/chainring/apps/api/model/Configuration.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/model/Configuration.kt
@@ -62,7 +62,5 @@ data class Market(
     val quoteDecimals: Int,
     val tickSize: BigDecimalJson,
     val lastPrice: BigDecimalJson,
-    val minAllowedBidPrice: BigDecimalJson,
-    val maxAllowedOfferPrice: BigDecimalJson,
     val minFee: BigIntegerJson,
 )

--- a/backend/src/main/kotlin/co/chainring/apps/api/model/GetLastPriceResponse.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/model/GetLastPriceResponse.kt
@@ -1,0 +1,8 @@
+package co.chainring.apps.api.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetLastPriceResponse(
+    val lastPrice: BigDecimalJson,
+)

--- a/backend/src/main/kotlin/co/chainring/apps/api/services/ExchangeApiService.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/services/ExchangeApiService.kt
@@ -38,6 +38,7 @@ import co.chainring.core.model.db.WithdrawalEntity
 import co.chainring.core.sequencer.SequencerClient
 import co.chainring.core.sequencer.toSequencerId
 import co.chainring.core.services.LinkedSignerService
+import co.chainring.core.utils.safeToInt
 import co.chainring.core.utils.toFundamentalUnits
 import co.chainring.core.utils.toHexBytes
 import co.chainring.sequencer.core.Asset
@@ -146,10 +147,14 @@ class ExchangeApiService(
         val quoteSymbol = getSymbolEntity(market.quoteSymbol)
 
         val ordersToAdd = createOrderRequestsByOrderId.map { (orderId, orderRequest) ->
-            val price = when (orderRequest) {
-                is CreateOrderApiRequest.Limit -> orderRequest.price
+            val levelIx = when (orderRequest) {
+                is CreateOrderApiRequest.Limit -> {
+                    ensurePriceIsMultipleOfTickSize(market, orderRequest.price)
+                    orderRequest.price.divideToIntegralValue(market.tickSize).toBigInteger().safeToInt()
+                        ?: throw RequestProcessingError("Order price is too large")
+                }
                 else -> null
-            }?.also { ensurePriceIsMultipleOfTickSize(market, it) }
+            }
 
             val percentage = when (orderRequest) {
                 is CreateOrderApiRequest.Market -> orderRequest.amount.percentage()
@@ -180,7 +185,7 @@ class ExchangeApiService(
             SequencerClient.Order(
                 sequencerOrderId = orderId.toSequencerId().value,
                 amount = orderRequest.amount.fixedAmount(),
-                levelIx = price?.divideToIntegralValue(market.tickSize)?.toInt(),
+                levelIx = levelIx,
                 orderType = toSequencerOrderType(orderRequest is CreateOrderApiRequest.Market, orderRequest.side),
                 nonce = BigInteger(1, orderRequest.nonce.toHexBytes()),
                 signature = orderRequest.signature,

--- a/backend/src/main/kotlin/co/chainring/apps/api/services/ExchangeApiService.kt
+++ b/backend/src/main/kotlin/co/chainring/apps/api/services/ExchangeApiService.kt
@@ -352,8 +352,6 @@ class ExchangeApiService(
                         quoteDecimals = it.quoteSymbol.decimals.toInt(),
                         tickSize = it.tickSize,
                         lastPrice = it.lastPrice,
-                        minAllowedBidPrice = it.minAllowedBidPrice,
-                        maxAllowedOfferPrice = it.maxAllowedOfferPrice,
                         minFee = it.minFee,
                     )
                 }

--- a/backend/src/main/kotlin/co/chainring/core/db/Migrations.kt
+++ b/backend/src/main/kotlin/co/chainring/core/db/Migrations.kt
@@ -63,6 +63,7 @@ import co.chainring.core.model.db.migrations.V64_AddIsAdminToWallet
 import co.chainring.core.model.db.migrations.V65_WalletLinkedSigner
 import co.chainring.core.model.db.migrations.V66_AddCounterOrderIdToOrderExecution
 import co.chainring.core.model.db.migrations.V67_AddLimitTable
+import co.chainring.core.model.db.migrations.V68_RemoveMinMaxOfferPriceFromMarket
 import co.chainring.core.model.db.migrations.V6_MarketTable
 import co.chainring.core.model.db.migrations.V7_OrderTable
 import co.chainring.core.model.db.migrations.V8_ExecutionsAndTrades
@@ -136,4 +137,5 @@ val migrations = listOf(
     V65_WalletLinkedSigner(),
     V66_AddCounterOrderIdToOrderExecution(),
     V67_AddLimitTable(),
+    V68_RemoveMinMaxOfferPriceFromMarket(),
 )

--- a/backend/src/main/kotlin/co/chainring/core/model/db/Market.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/Market.kt
@@ -36,8 +36,6 @@ object MarketTable : GUIDTable<MarketId>("market", ::MarketId) {
     val quoteSymbolGuid = reference("quote_symbol_guid", SymbolTable)
     val tickSize = decimal("tick_size", 30, 18)
     val lastPrice = decimal("last_price", 30, 18)
-    val minAllowedBidPrice = decimal("min_allowed_bid_price", 30, 18)
-    val maxAllowedOfferPrice = decimal("max_allowed_offer_price", 30, 18)
     val minFee = decimal("min_fee", 30, 0).default(BigDecimal.ZERO)
 }
 
@@ -57,8 +55,6 @@ class MarketEntity(guid: EntityID<MarketId>) : GUIDEntity<MarketId>(guid) {
             this.quoteSymbolGuid = quoteSymbol.guid
             this.tickSize = tickSize
             this.lastPrice = lastPrice
-            this.minAllowedBidPrice = lastPrice
-            this.maxAllowedOfferPrice = lastPrice
             this.minFee = minFee
         }
 
@@ -85,8 +81,6 @@ class MarketEntity(guid: EntityID<MarketId>) : GUIDEntity<MarketId>(guid) {
     var quoteSymbolGuid by MarketTable.quoteSymbolGuid
     var tickSize by MarketTable.tickSize
     var lastPrice by MarketTable.lastPrice
-    var minAllowedBidPrice by MarketTable.minAllowedBidPrice
-    var maxAllowedOfferPrice by MarketTable.maxAllowedOfferPrice
 
     var baseSymbol by SymbolEntity referencedOn MarketTable.baseSymbolGuid
     var quoteSymbol by SymbolEntity referencedOn MarketTable.quoteSymbolGuid

--- a/backend/src/main/kotlin/co/chainring/core/model/db/migrations/V68_RemoveMinMaxOfferPriceFromMarket.kt
+++ b/backend/src/main/kotlin/co/chainring/core/model/db/migrations/V68_RemoveMinMaxOfferPriceFromMarket.kt
@@ -1,0 +1,14 @@
+package co.chainring.core.model.db.migrations
+
+import co.chainring.core.db.Migration
+import org.jetbrains.exposed.sql.transactions.transaction
+
+@Suppress("ClassName")
+class V68_RemoveMinMaxOfferPriceFromMarket : Migration() {
+    override fun run() {
+        transaction {
+            exec("ALTER TABLE market DROP COLUMN min_allowed_bid_price")
+            exec("ALTER TABLE market DROP COLUMN max_allowed_offer_price")
+        }
+    }
+}

--- a/backend/src/main/kotlin/co/chainring/core/utils/TraceRecorder.kt
+++ b/backend/src/main/kotlin/co/chainring/core/utils/TraceRecorder.kt
@@ -40,6 +40,7 @@ interface TraceRecorder {
         AddAdmin,
         RemoveAdmin,
         SetFeeRates,
+        GetLastPrice,
     }
 
     data class Trace(

--- a/backend/src/main/kotlin/co/chainring/core/utils/Utils.kt
+++ b/backend/src/main/kotlin/co/chainring/core/utils/Utils.kt
@@ -106,3 +106,13 @@ class BigIntegerRangeIterator(
         return current++
     }
 }
+
+fun BigInteger.safeToInt(): Int? =
+    runCatching {
+        this.intValueExact()
+    }.recover { exception ->
+        when (exception) {
+            is ArithmeticException -> null
+            else -> throw exception
+        }
+    }.getOrNull()

--- a/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/TestApiClient.kt
+++ b/integrationtests/src/main/kotlin/co/chainring/integrationtests/utils/TestApiClient.kt
@@ -16,6 +16,7 @@ import co.chainring.apps.api.model.CreateWithdrawalApiRequest
 import co.chainring.apps.api.model.DepositApiResponse
 import co.chainring.apps.api.model.FaucetApiRequest
 import co.chainring.apps.api.model.FaucetApiResponse
+import co.chainring.apps.api.model.GetLastPriceResponse
 import co.chainring.apps.api.model.GetLimitsApiResponse
 import co.chainring.apps.api.model.GetOrderBookApiResponse
 import co.chainring.apps.api.model.ListDepositsApiResponse
@@ -314,6 +315,9 @@ class TestApiClient(ecKeyPair: ECKeyPair = Keys.createEcKeyPair(), traceRecorder
 
     override fun faucet(apiRequest: FaucetApiRequest): FaucetApiResponse =
         tryFaucet(apiRequest).assertSuccess()
+
+    override fun getLastPrice(marketId: MarketId): GetLastPriceResponse =
+        tryGetLastPrice(marketId).assertSuccess()
 }
 
 fun <T> Either<ApiCallFailure, T>.assertSuccess(): T {

--- a/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/PriceRoutesTest.kt
+++ b/integrationtests/src/test/kotlin/co/chainring/integrationtests/api/PriceRoutesTest.kt
@@ -1,0 +1,33 @@
+package co.chainring.integrationtests.api
+
+import co.chainring.apps.api.model.ApiError
+import co.chainring.apps.api.model.ReasonCode
+import co.chainring.core.model.db.MarketEntity
+import co.chainring.core.model.db.MarketId
+import co.chainring.integrationtests.testutils.AppUnderTestRunner
+import co.chainring.integrationtests.utils.TestApiClient
+import co.chainring.integrationtests.utils.assertError
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.Test
+
+@ExtendWith(AppUnderTestRunner::class)
+class PriceRoutesTest {
+    @Test
+    fun `get last price for market`() {
+        val apiClient = TestApiClient()
+
+        apiClient.getConfiguration().markets.forEach { market ->
+            assertEquals(
+                transaction { MarketEntity[market.id].lastPrice },
+                apiClient.getLastPrice(market.id).lastPrice,
+            )
+        }
+
+        // unknown market
+        apiClient
+            .tryGetLastPrice(MarketId("FOO/BAR"))
+            .assertError(ApiError(ReasonCode.MarketNotFound, "Unknown market"))
+    }
+}

--- a/mocker/src/main/kotlin/co/chainring/mocker/Main.kt
+++ b/mocker/src/main/kotlin/co/chainring/mocker/Main.kt
@@ -59,8 +59,6 @@ fun main() {
         quoteDecimals = 18,
         tickSize = BigDecimal("0.05"),
         lastPrice = BigDecimal("0.995"),
-        minAllowedBidPrice = BigDecimal("0.05"),
-        maxAllowedOfferPrice = BigDecimal("2"),
         minFee = BigInteger.ZERO
     )
     val priceFunction = PriceFunction.generateDeterministicHarmonicMovement(initialValue = 17.0, maxFluctuation = 1.5)

--- a/sequencer/src/main/kotlin/co/chainring/sequencer/apps/services/SequencerResponseProcessorService.kt
+++ b/sequencer/src/main/kotlin/co/chainring/sequencer/apps/services/SequencerResponseProcessorService.kt
@@ -154,9 +154,6 @@ object SequencerResponseProcessorService {
                 if (response.error == SequencerError.None) {
                     response.marketsCreatedList.forEach { marketCreated ->
                         MarketEntity[MarketId(marketCreated.marketId)].apply {
-                            // TODO delete min/max allowed price OR apply logical dynamic range
-                            minAllowedBidPrice = BigDecimal.ZERO
-                            maxAllowedOfferPrice = Integer.MAX_VALUE.toBigDecimal()
                             minFee = if (marketCreated.hasMinFee()) marketCreated.minFee.toBigInteger() else BigInteger.ZERO
                             updatedAt = Clock.System.now()
                             updatedBy = "seq:${response.sequence}"

--- a/web-ui/src/apiClient.ts
+++ b/web-ui/src/apiClient.ts
@@ -87,8 +87,6 @@ const MarketSchema = z.object({
   quoteSymbol: z.string(),
   tickSize: decimal(),
   lastPrice: decimal(),
-  minAllowedBidPrice: decimal(),
-  maxAllowedOfferPrice: decimal(),
   minFee: z.coerce.bigint()
 })
 export type Market = z.infer<typeof MarketSchema>

--- a/web-ui/src/components/Screens/HomeScreen/OrdersAndTradesWidget/test.ts
+++ b/web-ui/src/components/Screens/HomeScreen/OrdersAndTradesWidget/test.ts
@@ -90,8 +90,6 @@ describe('rollupTrades', () => {
         quoteDecimals: 6,
         tickSize: '25.000000000000000000',
         lastPrice: '61000.000000000000000000',
-        minAllowedBidPrice: '0.000000000000000000',
-        maxAllowedOfferPrice: '2147483647.000000000000000000',
         minFee: '20000'
       },
       {
@@ -102,8 +100,6 @@ describe('rollupTrades', () => {
         quoteDecimals: 18,
         tickSize: '0.010000000000000000',
         lastPrice: '2.160000000000000000',
-        minAllowedBidPrice: '0.000000000000000000',
-        maxAllowedOfferPrice: '2147483647.000000000000000000',
         minFee: '20000000000000000'
       }
     ],

--- a/web-ui/src/components/Screens/HomeScreen/swap/LimitModal.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/swap/LimitModal.tsx
@@ -376,23 +376,13 @@ export function LimitModal({
                         }
                       } else if (sr.mutation.isSuccess) {
                         return '✓ Submitted'
-                      } else if (sr.limitPriceTooLow) {
-                        return 'Price Too Low'
-                      } else if (sr.limitPriceTooHigh) {
-                        return 'Price Too High'
                       } else if (sr.amountTooLow) {
                         return 'Amount Too Low'
                       } else {
                         return 'Swap'
                       }
                     }}
-                    status={
-                      sr.limitPriceTooLow ||
-                      sr.limitPriceTooHigh ||
-                      sr.amountTooLow
-                        ? 'error'
-                        : sr.mutation.status
-                    }
+                    status={sr.amountTooLow ? 'error' : sr.mutation.status}
                   />
                 </>
               ) : (

--- a/web-ui/src/components/Screens/HomeScreen/swap/SwapInternals.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/swap/SwapInternals.tsx
@@ -59,8 +59,6 @@ export type SwapRender = {
   buyLimitPriceInputValue: string
   buyLimitPrice: Decimal
   limitPrice: Decimal
-  limitPriceTooLow: boolean
-  limitPriceTooHigh: boolean
   setPriceFromMarketPrice: (incrementDivisor?: bigint) => void
   noPriceFound: boolean
   canSubmit: boolean
@@ -841,12 +839,6 @@ export function SwapInternals({
   const canSubmit = useMemo(() => {
     if (mutation.isPending) return false
     if (baseAmount <= 0n) return false
-    if (
-      isLimitOrder &&
-      (limitPrice.lt(market.minAllowedBidPrice) ||
-        limitPrice.gt(market.maxAllowedOfferPrice))
-    )
-      return false
 
     if (side == 'Buy' && notional + fee > (quoteLimit || 0n)) return false
     if (side == 'Sell' && baseAmount > (baseLimit || 0n)) return false
@@ -858,15 +850,12 @@ export function SwapInternals({
     mutation.isPending,
     side,
     baseAmount,
-    limitPrice,
     notional,
     isLimitOrder,
     quoteLimit,
     baseLimit,
     noPriceFound,
     fee,
-    market.minAllowedBidPrice,
-    market.maxAllowedOfferPrice,
     amountTooLow
   ])
 
@@ -991,25 +980,6 @@ export function SwapInternals({
     secondMarketOrderBook
   ])
 
-  const [limitPriceTooLow, limitPriceTooHigh] = useMemo(() => {
-    const limitPriceTooLow =
-      isLimitOrder &&
-      limitPrice.gt(new Decimal(0)) &&
-      limitPrice.lt(market.minAllowedBidPrice)
-    const limitPriceTooHigh =
-      isLimitOrder && limitPrice.gt(market.maxAllowedOfferPrice)
-
-    return side === 'Sell'
-      ? [limitPriceTooLow, limitPriceTooHigh]
-      : [limitPriceTooHigh, limitPriceTooLow]
-  }, [
-    isLimitOrder,
-    limitPrice,
-    market.minAllowedBidPrice,
-    market.maxAllowedOfferPrice,
-    side
-  ])
-
   return Renderer({
     topBalance,
     topSymbol,
@@ -1034,8 +1004,6 @@ export function SwapInternals({
     buyLimitPriceInputValue,
     buyLimitPrice,
     limitPrice,
-    limitPriceTooLow,
-    limitPriceTooHigh,
     setPriceFromMarketPrice,
     noPriceFound,
     canSubmit,

--- a/web-ui/src/components/Screens/HomeScreen/swap/SwapWidget.tsx
+++ b/web-ui/src/components/Screens/HomeScreen/swap/SwapWidget.tsx
@@ -324,10 +324,6 @@ export function SwapWidget({
                         return '✓'
                       } else if (sr.sellAssetsNeeded > 0n) {
                         return 'Insufficient Balance'
-                      } else if (sr.limitPriceTooLow) {
-                        return 'Price Too Low'
-                      } else if (sr.limitPriceTooHigh) {
-                        return 'Price Too High'
                       } else if (sr.amountTooLow) {
                         return 'Amount Too Low'
                       } else {
@@ -335,10 +331,7 @@ export function SwapWidget({
                       }
                     }}
                     status={
-                      sr.sellAssetsNeeded > 0n ||
-                      sr.limitPriceTooLow ||
-                      sr.limitPriceTooHigh ||
-                      sr.amountTooLow
+                      sr.sellAssetsNeeded > 0n || sr.amountTooLow
                         ? 'error'
                         : sr.mutation.status
                     }

--- a/web-ui/src/markets.ts
+++ b/web-ui/src/markets.ts
@@ -10,8 +10,6 @@ export class Market {
   readonly tickSize: Decimal
   readonly quoteDecimalPlaces: number
   readonly lastPrice: Decimal
-  readonly minAllowedBidPrice: Decimal
-  readonly maxAllowedOfferPrice: Decimal
   readonly minFee: bigint
   readonly marketIds: string[]
 
@@ -21,8 +19,6 @@ export class Market {
     quoteSymbol: TradingSymbol,
     tickSize: Decimal,
     lastPrice: Decimal,
-    minAllowedBidPrice: Decimal,
-    maxAllowedOfferPrice: Decimal,
     minFee: bigint,
     marketIds: string[]
   ) {
@@ -32,8 +28,6 @@ export class Market {
     this.tickSize = tickSize
     this.lastPrice = lastPrice
     this.quoteDecimalPlaces = this.tickSize.decimalPlaces() + 1
-    this.minAllowedBidPrice = minAllowedBidPrice
-    this.maxAllowedOfferPrice = maxAllowedOfferPrice
     this.minFee = minFee
     this.marketIds = marketIds
   }
@@ -60,8 +54,6 @@ export default class Markets {
           symbols.getByName(m.quoteSymbol),
           m.tickSize,
           m.lastPrice,
-          m.minAllowedBidPrice,
-          m.maxAllowedOfferPrice,
           m.minFee,
           []
         )
@@ -164,8 +156,6 @@ export default class Markets {
                       symbols.getByName(secondMarket.quoteSymbol),
                       secondMarket.tickSize,
                       firstMarket.lastPrice.mul(secondMarket.lastPrice),
-                      new Decimal(0),
-                      new Decimal(0),
                       secondMarket.minFee,
                       [firstMarket.id, secondMarket.id]
                     )


### PR DESCRIPTION
Also removed `minAllowedBidPrice` and `maxAllowedOfferPrice` since Sequencer is more dynamic now.

@bholzman I would like to remove `market.lastPrice` from the config endpoint because it is dynamic response and the only place I've found that uses it is here: https://github.com/Chainring-Inc/chainring-monorepo/commit/17d93805223b230bebff0d71473a97676994fdc2#diff-2fdbccec7dc901990d4b7e717860d55823f329211a0bb7a6dd8bb16f1034e824R99-R105 

I don't quite understand why those particular numbers are hardcoded. Was it for made specifically for cross-chain BTC swaps?