### PR TITLE
skip docker tag latest

### DIFF
--- a/mocker/build.gradle.kts
+++ b/mocker/build.gradle.kts
@@ -69,9 +69,8 @@ jib {
     }
 
     to {
-        image = "851725450525.dkr.ecr.us-east-2.amazonaws.com/mocker"
+        image = "851725450525.dkr.ecr.us-east-2.amazonaws.com/mocker:${version}-${buildNumber}"
         credHelper.helper = "ecr-login"
-        tags = setOf("${version}-${buildNumber}")
     }
 
     container {


### PR DESCRIPTION
`latest` is default tag that is used when image has no tag specified explicitly. `tags` are used as additional tags.